### PR TITLE
Various edits

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1526,7 +1526,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4164,12 +4164,6 @@
         Reference '<value-of select="ancestor::ref/@id"/>' does not.
       </assert>
       
-      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
-        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value '<value-of select="@iso-8601-date"/>'.
-      </assert>
-      
       <assert test="matches(normalize-space(.),'(^\d{4}[a-z]?)')" role="error" id="err-elem-cit-periodical-7-4-1">[err-elem-cit-periodical-7-4-1]
         The &lt;year&gt; element in a reference must contain 4 digits, possibly followed by one (but not more) lower-case letter.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
@@ -4182,29 +4176,21 @@
         the value '<value-of select="."/>'.
       </assert>
       
-      <assert test="not(./@iso-8601-date) or substring(normalize-space(./@iso-8601-date),1,4) = $YYYY" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
-        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
-        &lt;year&gt; element.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
-        the value '<value-of select="."/>' and the attribute contains the value 
-        '<value-of select="./@iso-8601-date"/>'.
-      </assert>
-      
-      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
+      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
         If the &lt;year&gt; element contains the letter 'a' after the digits, there must be another reference with 
         the same first author surname with a letter "b" after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
+      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
         If the &lt;year&gt; element contains any letter other than 'a' after the digits, there must be another 
         reference with the same first author surname with the preceding letter after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
+      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname[1] = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname[1]" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
         Letter suffixes must be unique for the combination of year and first author surname. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
         contains the &lt;year&gt; '<value-of select="."/>' more than once for the same first author surname
-        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>'.</report>
+        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname[1]"/>'.</report>
       
     </rule>
   </pattern>
@@ -4240,6 +4226,7 @@
   </pattern>
   <pattern id="elem-citation-periodical-string-date-pattern">
     <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
       
       <assert test="count(month)=1 and count(year)=1" role="error" id="err-elem-cit-periodical-14-2">[err-elem-cit-periodical-14-2]
         The &lt;string-date&gt; element must include one of each of &lt;month&gt; and &lt;year&gt; 
@@ -4258,6 +4245,20 @@
         The format of the element content must match &lt;month&gt;, space, &lt;day&gt;, comma, &lt;year&gt;, or &lt;month&gt;, comma, &lt;year&gt;.
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="."/>.</assert>    
       
+      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
+        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+        the value '<value-of select="@iso-8601-date"/>'.
+      </assert>
+      
+      <report test="not(@iso-8601-date) or (substring(normalize-space(@iso-8601-date),1,4) != $YYYY)" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
+        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
+        &lt;year&gt; element.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
+        the value '<value-of select="."/>' and the attribute contains the value 
+        '<value-of select="./@iso-8601-date"/>'.
+      </report>
+      
     </rule>
   </pattern>
   <pattern id="elem-citation-periodical-month-pattern">
@@ -4269,11 +4270,11 @@
         the value  &lt;month&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
         The content of &lt;month&gt; must match the content of the month section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;month&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;month&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -4287,11 +4288,11 @@
         the value  &lt;day&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
         The content of &lt;day&gt;, if present, must match the content of the day section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;day&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;day&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -5658,7 +5659,7 @@
     <rule context="element-citation[(@publication-type='journal') and (fpage or lpage)]" id="page-conformity">
       <let name="cite" value="e:citation-format1(year)"/>
       
-      <report test="matches(lower-case(source),'plos')" role="error" id="online-journal-w-page">
+      <report test="matches(lower-case(source),'plos|^elife$|^mbio$')" role="error" id="online-journal-w-page">
         <value-of select="$cite"/> is a <value-of select="source"/> article, but has a page number, which is incorrect.</report>
       
     </rule>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1532,7 +1532,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4170,12 +4170,6 @@
         Reference '<value-of select="ancestor::ref/@id"/>' does not.
       </assert>
       
-      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
-        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value '<value-of select="@iso-8601-date"/>'.
-      </assert>
-      
       <assert test="matches(normalize-space(.),'(^\d{4}[a-z]?)')" role="error" id="err-elem-cit-periodical-7-4-1">[err-elem-cit-periodical-7-4-1]
         The &lt;year&gt; element in a reference must contain 4 digits, possibly followed by one (but not more) lower-case letter.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
@@ -4188,29 +4182,21 @@
         the value '<value-of select="."/>'.
       </assert>
       
-      <assert test="not(./@iso-8601-date) or substring(normalize-space(./@iso-8601-date),1,4) = $YYYY" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
-        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
-        &lt;year&gt; element.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
-        the value '<value-of select="."/>' and the attribute contains the value 
-        '<value-of select="./@iso-8601-date"/>'.
-      </assert>
-      
-      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
+      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
         If the &lt;year&gt; element contains the letter 'a' after the digits, there must be another reference with 
         the same first author surname with a letter "b" after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
+      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
         If the &lt;year&gt; element contains any letter other than 'a' after the digits, there must be another 
         reference with the same first author surname with the preceding letter after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
+      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname[1] = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname[1]" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
         Letter suffixes must be unique for the combination of year and first author surname. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
         contains the &lt;year&gt; '<value-of select="."/>' more than once for the same first author surname
-        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>'.</report>
+        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname[1]"/>'.</report>
       
     </rule>
   </pattern>
@@ -4246,6 +4232,7 @@
   </pattern>
   <pattern id="elem-citation-periodical-string-date-pattern">
     <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
       
       <assert test="count(month)=1 and count(year)=1" role="error" id="err-elem-cit-periodical-14-2">[err-elem-cit-periodical-14-2]
         The &lt;string-date&gt; element must include one of each of &lt;month&gt; and &lt;year&gt; 
@@ -4264,6 +4251,20 @@
         The format of the element content must match &lt;month&gt;, space, &lt;day&gt;, comma, &lt;year&gt;, or &lt;month&gt;, comma, &lt;year&gt;.
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="."/>.</assert>    
       
+      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
+        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+        the value '<value-of select="@iso-8601-date"/>'.
+      </assert>
+      
+      <report test="not(@iso-8601-date) or (substring(normalize-space(@iso-8601-date),1,4) != $YYYY)" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
+        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
+        &lt;year&gt; element.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
+        the value '<value-of select="."/>' and the attribute contains the value 
+        '<value-of select="./@iso-8601-date"/>'.
+      </report>
+      
     </rule>
   </pattern>
   <pattern id="elem-citation-periodical-month-pattern">
@@ -4275,11 +4276,11 @@
         the value  &lt;month&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
         The content of &lt;month&gt; must match the content of the month section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;month&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;month&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -4293,11 +4294,11 @@
         the value  &lt;day&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
         The content of &lt;day&gt;, if present, must match the content of the day section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;day&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;day&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -5664,7 +5665,7 @@
     <rule context="element-citation[(@publication-type='journal') and (fpage or lpage)]" id="page-conformity">
       <let name="cite" value="e:citation-format1(year)"/>
       
-      <report test="matches(lower-case(source),'plos')" role="error" id="online-journal-w-page">
+      <report test="matches(lower-case(source),'plos|^elife$|^mbio$')" role="error" id="online-journal-w-page">
         <value-of select="$cite"/> is a <value-of select="source"/> article, but has a page number, which is incorrect.</report>
       
     </rule>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1526,7 +1526,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4165,12 +4165,6 @@
         Reference '<value-of select="ancestor::ref/@id"/>' does not.
       </assert>
       
-      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
-        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value '<value-of select="@iso-8601-date"/>'.
-      </assert>
-      
       <assert test="matches(normalize-space(.),'(^\d{4}[a-z]?)')" role="error" id="err-elem-cit-periodical-7-4-1">[err-elem-cit-periodical-7-4-1]
         The &lt;year&gt; element in a reference must contain 4 digits, possibly followed by one (but not more) lower-case letter.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
@@ -4183,29 +4177,21 @@
         the value '<value-of select="."/>'.
       </assert>
       
-      <assert test="not(./@iso-8601-date) or substring(normalize-space(./@iso-8601-date),1,4) = $YYYY" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
-        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
-        &lt;year&gt; element.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
-        the value '<value-of select="."/>' and the attribute contains the value 
-        '<value-of select="./@iso-8601-date"/>'.
-      </assert>
-      
-      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
+      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
         If the &lt;year&gt; element contains the letter 'a' after the digits, there must be another reference with 
         the same first author surname with a letter "b" after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
+      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
         If the &lt;year&gt; element contains any letter other than 'a' after the digits, there must be another 
         reference with the same first author surname with the preceding letter after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
+      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname[1] = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname[1]" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
         Letter suffixes must be unique for the combination of year and first author surname. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
         contains the &lt;year&gt; '<value-of select="."/>' more than once for the same first author surname
-        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>'.</report>
+        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname[1]"/>'.</report>
       
     </rule>
   </pattern>
@@ -4241,6 +4227,7 @@
   </pattern>
   <pattern id="elem-citation-periodical-string-date-pattern">
     <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
       
       <assert test="count(month)=1 and count(year)=1" role="error" id="err-elem-cit-periodical-14-2">[err-elem-cit-periodical-14-2]
         The &lt;string-date&gt; element must include one of each of &lt;month&gt; and &lt;year&gt; 
@@ -4259,6 +4246,20 @@
         The format of the element content must match &lt;month&gt;, space, &lt;day&gt;, comma, &lt;year&gt;, or &lt;month&gt;, comma, &lt;year&gt;.
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="."/>.</assert>    
       
+      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
+        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+        the value '<value-of select="@iso-8601-date"/>'.
+      </assert>
+      
+      <report test="not(@iso-8601-date) or (substring(normalize-space(@iso-8601-date),1,4) != $YYYY)" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
+        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
+        &lt;year&gt; element.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
+        the value '<value-of select="."/>' and the attribute contains the value 
+        '<value-of select="./@iso-8601-date"/>'.
+      </report>
+      
     </rule>
   </pattern>
   <pattern id="elem-citation-periodical-month-pattern">
@@ -4270,11 +4271,11 @@
         the value  &lt;month&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
         The content of &lt;month&gt; must match the content of the month section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;month&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;month&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -4288,11 +4289,11 @@
         the value  &lt;day&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
         The content of &lt;day&gt;, if present, must match the content of the day section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;day&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;day&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -5659,7 +5660,7 @@
     <rule context="element-citation[(@publication-type='journal') and (fpage or lpage)]" id="page-conformity">
       <let name="cite" value="e:citation-format1(year)"/>
       
-      <report test="matches(lower-case(source),'plos')" role="error" id="online-journal-w-page">
+      <report test="matches(lower-case(source),'plos|^elife$|^mbio$')" role="error" id="online-journal-w-page">
         <value-of select="$cite"/> is a <value-of select="source"/> article, but has a page number, which is incorrect.</report>
       
     </rule>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1974,7 +1974,7 @@
         role="error" 
         id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')"
+      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')"
         role="warning" 
         id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
@@ -5393,12 +5393,6 @@
         Reference '<value-of select="ancestor::ref/@id"/>' does not.
       </assert>
       
-      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
-        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value '<value-of select="@iso-8601-date"/>'.
-      </assert>
-      
       <assert test="matches(normalize-space(.),'(^\d{4}[a-z]?)')" role="error" id="err-elem-cit-periodical-7-4-1">[err-elem-cit-periodical-7-4-1]
         The &lt;year&gt; element in a reference must contain 4 digits, possibly followed by one (but not more) lower-case letter.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
@@ -5411,29 +5405,21 @@
         the value '<value-of select="."/>'.
       </assert>
       
-      <assert test="not(./@iso-8601-date) or substring(normalize-space(./@iso-8601-date),1,4) = $YYYY" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
-        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
-        &lt;year&gt; element.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
-        the value '<value-of select="."/>' and the attribute contains the value 
-        '<value-of select="./@iso-8601-date"/>'.
-      </assert>
-      
-      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
+      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
         If the &lt;year&gt; element contains the letter 'a' after the digits, there must be another reference with 
         the same first author surname with a letter "b" after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
+      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
         If the &lt;year&gt; element contains any letter other than 'a' after the digits, there must be another 
         reference with the same first author surname with the preceding letter after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
+      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname[1] = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname[1]" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
         Letter suffixes must be unique for the combination of year and first author surname. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
         contains the &lt;year&gt; '<value-of select="."/>' more than once for the same first author surname
-        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>'.</report>
+        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname[1]"/>'.</report>
       
     </rule>
     
@@ -5465,6 +5451,7 @@
     </rule>
     
     <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
       
       <assert test="count(month)=1 and count(year)=1" role="error" id="err-elem-cit-periodical-14-2">[err-elem-cit-periodical-14-2]
         The &lt;string-date&gt; element must include one of each of &lt;month&gt; and &lt;year&gt; 
@@ -5483,6 +5470,20 @@
         The format of the element content must match &lt;month&gt;, space, &lt;day&gt;, comma, &lt;year&gt;, or &lt;month&gt;, comma, &lt;year&gt;.
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="."/>.</assert>    
       
+      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
+        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+        the value '<value-of select="@iso-8601-date"/>'.
+      </assert>
+      
+      <report test="not(@iso-8601-date) or (substring(normalize-space(@iso-8601-date),1,4) != $YYYY)" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
+        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
+        &lt;year&gt; element.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
+        the value '<value-of select="."/>' and the attribute contains the value 
+        '<value-of select="./@iso-8601-date"/>'.
+      </report>
+      
     </rule>
     
     <rule context="element-citation[@publication-type='periodical']/string-date/month" id="elem-citation-periodical-month">
@@ -5493,12 +5494,12 @@
         the value  &lt;month&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[MNn]')
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[MNn]')
         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
         The content of &lt;month&gt; must match the content of the month section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;month&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;month&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -5511,12 +5512,12 @@
         the value  &lt;day&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[D]')
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]')
                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
         The content of &lt;day&gt;, if present, must match the content of the day section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;day&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;day&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -7559,7 +7560,7 @@
       id="page-conformity">
       <let name="cite" value="e:citation-format1(year)"/>
       
-      <report test="matches(lower-case(source),'plos')"
+      <report test="matches(lower-case(source),'plos|^elife$|^mbio$')"
         role="error" 
         id="online-journal-w-page"><value-of select="$cite"/> is a <value-of select="source"/> article, but has a page number, which is incorrect.</report>
       

--- a/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-6/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-6/fail.xml
@@ -17,7 +17,7 @@ Message: [errelemcitperiodical146]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>z</day>, <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>z</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-6/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-6/pass.xml
@@ -17,7 +17,7 @@ Message: [errelemcitperiodical146]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>9</day>, <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-7/err-elem-cit-periodical-14-7.sch
+++ b/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-7/err-elem-cit-periodical-14-7.sch
@@ -675,11 +675,11 @@
   </xsl:function>
   <pattern id="element-citation-periodical-tests">
     <rule context="element-citation[@publication-type='periodical']/string-date/day" id="elem-citation-periodical-day">
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
         The content of &lt;day&gt;, if present, must match the content of the day section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;day&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;day&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
     </rule>
   </pattern>

--- a/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-7/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-7/pass.xml
@@ -1,11 +1,11 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-14-7.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/day
-Test: report    if (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[D]') else .
+Test: report    if (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]') else .
 Message: [errelemcitperiodical147]
         The content of <day>, if present, must match the content of the day section of @iso8601date on the 
-        sibling year element.
+        parent stringdate element.
         Reference '' does not meet this requirement as it contains
-        the value <day>='' but <year>/@iso8601date=''.
+        the value <day>='' but <stringdate>/@iso8601date=''.
       -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
@@ -18,7 +18,7 @@ Message: [errelemcitperiodical147]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>9</day>, <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-5/err-elem-cit-periodical-14-5.sch
+++ b/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-5/err-elem-cit-periodical-14-5.sch
@@ -675,11 +675,11 @@
   </xsl:function>
   <pattern id="element-citation-periodical-tests">
     <rule context="element-citation[@publication-type='periodical']/string-date/month" id="elem-citation-periodical-month">
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
         The content of &lt;month&gt; must match the content of the month section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;month&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;month&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
     </rule>
   </pattern>

--- a/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-5/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-5/fail.xml
@@ -1,11 +1,11 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-14-5.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/month
-Test: report    if (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[MNn]') else .
+Test: report    if (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[MNn]') else .
 Message: [errelemcitperiodical145]
         The content of <month> must match the content of the month section of @iso8601date on the 
-        sibling year element.
+        sibling parent stringdate element.
         Reference '' does not meet this requirement as it contains
-        the value <month>='' but <year>/@iso8601date=''.
+        the value <month>='' but <stringdate>/@iso8601date=''.
       -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
@@ -18,7 +18,7 @@ Message: [errelemcitperiodical145]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>9</day>, <year iso-8601-date="1993-07-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-07-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-5/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-5/pass.xml
@@ -1,11 +1,11 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-14-5.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/month
-Test: report    if (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[MNn]') else .
+Test: report    if (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[MNn]') else .
 Message: [errelemcitperiodical145]
         The content of <month> must match the content of the month section of @iso8601date on the 
-        sibling year element.
+        parent stringdate element.
         Reference '' does not meet this requirement as it contains
-        the value <month>='' but <year>/@iso8601date=''.
+        the value <month>='' but <stringdate>/@iso8601date=''.
       -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
@@ -18,7 +18,7 @@ Message: [errelemcitperiodical145]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>9</day>, <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-2/err-elem-cit-periodical-14-2.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-2/err-elem-cit-periodical-14-2.sch
@@ -675,6 +675,7 @@
   </xsl:function>
   <pattern id="element-citation-periodical-tests">
     <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
       <assert test="count(month)=1 and count(year)=1" role="error" id="err-elem-cit-periodical-14-2">[err-elem-cit-periodical-14-2]
         The &lt;string-date&gt; element must include one of each of &lt;month&gt; and &lt;year&gt; 
         elements.

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-2/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-2/pass.xml
@@ -18,7 +18,7 @@ Message: [errelemcitperiodical142]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>9</day>, <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-3/err-elem-cit-periodical-14-3.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-3/err-elem-cit-periodical-14-3.sch
@@ -675,6 +675,7 @@
   </xsl:function>
   <pattern id="element-citation-periodical-tests">
     <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
       <assert test="count(day) le 1" role="error" id="err-elem-cit-periodical-14-3">[err-elem-cit-periodical-14-3]
         The &lt;string-date&gt; element may include one &lt;day&gt; element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-3/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-3/fail.xml
@@ -17,7 +17,7 @@ Message: [errelemcitperiodical143]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>9</day> <day>9</day>, <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-3/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-3/pass.xml
@@ -17,7 +17,7 @@ Message: [errelemcitperiodical143]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>9</day>, <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/err-elem-cit-periodical-14-8.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/err-elem-cit-periodical-14-8.sch
@@ -675,6 +675,7 @@
   </xsl:function>
   <pattern id="element-citation-periodical-tests">
     <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
       <assert test="(name(child::node()[1])='month' and replace(child::node()[2],'\s+',' ')=' ' and        name(child::node()[3])='day' and replace(child::node()[4],'\s+',' ')=', ' and name(*[position()=last()])='year') or       (name(child::node()[1])='month' and replace(child::node()[2],'\s+',' ')=', ' and name(*[position()=last()])='year')" role="error" id="err-elem-cit-periodical-14-8">[err-elem-cit-periodical-14-8]
         The format of the element content must match &lt;month&gt;, space, &lt;day&gt;, comma, &lt;year&gt;, or &lt;month&gt;, comma, &lt;year&gt;.
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="."/>.</assert>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/fail.xml
@@ -15,7 +15,7 @@ Message: [errelemcitperiodical148]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><day>9</day>, <month>September</month> <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><day>9</day>, <month>September</month> <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/pass.xml
@@ -15,7 +15,7 @@ Message: [errelemcitperiodical148]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date><month>September</month> <day>9</day>, <year iso-8601-date="1993-09-09">1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/err-elem-cit-periodical-7-3.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/err-elem-cit-periodical-7-3.sch
@@ -674,18 +674,18 @@
     </xsl:element>
   </xsl:function>
   <pattern id="element-citation-periodical-tests">
-    <rule context="element-citation[@publication-type='periodical']/string-date/year" id="elem-citation-periodical-year">
-      <let name="YYYY" value="substring(normalize-space(.), 1, 4)"/>
-      <let name="current-year" value="year-from-date(current-date())"/>
-      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
-        If the &lt;year&gt; element contains the letter 'a' after the digits, there must be another reference with 
-        the same first author surname with a letter "b" after the year. 
-        Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
+    <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
+      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
+        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+        the value '<value-of select="@iso-8601-date"/>'.
+      </assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='periodical']/string-date/year" role="error" id="elem-citation-periodical-year-xspec-assert">element-citation[@publication-type='periodical']/string-date/year must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='periodical']/string-date" role="error" id="elem-citation-periodical-string-date-xspec-assert">element-citation[@publication-type='periodical']/string-date must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/fail.xml
@@ -1,11 +1,10 @@
-<?oxygen SCHSchema="err-elem-cit-periodical-14-7.sch"?>
-<!--Context: element-citation[@publication-type='periodical']/string-date/day
-Test: report    if (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]') else .
-Message: [errelemcitperiodical147]
-        The content of <day>, if present, must match the content of the day section of @iso8601date on the 
-        parent stringdate element.
+<?oxygen SCHSchema="err-elem-cit-periodical-7-3.sch"?>
+<!--Context: element-citation[@publication-type='periodical']/string-date
+Test: assert    matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')
+Message: [errelemcitperiodical73]
+        The @iso8601date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
         Reference '' does not meet this requirement as it contains
-        the value <day>='' but <stringdate>/@iso8601date=''.
+        the value ''.
       -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
@@ -18,7 +17,7 @@ Message: [errelemcitperiodical147]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date iso-8601-date="1993-09-08"><month>September</month> <day>9</day>, <year>1993</year></string-date>
+          <string-date iso-8601-date="09-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/pass.xml
@@ -1,11 +1,10 @@
-<?oxygen SCHSchema="err-elem-cit-periodical-14-7.sch"?>
-<!--Context: element-citation[@publication-type='periodical']/string-date/day
-Test: report    if (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]') else .
-Message: [errelemcitperiodical147]
-        The content of <day>, if present, must match the content of the day section of @iso8601date on the 
-        parent stringdate element.
+<?oxygen SCHSchema="err-elem-cit-periodical-7-3.sch"?>
+<!--Context: element-citation[@publication-type='periodical']/string-date
+Test: assert    matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')
+Message: [errelemcitperiodical73]
+        The @iso8601date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
         Reference '' does not meet this requirement as it contains
-        the value <day>='' but <stringdate>/@iso8601date=''.
+        the value ''.
       -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
@@ -18,7 +17,7 @@ Message: [errelemcitperiodical147]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date iso-8601-date="1993-09-08"><month>September</month> <day>9</day>, <year>1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/err-elem-cit-periodical-7-5.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/err-elem-cit-periodical-7-5.sch
@@ -674,18 +674,20 @@
     </xsl:element>
   </xsl:function>
   <pattern id="element-citation-periodical-tests">
-    <rule context="element-citation[@publication-type='periodical']/string-date/year" id="elem-citation-periodical-year">
-      <let name="YYYY" value="substring(normalize-space(.), 1, 4)"/>
-      <let name="current-year" value="year-from-date(current-date())"/>
-      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
-        If the &lt;year&gt; element contains the letter 'a' after the digits, there must be another reference with 
-        the same first author surname with a letter "b" after the year. 
-        Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
+    <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
+      <report test="not(@iso-8601-date) or (substring(normalize-space(@iso-8601-date),1,4) != $YYYY)" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
+        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
+        &lt;year&gt; element.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
+        the value '<value-of select="."/>' and the attribute contains the value 
+        '<value-of select="./@iso-8601-date"/>'.
+      </report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='periodical']/string-date/year" role="error" id="elem-citation-periodical-year-xspec-assert">element-citation[@publication-type='periodical']/string-date/year must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='periodical']/string-date" role="error" id="elem-citation-periodical-string-date-xspec-assert">element-citation[@publication-type='periodical']/string-date must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/fail.xml
@@ -1,11 +1,12 @@
-<?oxygen SCHSchema="err-elem-cit-periodical-14-2.sch"?>
+<?oxygen SCHSchema="err-elem-cit-periodical-7-5.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date
-Test: assert    count(month)=1 and count(year)=1
-Message: [errelemcitperiodical142]
-        The <stringdate> element must include one of each of <month> and <year> 
-        elements.
-        Reference '' does not meet this requirement as it contains
-         <month> elements and  <year> elements.
+Test: report    not(@iso-8601-date) or (substring(normalize-space(@iso-8601-date),1,4) != $YYYY)
+Message: [errelemcitperiodical75]
+        The numeric value of the first 4 digits of the @iso8601date attribute must match the first 4 digits on the 
+        <year> element.
+        Reference '' does not meet this requirement as the element contains
+        the value '' and the attribute contains the value 
+        ''.
       -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
@@ -18,7 +19,7 @@ Message: [errelemcitperiodical142]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date iso-8601-date="1993-09-09"> <day>9</day>, <year>1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1994</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/pass.xml
@@ -1,11 +1,12 @@
-<?oxygen SCHSchema="err-elem-cit-periodical-14-2.sch"?>
+<?oxygen SCHSchema="err-elem-cit-periodical-7-5.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date
-Test: assert    count(month)=1 and count(year)=1
-Message: [errelemcitperiodical142]
-        The <stringdate> element must include one of each of <month> and <year> 
-        elements.
-        Reference '' does not meet this requirement as it contains
-         <month> elements and  <year> elements.
+Test: report    not(@iso-8601-date) or (substring(normalize-space(@iso-8601-date),1,4) != $YYYY)
+Message: [errelemcitperiodical75]
+        The numeric value of the first 4 digits of the @iso8601date attribute must match the first 4 digits on the 
+        <year> element.
+        Reference '' does not meet this requirement as the element contains
+        the value '' and the attribute contains the value 
+        ''.
       -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
@@ -18,7 +19,7 @@ Message: [errelemcitperiodical142]
               <given-names>J</given-names>
             </name>
           </person-group>
-          <string-date iso-8601-date="1993-09-09"> <day>9</day>, <year>1993</year></string-date>
+          <string-date iso-8601-date="1993-09-09"><month>September</month> <day>9</day>, <year>1993</year></string-date>
           <article-title>Obesity affects economic, social status</article-title>
           <source>The Washington Post</source>
           <fpage>A1</fpage>

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-6/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-6/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-7-6.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/year
-Test: assert    not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and (some $y in //element-citation/descendant::year satisfies (normalize-space($y) = concat($YYYY,'b')) and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname) )
+Test: assert    not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and (some $y in //element-citation/descendant::year satisfies (normalize-space($y) = concat($YYYY,'b')) and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1]) )
 Message: [errelemcitperiodical76]
         If the <year> element contains the letter 'a' after the digits, there must be another reference with 
         the same first author surname with a letter "b" after the year. 

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-6/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-6/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-7-6.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/year
-Test: assert    not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and (some $y in //element-citation/descendant::year satisfies (normalize-space($y) = concat($YYYY,'b')) and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname) )
+Test: assert    not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and (some $y in //element-citation/descendant::year satisfies (normalize-space($y) = concat($YYYY,'b')) and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1]) )
 Message: [errelemcitperiodical76]
         If the <year> element contains the letter 'a' after the digits, there must be another reference with 
         the same first author surname with a letter "b" after the year. 

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-7/err-elem-cit-periodical-7-7.sch
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-7/err-elem-cit-periodical-7-7.sch
@@ -677,7 +677,7 @@
     <rule context="element-citation[@publication-type='periodical']/string-date/year" id="elem-citation-periodical-year">
       <let name="YYYY" value="substring(normalize-space(.), 1, 4)"/>
       <let name="current-year" value="year-from-date(current-date())"/>
-      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
+      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
         If the &lt;year&gt; element contains any letter other than 'a' after the digits, there must be another 
         reference with the same first author surname with the preceding letter after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-7/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-7/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-7-7.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/year
-Test: assert    not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or (some $y in //element-citation/descendant::year satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz', 'abcdefghijklmnopqrstuvwxy'))) and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)
+Test: assert    not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or (some $y in //element-citation/descendant::year satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz', 'abcdefghijklmnopqrstuvwxy'))) and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])
 Message: [errelemcitperiodical77]
         If the <year> element contains any letter other than 'a' after the digits, there must be another 
         reference with the same first author surname with the preceding letter after the year. 

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-7/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-7/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-7-7.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/year
-Test: assert    not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or (some $y in //element-citation/descendant::year satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz', 'abcdefghijklmnopqrstuvwxy'))) and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)
+Test: assert    not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or (some $y in //element-citation/descendant::year satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz', 'abcdefghijklmnopqrstuvwxy'))) and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])
 Message: [errelemcitperiodical77]
         If the <year> element contains any letter other than 'a' after the digits, there must be another 
         reference with the same first author surname with the preceding letter after the year. 

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-8/err-elem-cit-periodical-7-8.sch
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-8/err-elem-cit-periodical-7-8.sch
@@ -677,11 +677,11 @@
     <rule context="element-citation[@publication-type='periodical']/string-date/year" id="elem-citation-periodical-year">
       <let name="YYYY" value="substring(normalize-space(.), 1, 4)"/>
       <let name="current-year" value="year-from-date(current-date())"/>
-      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
+      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname[1] = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname[1]" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
         Letter suffixes must be unique for the combination of year and first author surname. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
         contains the &lt;year&gt; '<value-of select="."/>' more than once for the same first author surname
-        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>'.</report>
+        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname[1]"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-8/fail.xml
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-8/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-7-8.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/year
-Test: report    . = preceding::year and ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname
+Test: report    . = preceding::year and ancestor::element-citation/person-group[1]/name[1]/surname[1] = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname[1]
 Message: [errelemcitperiodical78]
         Letter suffixes must be unique for the combination of year and first author surname. 
         Reference '' does not fulfill this requirement as it 

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-8/pass.xml
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-8/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="err-elem-cit-periodical-7-8.sch"?>
 <!--Context: element-citation[@publication-type='periodical']/string-date/year
-Test: report    . = preceding::year and ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname
+Test: report    . = preceding::year and ancestor::element-citation/person-group[1]/name[1]/surname[1] = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname[1]
 Message: [errelemcitperiodical78]
         Letter suffixes must be unique for the combination of year and first author surname. 
         Reference '' does not fulfill this requirement as it 

--- a/test/tests/gen/p-tests/p-test-5/fail.xml
+++ b/test/tests/gen/p-tests/p-test-5/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-test-5.sch"?>
 <!--Context: p
-Test: report    (ancestor::body) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')
+Test: report    (ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')
 Message: p element starts with bolded text    Should it be a header?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/p-tests/p-test-5/p-test-5.sch
+++ b/test/tests/gen/p-tests/p-test-5/p-test-5.sch
@@ -677,7 +677,7 @@
     <rule context="p" id="p-tests">
       <let name="article-type" value="ancestor::article/@article-type"/>
       <let name="text-tokens" value="for $x in tokenize(.,' ') return if (matches($x,'±[Ss][Dd]|±standard|±SEM|±S\.E\.M|±s\.e\.m|\+[Ss][Dd]|\+standard|\+SEM|\+S\.E\.M|\+s\.e\.m')) then $x else ()"/>
-      <report test="(ancestor::body) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/p-tests/p-test-5/pass.xml
+++ b/test/tests/gen/p-tests/p-test-5/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-test-5.sch"?>
 <!--Context: p
-Test: report    (ancestor::body) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')
+Test: report    (ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')
 Message: p element starts with bolded text    Should it be a header?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/page-conformity/online-journal-w-page/fail.xml
+++ b/test/tests/gen/page-conformity/online-journal-w-page/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="online-journal-w-page.sch"?>
 <!--Context: element-citation[(@publication-type='journal') and (fpage or lpage)]
-Test: report    matches(lower-case(source),'plos')
+Test: report    matches(lower-case(source),'plos|^elife$|^mbio$')
 Message:  is a  article, but has a page number, which is incorrect.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/page-conformity/online-journal-w-page/online-journal-w-page.sch
+++ b/test/tests/gen/page-conformity/online-journal-w-page/online-journal-w-page.sch
@@ -676,7 +676,7 @@
   <pattern id="house-style">
     <rule context="element-citation[(@publication-type='journal') and (fpage or lpage)]" id="page-conformity">
       <let name="cite" value="e:citation-format1(year)"/>
-      <report test="matches(lower-case(source),'plos')" role="error" id="online-journal-w-page">
+      <report test="matches(lower-case(source),'plos|^elife$|^mbio$')" role="error" id="online-journal-w-page">
         <value-of select="$cite"/> is a <value-of select="source"/> article, but has a page number, which is incorrect.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/page-conformity/online-journal-w-page/pass.xml
+++ b/test/tests/gen/page-conformity/online-journal-w-page/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="online-journal-w-page.sch"?>
 <!--Context: element-citation[(@publication-type='journal') and (fpage or lpage)]
-Test: report    matches(lower-case(source),'plos')
+Test: report    matches(lower-case(source),'plos|^elife$|^mbio$')
 Message:  is a  article, but has a page number, which is incorrect.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1526,7 +1526,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4172,12 +4172,6 @@
         Reference '<value-of select="ancestor::ref/@id"/>' does not.
       </assert>
       
-      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
-        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value '<value-of select="@iso-8601-date"/>'.
-      </assert>
-      
       <assert test="matches(normalize-space(.),'(^\d{4}[a-z]?)')" role="error" id="err-elem-cit-periodical-7-4-1">[err-elem-cit-periodical-7-4-1]
         The &lt;year&gt; element in a reference must contain 4 digits, possibly followed by one (but not more) lower-case letter.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
@@ -4190,29 +4184,21 @@
         the value '<value-of select="."/>'.
       </assert>
       
-      <assert test="not(./@iso-8601-date) or substring(normalize-space(./@iso-8601-date),1,4) = $YYYY" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
-        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
-        &lt;year&gt; element.
-        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
-        the value '<value-of select="."/>' and the attribute contains the value 
-        '<value-of select="./@iso-8601-date"/>'.
-      </assert>
-      
-      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
+      <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and        (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,'b'))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       )" role="error" id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
         If the &lt;year&gt; element contains the letter 'a' after the digits, there must be another reference with 
         the same first author surname with a letter "b" after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname = $y/ancestor::element-citation/person-group[1]/name[1]/surname)       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
+      <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or       (some $y in //element-citation/descendant::year        satisfies (normalize-space($y) = concat($YYYY,translate(substring(normalize-space(.),5,1),'bcdefghijklmnopqrstuvwxyz',       'abcdefghijklmnopqrstuvwxy')))        and ancestor::element-citation/person-group[1]/name[1]/surname[1] = $y/ancestor::element-citation/person-group[1]/name[1]/surname[1])       " role="error" id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
         If the &lt;year&gt; element contains any letter other than 'a' after the digits, there must be another 
         reference with the same first author surname with the preceding letter after the year. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
       
-      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
+      <report test=". = preceding::year and        ancestor::element-citation/person-group[1]/name[1]/surname[1] = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname[1]" role="error" id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
         Letter suffixes must be unique for the combination of year and first author surname. 
         Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
         contains the &lt;year&gt; '<value-of select="."/>' more than once for the same first author surname
-        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>'.</report>
+        '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname[1]"/>'.</report>
       
     </rule>
   </pattern>
@@ -4248,6 +4234,7 @@
   </pattern>
   <pattern id="elem-citation-periodical-string-date-pattern">
     <rule context="element-citation[@publication-type='periodical']/string-date" id="elem-citation-periodical-string-date">
+      <let name="YYYY" value="substring(normalize-space(year[1]), 1, 4)"/>
       
       <assert test="count(month)=1 and count(year)=1" role="error" id="err-elem-cit-periodical-14-2">[err-elem-cit-periodical-14-2]
         The &lt;string-date&gt; element must include one of each of &lt;month&gt; and &lt;year&gt; 
@@ -4266,6 +4253,20 @@
         The format of the element content must match &lt;month&gt;, space, &lt;day&gt;, comma, &lt;year&gt;, or &lt;month&gt;, comma, &lt;year&gt;.
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="."/>.</assert>    
       
+      <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')" role="error" id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
+        The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+        the value '<value-of select="@iso-8601-date"/>'.
+      </assert>
+      
+      <report test="not(@iso-8601-date) or (substring(normalize-space(@iso-8601-date),1,4) != $YYYY)" role="error" id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
+        The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
+        &lt;year&gt; element.
+        Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
+        the value '<value-of select="."/>' and the attribute contains the value 
+        '<value-of select="./@iso-8601-date"/>'.
+      </report>
+      
     </rule>
   </pattern>
   <pattern id="elem-citation-periodical-month-pattern">
@@ -4277,11 +4278,11 @@
         the value  &lt;month&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[MNn]')         else ." role="error" id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
         The content of &lt;month&gt; must match the content of the month section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;month&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;month&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -4295,11 +4296,11 @@
         the value  &lt;day&gt;='<value-of select="."/>'.
       </assert>
       
-      <report test="if  (matches(normalize-space(../year/@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../year/@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
+      <report test="if  (matches(normalize-space(../@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')) then .!=format-date(xs:date(../@iso-8601-date), '[D]')                     else ." role="error" id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
         The content of &lt;day&gt;, if present, must match the content of the day section of @iso-8601-date on the 
-        sibling year element.
+        parent string-date element.
         Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-        the value &lt;day&gt;='<value-of select="."/>' but &lt;year&gt;/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
+        the value &lt;day&gt;='<value-of select="."/>' but &lt;string-date&gt;/@iso-8601-date='<value-of select="../@iso-8601-date"/>'.
       </report>
       
     </rule>
@@ -5654,7 +5655,7 @@
     <rule context="element-citation[(@publication-type='journal') and (fpage or lpage)]" id="page-conformity">
       <let name="cite" value="e:citation-format1(year)"/>
       
-      <report test="matches(lower-case(source),'plos')" role="error" id="online-journal-w-page">
+      <report test="matches(lower-case(source),'plos|^elife$|^mbio$')" role="error" id="online-journal-w-page">
         <value-of select="$cite"/> is a <value-of select="source"/> article, but has a page number, which is incorrect.</report>
       
     </rule>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -7397,16 +7397,6 @@
         <x:expect-assert id="err-elem-cit-periodical-7-2" role="error"/>
         <x:expect-not-assert id="elem-citation-periodical-year-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="err-elem-cit-periodical-7-3-pass">
-        <x:context href="../tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-3/pass.xml"/>
-        <x:expect-not-assert id="err-elem-cit-periodical-7-3" role="error"/>
-        <x:expect-not-assert id="elem-citation-periodical-year-xspec-assert" role="error"/>
-      </x:scenario>
-      <x:scenario label="err-elem-cit-periodical-7-3-fail">
-        <x:context href="../tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-3/fail.xml"/>
-        <x:expect-assert id="err-elem-cit-periodical-7-3" role="error"/>
-        <x:expect-not-assert id="elem-citation-periodical-year-xspec-assert" role="error"/>
-      </x:scenario>
       <x:scenario label="err-elem-cit-periodical-7-4-1-pass">
         <x:context href="../tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-4-1/pass.xml"/>
         <x:expect-not-assert id="err-elem-cit-periodical-7-4-1" role="error"/>
@@ -7425,16 +7415,6 @@
       <x:scenario label="err-elem-cit-periodical-7-4-2-fail">
         <x:context href="../tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-4-2/fail.xml"/>
         <x:expect-assert id="err-elem-cit-periodical-7-4-2" role="warning"/>
-        <x:expect-not-assert id="elem-citation-periodical-year-xspec-assert" role="error"/>
-      </x:scenario>
-      <x:scenario label="err-elem-cit-periodical-7-5-pass">
-        <x:context href="../tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-5/pass.xml"/>
-        <x:expect-not-assert id="err-elem-cit-periodical-7-5" role="error"/>
-        <x:expect-not-assert id="elem-citation-periodical-year-xspec-assert" role="error"/>
-      </x:scenario>
-      <x:scenario label="err-elem-cit-periodical-7-5-fail">
-        <x:context href="../tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-5/fail.xml"/>
-        <x:expect-assert id="err-elem-cit-periodical-7-5" role="error"/>
         <x:expect-not-assert id="elem-citation-periodical-year-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="err-elem-cit-periodical-7-6-pass">
@@ -7533,6 +7513,26 @@
       <x:scenario label="err-elem-cit-periodical-14-8-fail">
         <x:context href="../tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/fail.xml"/>
         <x:expect-assert id="err-elem-cit-periodical-14-8" role="error"/>
+        <x:expect-not-assert id="elem-citation-periodical-string-date-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="err-elem-cit-periodical-7-3-pass">
+        <x:context href="../tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/pass.xml"/>
+        <x:expect-not-assert id="err-elem-cit-periodical-7-3" role="error"/>
+        <x:expect-not-assert id="elem-citation-periodical-string-date-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="err-elem-cit-periodical-7-3-fail">
+        <x:context href="../tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/fail.xml"/>
+        <x:expect-assert id="err-elem-cit-periodical-7-3" role="error"/>
+        <x:expect-not-assert id="elem-citation-periodical-string-date-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="err-elem-cit-periodical-7-5-pass">
+        <x:context href="../tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/pass.xml"/>
+        <x:expect-not-report id="err-elem-cit-periodical-7-5" role="error"/>
+        <x:expect-not-assert id="elem-citation-periodical-string-date-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="err-elem-cit-periodical-7-5-fail">
+        <x:context href="../tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/fail.xml"/>
+        <x:expect-report id="err-elem-cit-periodical-7-5" role="error"/>
         <x:expect-not-assert id="elem-citation-periodical-string-date-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>


### PR DESCRIPTION
- Exclude `sub-article`s from `p-test-5`
- Include eLife and mBio in `online-journal-w-page`
- move `iso-date` attribute mandate from `year` to `string-date` in periodicals
- Specify first element in certain tests to avoid fatal errors when more than 1 is erroneously included.