### PR TITLE
correction/retraction updates

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -860,7 +860,7 @@
 	  <report test="($subj-type = ('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Research Communication', 'Feature article', 'Insight', 'Editorial', 'Scientific Correspondence')) and matches(article-title,':')" role="warning" id="article-title-test-10">Article title contains a colon. This almost never allowed. - <value-of select="article-title"/>
       </report>
 	  
-	  <report test="matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
+	  <report test="($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
       </report>
 	  
 	  <report test="matches(article-title,' [Bb]ased ') and not(matches(article-title,' [Bb]ased on '))" role="warning" id="article-title-test-12">Article title contains the string ' based'. Should the preceding space be replaced by a hyphen - '-based'.  - <value-of select="article-title"/>
@@ -2621,6 +2621,20 @@
     <rule context="article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = 'Insight']//article-meta" id="insight-test">
       
       <assert test="count(related-article) gt 0" role="error" id="related-articles-test-2">Insight must contain an article-reference link to the original article it is discussing.</assert>
+      
+    </rule>
+  </pattern>
+  <pattern id="correction-test-pattern">
+    <rule context="article[@article-type='correction']//article-meta" id="correction-test">
+      
+      <assert test="count(related-article[@related-article-type='corrected-article']) gt 0" role="error" id="related-articles-test-8">Corrections must contain at least 1 related-article link with the attribute related-article-type='corrected-article'.</assert>
+      
+    </rule>
+  </pattern>
+  <pattern id="retraction-test-pattern">
+    <rule context="article[@article-type='retraction']//article-meta" id="retraction-test">
+      
+      <assert test="count(related-article[@related-article-type='retracted-article']) gt 0" role="error" id="related-articles-test-9">Retractions must contain at least 1 related-article link with the attribute related-article-type='retracted-article'.</assert>
       
     </rule>
   </pattern>
@@ -5541,9 +5555,9 @@
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="italic-house-style-pattern">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -866,7 +866,7 @@
 	  <report test="($subj-type = ('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Research Communication', 'Feature article', 'Insight', 'Editorial', 'Scientific Correspondence')) and matches(article-title,':')" role="warning" id="article-title-test-10">Article title contains a colon. This almost never allowed. - <value-of select="article-title"/>
       </report>
 	  
-	  <report test="matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
+	  <report test="($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
       </report>
 	  
 	  <report test="matches(article-title,' [Bb]ased ') and not(matches(article-title,' [Bb]ased on '))" role="warning" id="article-title-test-12">Article title contains the string ' based'. Should the preceding space be replaced by a hyphen - '-based'.  - <value-of select="article-title"/>
@@ -2627,6 +2627,20 @@
     <rule context="article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = 'Insight']//article-meta" id="insight-test">
       
       <assert test="count(related-article) gt 0" role="error" id="related-articles-test-2">Insight must contain an article-reference link to the original article it is discussing.</assert>
+      
+    </rule>
+  </pattern>
+  <pattern id="correction-test-pattern">
+    <rule context="article[@article-type='correction']//article-meta" id="correction-test">
+      
+      <assert test="count(related-article[@related-article-type='corrected-article']) gt 0" role="error" id="related-articles-test-8">Corrections must contain at least 1 related-article link with the attribute related-article-type='corrected-article'.</assert>
+      
+    </rule>
+  </pattern>
+  <pattern id="retraction-test-pattern">
+    <rule context="article[@article-type='retraction']//article-meta" id="retraction-test">
+      
+      <assert test="count(related-article[@related-article-type='retracted-article']) gt 0" role="error" id="related-articles-test-9">Retractions must contain at least 1 related-article link with the attribute related-article-type='retracted-article'.</assert>
       
     </rule>
   </pattern>
@@ -5547,9 +5561,9 @@
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="italic-house-style-pattern">

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -860,7 +860,7 @@
 	  <report test="($subj-type = ('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Research Communication', 'Feature article', 'Insight', 'Editorial', 'Scientific Correspondence')) and matches(article-title,':')" role="warning" id="article-title-test-10">Article title contains a colon. This almost never allowed. - <value-of select="article-title"/>
       </report>
 	  
-	  <report test="matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
+	  <report test="($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
       </report>
 	  
 	  <report test="matches(article-title,' [Bb]ased ') and not(matches(article-title,' [Bb]ased on '))" role="warning" id="article-title-test-12">Article title contains the string ' based'. Should the preceding space be replaced by a hyphen - '-based'.  - <value-of select="article-title"/>
@@ -2622,6 +2622,20 @@
     <rule context="article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = 'Insight']//article-meta" id="insight-test">
       
       <assert test="count(related-article) gt 0" role="error" id="related-articles-test-2">Insight must contain an article-reference link to the original article it is discussing.</assert>
+      
+    </rule>
+  </pattern>
+  <pattern id="correction-test-pattern">
+    <rule context="article[@article-type='correction']//article-meta" id="correction-test">
+      
+      <assert test="count(related-article[@related-article-type='corrected-article']) gt 0" role="error" id="related-articles-test-8">Corrections must contain at least 1 related-article link with the attribute related-article-type='corrected-article'.</assert>
+      
+    </rule>
+  </pattern>
+  <pattern id="retraction-test-pattern">
+    <rule context="article[@article-type='retraction']//article-meta" id="retraction-test">
+      
+      <assert test="count(related-article[@related-article-type='retracted-article']) gt 0" role="error" id="related-articles-test-9">Retractions must contain at least 1 related-article link with the attribute related-article-type='retracted-article'.</assert>
       
     </rule>
   </pattern>
@@ -5542,9 +5556,9 @@
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="italic-house-style-pattern">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1015,7 +1015,7 @@
 	    role="warning" 
 	    id="article-title-test-10">Article title contains a colon. This almost never allowed. - <value-of select="article-title"/></report>
 	  
-	  <report test="matches($tokens,'[A-Za-z]')"
+	  <report test="($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')"
 	    role="warning" 
 	    id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/></report>
 	  
@@ -3689,6 +3689,24 @@
       <assert test="count(related-article) gt 0"
         role="error"
         id="related-articles-test-2">Insight must contain an article-reference link to the original article it is discussing.</assert>
+      
+    </rule>
+    
+    <rule context="article[@article-type='correction']//article-meta" 
+      id="correction-test">
+      
+      <assert test="count(related-article[@related-article-type='corrected-article']) gt 0"
+        role="error"
+        id="related-articles-test-8">Corrections must contain at least 1 related-article link with the attribute related-article-type='corrected-article'.</assert>
+      
+    </rule>
+    
+    <rule context="article[@article-type='retraction']//article-meta" 
+      id="retraction-test">
+      
+      <assert test="count(related-article[@related-article-type='retracted-article']) gt 0"
+        role="error"
+        id="related-articles-test-9">Retractions must contain at least 1 related-article link with the attribute related-article-type='retracted-article'.</assert>
       
     </rule>
     
@@ -7431,11 +7449,11 @@
       id="p-punctuation">
       <let name="para" value="replace(.,'&#x00A0;',' ')"/>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))"
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))"
         role="warning" 
         id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))"
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))"
         role="warning" 
         id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>

--- a/test/tests/gen/correction-test/related-articles-test-8/fail.xml
+++ b/test/tests/gen/correction-test/related-articles-test-8/fail.xml
@@ -1,0 +1,17 @@
+<?oxygen SCHSchema="related-articles-test-8.sch"?>
+<!--Context: article[@article-type='correction']//article-meta
+Test: assert    count(related-article[@related-article-type='corrected-article']) gt 0
+Message: Corrections must contain at least 1 relatedarticle link with the attribute relatedarticletype='correctedarticle'.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="correction">
+    <front>
+      <article-meta>
+        <article-categories>
+          <subj-group subj-group-type="display-channel"><subject>Retraction</subject></subj-group>
+        </article-categories>
+        <title-group><article-title>Retraction: The structure of SV40 large T hexameric helicase in complex with AT-rich origin DNA</article-title></title-group>
+        <related-article ext-link-type="doi" id="ra1" related-article-type="retracted-article" xlink:href="10.7554/eLife.00000"/>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/correction-test/related-articles-test-8/pass.xml
+++ b/test/tests/gen/correction-test/related-articles-test-8/pass.xml
@@ -1,0 +1,17 @@
+<?oxygen SCHSchema="related-articles-test-8.sch"?>
+<!--Context: article[@article-type='correction']//article-meta
+Test: assert    count(related-article[@related-article-type='corrected-article']) gt 0
+Message: Corrections must contain at least 1 relatedarticle link with the attribute relatedarticletype='correctedarticle'.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="correction">
+    <front>
+      <article-meta>
+        <article-categories>
+          <subj-group subj-group-type="display-channel"><subject>Retraction</subject></subj-group>
+        </article-categories>
+        <title-group><article-title>Retraction: The structure of SV40 large T hexameric helicase in complex with AT-rich origin DNA</article-title></title-group>
+        <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.7554/eLife.00000"/>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/correction-test/related-articles-test-8/related-articles-test-8.sch
+++ b/test/tests/gen/correction-test/related-articles-test-8/related-articles-test-8.sch
@@ -608,20 +608,14 @@
       </xsl:if>
     </xsl:element>
   </xsl:function>
-  <pattern id="article-metadata">
-    <rule context="article/front/article-meta/title-group" id="test-title-group">
-      <let name="subj-type" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject"/>
-      <let name="lc" value="normalize-space(lower-case(article-title))"/>
-      <let name="title" value="replace(article-title,'\p{P}','')"/>
-      <let name="body" value="ancestor::front/following-sibling::body"/>
-      <let name="tokens" value="string-join(for $x in tokenize($title,' ')[position() &gt; 1] return       if (matches($x,'^[A-Z]') and matches($body,concat(' ',lower-case($x),' '))) then $x      else (),', ')"/>
-      <report test="($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
-      </report>
+  <pattern id="related-articles">
+    <rule context="article[@article-type='correction']//article-meta" id="correction-test">
+      <assert test="count(related-article[@related-article-type='corrected-article']) gt 0" role="error" id="related-articles-test-8">Corrections must contain at least 1 related-article link with the attribute related-article-type='corrected-article'.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article/front/article-meta/title-group" role="error" id="test-title-group-xspec-assert">article/front/article-meta/title-group must be present.</assert>
+      <assert test="descendant::article[@article-type='correction']//article-meta" role="error" id="correction-test-xspec-assert">article[@article-type='correction']//article-meta must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/p-punctuation/p-bracket-test/fail.xml
+++ b/test/tests/gen/p-punctuation/p-bracket-test/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-bracket-test.sch"?>
 <!--Context: article/body//p[not(parent::list-item)]
-Test: report    if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))
+Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))
 Message: paragraph doesn't end with a full stop, colon, question or excalamation mark  Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/p-punctuation/p-bracket-test/p-bracket-test.sch
+++ b/test/tests/gen/p-punctuation/p-bracket-test/p-bracket-test.sch
@@ -611,7 +611,7 @@
   <pattern id="house-style">
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/p-punctuation/p-bracket-test/pass.xml
+++ b/test/tests/gen/p-punctuation/p-bracket-test/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-bracket-test.sch"?>
 <!--Context: article/body//p[not(parent::list-item)]
-Test: report    if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))
+Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))
 Message: paragraph doesn't end with a full stop, colon, question or excalamation mark  Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/p-punctuation/p-punctuation-test/fail.xml
+++ b/test/tests/gen/p-punctuation/p-punctuation-test/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-punctuation-test.sch"?>
 <!--Context: article/body//p[not(parent::list-item)]
-Test: report    if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))
+Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))
 Message: paragraph doesn't end with punctuation  Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/p-punctuation/p-punctuation-test/p-punctuation-test.sch
+++ b/test/tests/gen/p-punctuation/p-punctuation-test/p-punctuation-test.sch
@@ -611,7 +611,7 @@
   <pattern id="house-style">
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/p-punctuation/p-punctuation-test/pass.xml
+++ b/test/tests/gen/p-punctuation/p-punctuation-test/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-punctuation-test.sch"?>
 <!--Context: article/body//p[not(parent::list-item)]
-Test: report    if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))
+Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))
 Message: paragraph doesn't end with punctuation  Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/retraction-test/related-articles-test-9/fail.xml
+++ b/test/tests/gen/retraction-test/related-articles-test-9/fail.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="related-articles-test-9.sch"?>
+<!--Context: article[@article-type='retraction']//article-meta
+Test: assert    count(related-article[@related-article-type='retracted-article']) gt 0
+Message: Retractions must contain at least 1 relatedarticle link with the attribute relatedarticletype='retractedarticle'.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="retraction">
+    <front>
+      <article-meta>
+        <article-categories>
+          <subj-group subj-group-type="display-channel"><subject>Retraction</subject></subj-group>
+        </article-categories>
+        <title-group><article-title>Retraction: The structure of SV40 large T hexameric helicase in complex with AT-rich origin DNA</article-title></title-group>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/retraction-test/related-articles-test-9/pass.xml
+++ b/test/tests/gen/retraction-test/related-articles-test-9/pass.xml
@@ -1,0 +1,17 @@
+<?oxygen SCHSchema="related-articles-test-9.sch"?>
+<!--Context: article[@article-type='retraction']//article-meta
+Test: assert    count(related-article[@related-article-type='retracted-article']) gt 0
+Message: Retractions must contain at least 1 relatedarticle link with the attribute relatedarticletype='retractedarticle'.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="retraction">
+    <front>
+      <article-meta>
+        <article-categories>
+          <subj-group subj-group-type="display-channel"><subject>Retraction</subject></subj-group>
+        </article-categories>
+        <title-group><article-title>Retraction: The structure of SV40 large T hexameric helicase in complex with AT-rich origin DNA</article-title></title-group>
+        <related-article ext-link-type="doi" id="ra1" related-article-type="retracted-article" xlink:href="10.7554/eLife.00000"/>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/retraction-test/related-articles-test-9/related-articles-test-9.sch
+++ b/test/tests/gen/retraction-test/related-articles-test-9/related-articles-test-9.sch
@@ -608,20 +608,14 @@
       </xsl:if>
     </xsl:element>
   </xsl:function>
-  <pattern id="article-metadata">
-    <rule context="article/front/article-meta/title-group" id="test-title-group">
-      <let name="subj-type" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject"/>
-      <let name="lc" value="normalize-space(lower-case(article-title))"/>
-      <let name="title" value="replace(article-title,'\p{P}','')"/>
-      <let name="body" value="ancestor::front/following-sibling::body"/>
-      <let name="tokens" value="string-join(for $x in tokenize($title,' ')[position() &gt; 1] return       if (matches($x,'^[A-Z]') and matches($body,concat(' ',lower-case($x),' '))) then $x      else (),', ')"/>
-      <report test="($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
-      </report>
+  <pattern id="related-articles">
+    <rule context="article[@article-type='retraction']//article-meta" id="retraction-test">
+      <assert test="count(related-article[@related-article-type='retracted-article']) gt 0" role="error" id="related-articles-test-9">Retractions must contain at least 1 related-article link with the attribute related-article-type='retracted-article'.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article/front/article-meta/title-group" role="error" id="test-title-group-xspec-assert">article/front/article-meta/title-group must be present.</assert>
+      <assert test="descendant::article[@article-type='retraction']//article-meta" role="error" id="retraction-test-xspec-assert">article[@article-type='retraction']//article-meta must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/test-title-group/article-title-test-11/fail.xml
+++ b/test/tests/gen/test-title-group/article-title-test-11/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="article-title-test-11.sch"?>
 <!--Context: article/front/article-meta/title-group
-Test: report    matches($tokens,'[A-Za-z]')
+Test: report    ($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')
 Message: Article title contains a capitalised word(s) which is not capitalised in the body of the article    is this correct?  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/test-title-group/article-title-test-11/pass.xml
+++ b/test/tests/gen/test-title-group/article-title-test-11/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="article-title-test-11.sch"?>
 <!--Context: article/front/article-meta/title-group
-Test: report    matches($tokens,'[A-Za-z]')
+Test: report    ($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')
 Message: Article title contains a capitalised word(s) which is not capitalised in the body of the article    is this correct?  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -860,7 +860,7 @@
 	  <report test="($subj-type = ('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Research Communication', 'Feature article', 'Insight', 'Editorial', 'Scientific Correspondence')) and matches(article-title,':')" role="warning" id="article-title-test-10">Article title contains a colon. This almost never allowed. - <value-of select="article-title"/>
       </report>
 	  
-	  <report test="matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
+	  <report test="($subj-type!='Correction') and ($subj-type!='Retraction') and matches($tokens,'[A-Za-z]')" role="warning" id="article-title-test-11">Article title contains a capitalised word(s) which is not capitalised in the body of the article - <value-of select="$tokens"/> - is this correct? - <value-of select="article-title"/>
       </report>
 	  
 	  <report test="matches(article-title,' [Bb]ased ') and not(matches(article-title,' [Bb]ased on '))" role="warning" id="article-title-test-12">Article title contains the string ' based'. Should the preceding space be replaced by a hyphen - '-based'.  - <value-of select="article-title"/>
@@ -2628,6 +2628,20 @@
     <rule context="article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = 'Insight']//article-meta" id="insight-test">
       
       <assert test="count(related-article) gt 0" role="error" id="related-articles-test-2">Insight must contain an article-reference link to the original article it is discussing.</assert>
+      
+    </rule>
+  </pattern>
+  <pattern id="correction-test-pattern">
+    <rule context="article[@article-type='correction']//article-meta" id="correction-test">
+      
+      <assert test="count(related-article[@related-article-type='corrected-article']) gt 0" role="error" id="related-articles-test-8">Corrections must contain at least 1 related-article link with the attribute related-article-type='corrected-article'.</assert>
+      
+    </rule>
+  </pattern>
+  <pattern id="retraction-test-pattern">
+    <rule context="article[@article-type='retraction']//article-meta" id="retraction-test">
+      
+      <assert test="count(related-article[@related-article-type='retracted-article']) gt 0" role="error" id="related-articles-test-9">Retractions must contain at least 1 related-article link with the attribute related-article-type='retracted-article'.</assert>
       
     </rule>
   </pattern>
@@ -5536,9 +5550,9 @@
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (count(preceding::p[ancestor::body]) = 0)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\s*?$|:\s*?$|\?\s*?$|!\s*?$'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="italic-house-style-pattern">
@@ -5888,6 +5902,8 @@
       <assert test="descendant::sub-article[@article-type='reply']/body//p[not(ancestor::disp-quote)]" role="error" id="reply-missing-disp-quote-tests-xspec-assert">sub-article[@article-type='reply']/body//p[not(ancestor::disp-quote)] must be present.</assert>
       <assert test="descendant::article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = 'Research Advance']//article-meta" role="error" id="research-advance-test-xspec-assert">article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = 'Research Advance']//article-meta must be present.</assert>
       <assert test="descendant::article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = 'Insight']//article-meta" role="error" id="insight-test-xspec-assert">article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = 'Insight']//article-meta must be present.</assert>
+      <assert test="descendant::article[@article-type='correction']//article-meta" role="error" id="correction-test-xspec-assert">article[@article-type='correction']//article-meta must be present.</assert>
+      <assert test="descendant::article[@article-type='retraction']//article-meta" role="error" id="retraction-test-xspec-assert">article[@article-type='retraction']//article-meta must be present.</assert>
       <assert test="descendant::related-article" role="error" id="related-articles-conformance-xspec-assert">related-article must be present.</assert>
       <assert test="descendant::element-citation" role="error" id="elem-citation-general-xspec-assert">element-citation must be present.</assert>
       <assert test="descendant::element-citation/person-group" role="error" id="elem-citation-gen-name-3-1-xspec-assert">element-citation/person-group must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -5256,6 +5256,30 @@
         <x:expect-not-assert id="insight-test-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="correction-test">
+      <x:scenario label="related-articles-test-8-pass">
+        <x:context href="../tests/gen/correction-test/related-articles-test-8/pass.xml"/>
+        <x:expect-not-assert id="related-articles-test-8" role="error"/>
+        <x:expect-not-assert id="correction-test-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="related-articles-test-8-fail">
+        <x:context href="../tests/gen/correction-test/related-articles-test-8/fail.xml"/>
+        <x:expect-assert id="related-articles-test-8" role="error"/>
+        <x:expect-not-assert id="correction-test-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="retraction-test">
+      <x:scenario label="related-articles-test-9-pass">
+        <x:context href="../tests/gen/retraction-test/related-articles-test-9/pass.xml"/>
+        <x:expect-not-assert id="related-articles-test-9" role="error"/>
+        <x:expect-not-assert id="retraction-test-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="related-articles-test-9-fail">
+        <x:context href="../tests/gen/retraction-test/related-articles-test-9/fail.xml"/>
+        <x:expect-assert id="related-articles-test-9" role="error"/>
+        <x:expect-not-assert id="retraction-test-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
     <x:scenario label="related-articles-conformance">
       <x:scenario label="related-articles-test-3-pass">
         <x:context href="../tests/gen/related-articles-conformance/related-articles-test-3/pass.xml"/>


### PR DESCRIPTION
- Add test for correct `related-article` in correction/retraction
- Exclude `p-punctuation-test` and `p-bracket-test` from corrections/retractions