### PR TITLE
graphic conformance

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1596,19 +1596,27 @@
     </rule>
   </pattern>
   <pattern id="graphic-tests-pattern">
-    <rule context="graphic" id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
       
-      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">graphic has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">
+        <name/> has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
       
-      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">graphic has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">
+        <name/> has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
       
-      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">graphic has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">
+        <name/> has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
       
       <!-- Should this just be image? application included because during proofing stages non-web image files are referenced, e.g postscript -->
-      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">graphic must have a @mimetype='image'.</assert>
+      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">
+        <name/> must have a @mimetype='image'.</assert>
       
-      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">graphic must have an @xlink:href which contains a file reference.</assert>
+      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">
+        <name/> must have an @xlink:href which contains a file reference.</assert>
+      
+      <report test="preceding::graphic/@xlink:href = $link" role="error" id="graphic-test-6">Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
     </rule>
   </pattern>
   <pattern id="media-tests-pattern">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1602,19 +1602,27 @@
     </rule>
   </pattern>
   <pattern id="graphic-tests-pattern">
-    <rule context="graphic" id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
       
-      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">graphic has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">
+        <name/> has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
       
-      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">graphic has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">
+        <name/> has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
       
-      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">graphic has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">
+        <name/> has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
       
       <!-- Should this just be image? application included because during proofing stages non-web image files are referenced, e.g postscript -->
-      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">graphic must have a @mimetype='image'.</assert>
+      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">
+        <name/> must have a @mimetype='image'.</assert>
       
-      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">graphic must have an @xlink:href which contains a file reference.</assert>
+      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">
+        <name/> must have an @xlink:href which contains a file reference.</assert>
+      
+      <report test="preceding::graphic/@xlink:href = $link" role="error" id="graphic-test-6">Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
     </rule>
   </pattern>
   <pattern id="media-tests-pattern">

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1597,19 +1597,27 @@
     </rule>
   </pattern>
   <pattern id="graphic-tests-pattern">
-    <rule context="graphic" id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
       
-      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">graphic has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">
+        <name/> has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
       
-      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">graphic has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">
+        <name/> has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
       
-      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">graphic has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">
+        <name/> has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
       
       <!-- Should this just be image? application included because during proofing stages non-web image files are referenced, e.g postscript -->
-      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">graphic must have a @mimetype='image'.</assert>
+      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">
+        <name/> must have a @mimetype='image'.</assert>
       
-      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">graphic must have an @xlink:href which contains a file reference.</assert>
+      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">
+        <name/> must have an @xlink:href which contains a file reference.</assert>
+      
+      <report test="preceding::graphic/@xlink:href = $link" role="error" id="graphic-test-6">Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
     </rule>
   </pattern>
   <pattern id="media-tests-pattern">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2141,30 +2141,35 @@
         id="final-ar-fig-position-test"><value-of select="label"/> does not appear in sequence which is incorrect. Relative to the other AR images it is placed in position <value-of select="$pos"/>.</assert>
     </rule>
     
-    <rule context="graphic" 
+    <rule context="graphic|inline-graphic" 
       id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
       
       <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))"
         role="error"
-        id="graphic-test-1">graphic has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
+        id="graphic-test-1"><name/> has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
       
       <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))"
         role="error"
-        id="graphic-test-2">graphic has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
+        id="graphic-test-2"><name/> has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
       
       <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))"
         role="error"
-        id="graphic-test-3">graphic has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
+        id="graphic-test-3"><name/> has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
       
       <!-- Should this just be image? application included because during proofing stages non-web image files are referenced, e.g postscript -->
       <assert test="@mimetype=('image','application')"
         role="error"
-        id="graphic-test-4">graphic must have a @mimetype='image'.</assert>
+        id="graphic-test-4"><name/> must have a @mimetype='image'.</assert>
       
       <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" 
         role="error"
-        id="graphic-test-5">graphic must have an @xlink:href which contains a file reference.</assert>
+        id="graphic-test-5"><name/> must have an @xlink:href which contains a file reference.</assert>
+      
+      <report test="preceding::graphic/@xlink:href = $link" 
+        role="error"
+        id="graphic-test-6">Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
     </rule>
     
     <rule context="media" 

--- a/test/tests/gen/graphic-tests/graphic-test-1/fail.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-1.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: report    contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))
-Message: graphic has tif mimesubtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.-->
+Message:  has tif mimesubtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <graphic mime-subtype="tiff" xlink:href="file.jpg"/>

--- a/test/tests/gen/graphic-tests/graphic-test-1/graphic-test-1.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-1/graphic-test-1.sch
@@ -609,14 +609,16 @@
     </xsl:element>
   </xsl:function>
   <pattern id="content-containers">
-    <rule context="graphic" id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
-      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">graphic has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
+      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">
+        <name/> has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::graphic" role="error" id="graphic-tests-xspec-assert">graphic must be present.</assert>
+      <assert test="descendant::graphic or descendant::inline-graphic" role="error" id="graphic-tests-xspec-assert">graphic|inline-graphic must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/graphic-tests/graphic-test-1/pass.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-1.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: report    contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))
-Message: graphic has tif mimesubtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.-->
+Message:  has tif mimesubtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <graphic mime-subtype="tiff" xlink:href="file.tif"/>

--- a/test/tests/gen/graphic-tests/graphic-test-2/fail.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-2.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: report    contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))
-Message: graphic has postscript mimesubtype but filename does not end with '.eps'. This cannot be correct.-->
+Message:  has postscript mimesubtype but filename does not end with '.eps'. This cannot be correct.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <graphic mime-subtype="postscript" xlink:href="file.tif"/>

--- a/test/tests/gen/graphic-tests/graphic-test-2/graphic-test-2.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-2/graphic-test-2.sch
@@ -609,14 +609,16 @@
     </xsl:element>
   </xsl:function>
   <pattern id="content-containers">
-    <rule context="graphic" id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
-      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">graphic has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
+      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">
+        <name/> has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::graphic" role="error" id="graphic-tests-xspec-assert">graphic must be present.</assert>
+      <assert test="descendant::graphic or descendant::inline-graphic" role="error" id="graphic-tests-xspec-assert">graphic|inline-graphic must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/graphic-tests/graphic-test-2/pass.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-2.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: report    contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))
-Message: graphic has postscript mimesubtype but filename does not end with '.eps'. This cannot be correct.-->
+Message:  has postscript mimesubtype but filename does not end with '.eps'. This cannot be correct.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <graphic mime-subtype="postscript" xlink:href="file.eps"/>

--- a/test/tests/gen/graphic-tests/graphic-test-3/fail.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-3.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: report    contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))
-Message: graphic has jpeg mimesubtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.-->
+Message:  has jpeg mimesubtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <graphic mime-subtype="jpeg" xlink:href="file.eps"/>

--- a/test/tests/gen/graphic-tests/graphic-test-3/graphic-test-3.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-3/graphic-test-3.sch
@@ -609,14 +609,16 @@
     </xsl:element>
   </xsl:function>
   <pattern id="content-containers">
-    <rule context="graphic" id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
-      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">graphic has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
+      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">
+        <name/> has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::graphic" role="error" id="graphic-tests-xspec-assert">graphic must be present.</assert>
+      <assert test="descendant::graphic or descendant::inline-graphic" role="error" id="graphic-tests-xspec-assert">graphic|inline-graphic must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/graphic-tests/graphic-test-3/pass.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-3.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: report    contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))
-Message: graphic has jpeg mimesubtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.-->
+Message:  has jpeg mimesubtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <graphic mime-subtype="jpeg" xlink:href="file.jpeg"/>

--- a/test/tests/gen/graphic-tests/graphic-test-4/fail.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-4/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-4.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: assert    @mimetype=('image','application')
-Message: graphic must have a @mimetype='image'.-->
+Message:  must have a @mimetype='image'.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <fig>

--- a/test/tests/gen/graphic-tests/graphic-test-4/pass.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-4/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-4.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: assert    @mimetype=('image','application')
-Message: graphic must have a @mimetype='image'.-->
+Message:  must have a @mimetype='image'.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <fig>

--- a/test/tests/gen/graphic-tests/graphic-test-5/fail.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-5/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-5.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: assert    matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')
-Message: graphic must have an @xlink:href which contains a file reference.-->
+Message:  must have an @xlink:href which contains a file reference.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <graphic xlink:href="f1fs001" mimetype="image" mime-subtype="x-tiff"/>

--- a/test/tests/gen/graphic-tests/graphic-test-5/graphic-test-5.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-5/graphic-test-5.sch
@@ -609,14 +609,16 @@
     </xsl:element>
   </xsl:function>
   <pattern id="content-containers">
-    <rule context="graphic" id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
-      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">graphic must have an @xlink:href which contains a file reference.</assert>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
+      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">
+        <name/> must have an @xlink:href which contains a file reference.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::graphic" role="error" id="graphic-tests-xspec-assert">graphic must be present.</assert>
+      <assert test="descendant::graphic or descendant::inline-graphic" role="error" id="graphic-tests-xspec-assert">graphic|inline-graphic must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/graphic-tests/graphic-test-5/pass.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-5/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="graphic-test-5.sch"?>
-<!--Context: graphic
+<!--Context: graphic|inline-graphic
 Test: assert    matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')
-Message: graphic must have an @xlink:href which contains a file reference.-->
+Message:  must have an @xlink:href which contains a file reference.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <graphic xlink:href="f1fs001.tif" mimetype="image" mime-subtype="x-tiff"/>

--- a/test/tests/gen/graphic-tests/graphic-test-6/fail.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-6/fail.xml
@@ -1,0 +1,34 @@
+<?oxygen SCHSchema="graphic-test-6.sch"?>
+<!--Context: graphic|inline-graphic
+Test: report    preceding::graphic/@xlink:href = $link
+Message: Image file for  () is the same as the one used for .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <body>
+      <fig-group>
+        <fig id="fig1" position="float">
+          <label>Figure 1.</label>
+          <caption>
+            <title>...</title>
+            <p/></caption>
+          <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00000-fig1-v3.tif"/>
+        </fig>
+        <fig id="fig1s1" position="float">
+          <label>Figure 1-figure supplement 1.</label>
+          <caption>
+            <title>...</title>
+            <p/></caption>
+          <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00000-fig1-v3.tif"/>
+        </fig>
+      </fig-group>
+      <fig id="fig2" position="float">
+        <label>Figure 2.</label>
+        <caption>
+          <title>...</title>
+          <p/></caption>
+        <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00000-fig1-v3.tif"/>
+      </fig>
+      <p> ... <inline-graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00000-fig1-v3.tif"/> ... </p>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/graphic-tests/graphic-test-6/graphic-test-6.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-6/graphic-test-6.sch
@@ -612,8 +612,7 @@
     <rule context="graphic|inline-graphic" id="graphic-tests">
       <let name="link" value="@xlink:href"/>
       <let name="file" value="lower-case($link)"/>
-      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">
-        <name/> must have a @mimetype='image'.</assert>
+      <report test="preceding::graphic/@xlink:href = $link" role="error" id="graphic-test-6">Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/graphic-tests/graphic-test-6/pass.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-6/pass.xml
@@ -1,0 +1,34 @@
+<?oxygen SCHSchema="graphic-test-6.sch"?>
+<!--Context: graphic|inline-graphic
+Test: report    preceding::graphic/@xlink:href = $link
+Message: Image file for  () is the same as the one used for .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <body>
+      <fig-group>
+        <fig id="fig1" position="float">
+          <label>Figure 1.</label>
+          <caption>
+            <title>...</title>
+            <p/></caption>
+          <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00000-fig1-v3.tif"/>
+        </fig>
+        <fig id="fig1s1" position="float">
+          <label>Figure 1-figure supplement 1.</label>
+          <caption>
+            <title>...</title>
+            <p/></caption>
+          <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00000-fig1s1-v3.tif"/>
+        </fig>
+      </fig-group>
+      <fig id="fig2" position="float">
+        <label>Figure 2.</label>
+        <caption>
+          <title>...</title>
+          <p/></caption>
+        <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00000-fig2-v3.tif"/>
+      </fig>
+      <p> ... <inline-graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00000-ing1-v3.tif"/> ... </p>
+    </body>
+  </article>
+</root>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1598,19 +1598,27 @@
     </rule>
   </pattern>
   <pattern id="graphic-tests-pattern">
-    <rule context="graphic" id="graphic-tests">
-      <let name="file" value="lower-case(@xlink:href)"/>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
       
-      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">graphic has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'tiff') and not(matches($file,'\.tif$|\.tiff$'))" role="error" id="graphic-test-1">
+        <name/> has tif mime-subtype but filename does not end with '.tif' or '.tiff'. This cannot be correct.</report>
       
-      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">graphic has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'postscript') and not(ends-with($file,'.eps'))" role="error" id="graphic-test-2">
+        <name/> has postscript mime-subtype but filename does not end with '.eps'. This cannot be correct.</report>
       
-      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">graphic has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
+      <report test="contains(@mime-subtype,'jpeg') and not(matches($file,'\.jpg$|\.jpeg$'))" role="error" id="graphic-test-3">
+        <name/> has jpeg mime-subtype but filename does not end with '.jpg' or '.jpeg'. This cannot be correct.</report>
       
       <!-- Should this just be image? application included because during proofing stages non-web image files are referenced, e.g postscript -->
-      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">graphic must have a @mimetype='image'.</assert>
+      <assert test="@mimetype=('image','application')" role="error" id="graphic-test-4">
+        <name/> must have a @mimetype='image'.</assert>
       
-      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">graphic must have an @xlink:href which contains a file reference.</assert>
+      <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">
+        <name/> must have an @xlink:href which contains a file reference.</assert>
+      
+      <report test="preceding::graphic/@xlink:href = $link" role="error" id="graphic-test-6">Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
     </rule>
   </pattern>
   <pattern id="media-tests-pattern">
@@ -5834,7 +5842,7 @@
       <assert test="descendant::fig-group/*" role="error" id="fig-group-child-tests-xspec-assert">fig-group/* must be present.</assert>
       <assert test="descendant::fig[not(ancestor::sub-article[@article-type='reply'])]" role="error" id="fig-tests-xspec-assert">fig[not(ancestor::sub-article[@article-type='reply'])] must be present.</assert>
       <assert test="descendant::fig[ancestor::sub-article[@article-type='reply']]" role="error" id="ar-fig-tests-xspec-assert">fig[ancestor::sub-article[@article-type='reply']] must be present.</assert>
-      <assert test="descendant::graphic" role="error" id="graphic-tests-xspec-assert">graphic must be present.</assert>
+      <assert test="descendant::graphic or descendant::inline-graphic" role="error" id="graphic-tests-xspec-assert">graphic|inline-graphic must be present.</assert>
       <assert test="descendant::media" role="error" id="media-tests-xspec-assert">media must be present.</assert>
       <assert test="descendant::media[child::label]" role="error" id="video-test-xspec-assert">media[child::label] must be present.</assert>
       <assert test="descendant::supplementary-material" role="error" id="supplementary-material-tests-xspec-assert">supplementary-material must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -2793,6 +2793,16 @@
         <x:expect-assert id="graphic-test-5" role="error"/>
         <x:expect-not-assert id="graphic-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="graphic-test-6-pass">
+        <x:context href="../tests/gen/graphic-tests/graphic-test-6/pass.xml"/>
+        <x:expect-not-report id="graphic-test-6" role="error"/>
+        <x:expect-not-assert id="graphic-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="graphic-test-6-fail">
+        <x:context href="../tests/gen/graphic-tests/graphic-test-6/fail.xml"/>
+        <x:expect-report id="graphic-test-6" role="error"/>
+        <x:expect-not-assert id="graphic-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="media-tests">
       <x:scenario label="media-test-1-pass">


### PR DESCRIPTION
- Include `<inline-graphic>` in `graphic-tests`
- Add `graphic-test-6` to maintain distinct image files