### PR TITLE
Fixes and improvements

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -5895,7 +5895,7 @@
       
       <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
       
-      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='PDB'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'PDB', which must be incorrect.</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
       

--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1801,9 +1801,9 @@
       
       <assert test="mml:math" role="error" id="inline-formula-test-1">inline-formula must contain an mml:math element.</assert>
       
-      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$') and not(matches(.,'^\s+'))" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
+      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$')" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
-      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]') and not(matches(.,'\s+$'))" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
+      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]')" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
       
       <assert test="parent::p or parent::td or parent::th or parent::title" role="error" id="inline-formula-test-4">
         <name/> must be a child of p, td,  th or title. The formula containing <value-of select="."/> is a child of <value-of select="parent::*/local-name()"/>
@@ -4505,6 +4505,17 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-asbtract-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/abstract" id="insight-asbtract-tests">
+     <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value"/>
+     <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value/*)"/>
+     
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4807,11 +4818,11 @@
       
       <report test="matches($post-text,'^ of [\p{Lu}][\p{Ll}]+[\-]?[\p{Ll}]? et al[\.]?')" role="warning" id="fig-xref-test-9">Is this figure citation a reference to a figure from other content (and as such should be captured instead as plain text)? - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="error" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="warning" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="error" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="warning" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="error" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="warning" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
       
       <report test="matches($post-text,'^[\s]?[Ss]upplement|^[\s]?[Ff]igure [Ss]upplement|^[\s]?[Ss]ource|^[\s]?[Vv]ideo')" role="warning" id="fig-xref-test-13">Figure citation is followed by text which suggests it could be an incomplete citation - <value-of select="concat(.,$post-text)"/>'. Is this OK?</report>
     </rule>
@@ -5720,18 +5731,195 @@
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
+      
+    </rule>
+  </pattern>
+  <pattern id="data-ref-tests-pattern">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/geo') and not(source[1]='NCBI Gene Expression Omnibus')" role="warning" id="data-geo-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/geo' type link, but the database name is not 'NCBI Gene Expression Omnibus' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/nuccore') and not(source[1]='NCBI GenBank') and not(source[1]='NCBI Nucleotide')" role="warning" id="data-nucleotide-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/nuccore' type link, but the database name is not 'NCBI Nucleotide' or 'NCBI GenBank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/bioproject') and not(source[1]='NCBI BioProject')" role="warning" id="data-bioproject-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/bioproject' type link, but the database name is not 'NCBI BioProject' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/gap') and not(source[1]='NCBI dbGaP')" role="warning" id="data-dbgap-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/gap' type link, but the database name is not 'NCBI dbGaP' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/popset') and not(source[1]='NCBI PopSet')" role="warning" id="data-popset-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/popset' type link, but the database name is not 'NCBI PopSet' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/sra') and not(source[1]='NCBI Sequence Read Archive')" role="warning" id="data-sra-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/sra' type link, but the database name is not 'NCBI Sequence Read Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/biosample') and not(source[1]='NCBI BioSample')" role="warning" id="data-biosample-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/biosample' type link, but the database name is not 'NCBI BioSample' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/assembly') and not(source[1]='NCBI Assembly')" role="warning" id="data-assembly-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/assembly' type link, but the database name is not 'NCBI Assembly' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-1">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked as an accession number, which is likely incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-2">Data reference with the database source '<value-of select="source[1]"/>' is not marked as an accession number, which is very likely incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-3">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-4">Data reference with the database source '<value-of select="source[1]"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (source[1]!='Dryad Digital Repository')" role="warning" id="data-dryad-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5061/dryad' but the database name is not 'Dryad Digital Repository' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad')) and (source[1]='Dryad Digital Repository')" role="warning" id="data-dryad-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5061/dryad', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (pub-id[1][@assigning-authority!='Dryad' or not(@assigning-authority)])" role="warning" id="data-dryad-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Dryad type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Dryad, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and not(source[1]='RCSB Protein Data Bank')" role="warning" id="data-rcsbpbd-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but the database name is not 'RCSB Protein Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and  pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]" role="warning" id="data-rcsbpbd-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but is not marked with PBD as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-arrayexpress-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-arrayexpress-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ArrayExpress 'www.ebi.ac.uk/arrayexpress' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and not(source[1]='PRIDE')" role="warning" id="data-pride-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but the database name is not 'PRIDE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-pride-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-pride-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PRIDE 'www.ebi.ac.uk/pride' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (source[1]!='Zenodo')" role="warning" id="data-zenodo-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5281/zenodo' but the database name is not 'Zenodo' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo')) and (source[1]='Zenodo')" role="warning" id="data-zenodo-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5281/zenodo', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (pub-id[1][@assigning-authority!='Zenodo'  or not(@assigning-authority)])" role="warning" id="data-zenodo-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Zenodo type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Zenodo, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and not(source[1]='Open Science Framework')" role="warning" id="data-osf-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (pub-id[1][@assigning-authority!='Open Science Framework'  or not(@assigning-authority)])" role="warning" id="data-osf-test-5">Data reference with the title '<value-of select="data-title[1]"/>' has a OSF type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Open Science Framework, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (source[1]!='figshare')" role="warning" id="data-figshare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6084/m9.figshare' but the database name is not 'figshare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare')) and (source[1]='figshare')" role="warning" id="data-figshare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6084/m9.figshare' - is this correct? Figshare sometimes host for other organisations (example http://doi.org/10.1184/R1/9963566), so this may be fine.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (pub-id[1][@assigning-authority!='figshare'  or not(@assigning-authority)])" role="warning" id="data-figshare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a figshare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not figshare, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and not(source[1]='ProteomeXchange')" role="warning" id="data-proteomexchange-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but the database name is not 'ProteomeXchange' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-proteomexchange-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but is not marked with 'other' as its assigning authority, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-proteomexchange-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ProteomeXchange 'http://proteomecentral.proteomexchange.org/' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (source[1]!='OpenNeuro')" role="warning" id="data-openneuro-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.18112/openneuro' but the database name is not 'OpenNeuro' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro')) and not(contains(pub-id[1]/@xlink:href,'openneuro.org/datasets')) and (source[1]='OpenNeuro')" role="warning" id="data-openneuro-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.18112/openneuro' or 'openneuro.org/datasets' type link, which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-openneuro-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a OpenNeuro type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (source[1]!='Synapse')" role="warning" id="data-synapse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7303/syn' but the database name is not 'Synapse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn')) and (source[1]='Synapse')" role="warning" id="data-synapse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7303/syn', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-synapse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Synapse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and not(source[1]='Biological Magnetic Resonance Data Bank')" role="warning" id="data-bmrb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but the database name is not 'Biological Magnetic Resonance Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-bmrb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-bmrb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a BMRB 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and not(source[1]='Morph D Base')" role="warning" id="data-morphdbase-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but the database name is not 'Morph D Base' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-morphdbase-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-morphdbase-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Morph D Base 'www.morphdbase.de' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (source[1]!='Mendeley Data')" role="warning" id="data-mendeley-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17632' but the database name is not 'Mendeley Data' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17632')) and (source[1]='Mendeley Data')" role="warning" id="data-mendeley-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17632', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-mendeley-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Mendeley Data type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (source[1]!='Edinburgh DataShare')" role="warning" id="data-edatashare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7488' but the database name is not 'Edinburgh DataShare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7488')) and (source[1]='Edinburgh DataShare')" role="warning" id="data-edatashare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7488', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (pub-id[1][@assigning-authority!='Edinburgh University'  or not(@assigning-authority)])" role="warning" id="data-edatashare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Edinburgh DataShare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'Edinburgh University', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (source[1]!='ETH Library research collection')" role="warning" id="data-eth-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.3929' but the database name is not 'ETH Library research collection' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.3929')) and (source[1]='ETH Library research collection')" role="warning" id="data-eth-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.3929', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-eth-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ETH Library research collection type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (source[1]!='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6080' but the database name is not 'Collaborative Research in Computational Neuroscience' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6080')) and (source[1]='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6080', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-crcns-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a CRCNS type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (source[1]!='MorphoSource')" role="warning" id="data-morphosource-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17602' but the database name is not 'MorphoSource' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17602')) and (source[1]='MorphoSource')" role="warning" id="data-morphosource-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17602', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-morphosource-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a MorphoSource type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and not(source[1]='NeuroVault')" role="warning" id="data-neurovault-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but the database name is not 'NeuroVault' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID')) and (source[1]='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.15785/SBGRID', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-sbgdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a SBGrid Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (source[1]!='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7910' but the database name is not 'Harvard Dataverse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7910')) and (source[1]='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7910', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-harvard-dataverse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Harvard Dataverse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and not(source[1]='ENCODE')" role="warning" id="data-encode-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but the database name is not 'ENCODE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-emdr-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdr-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an EMDataResource 'www.emdataresource.org' type link, but is not marked as an accession type link.</report>
       
     </rule>
   </pattern>
@@ -5915,9 +6103,9 @@
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="italic-house-style-pattern">
@@ -6008,14 +6196,6 @@
       <report test="matches(.,'[Ii]n [Oo]vo')" role="warning" id="final-in-ovo-italic-test">
         <name/> element contains 'In Ovo' - this should not be in italics (eLife house style).</report>
       
-    </rule>
-  </pattern>
-  <pattern id="list-house-style-pattern">
-    <rule context="list[@list-type]" id="list-house-style">
-      <let name="usual-types" value="('bullet','simple','order')"/>
-      
-      <assert test="@list-type = $usual-types" role="warning" id="list-type-house-style-test">
-        <name/> element is a list-type='<value-of select="@list-type"/>'. According to house style, bullets, numbers or no indicators should be used. Usual values - ('bullet','simple','order').</assert>
     </rule>
   </pattern>
   <pattern id="pubmed-link-pattern">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -5901,7 +5901,7 @@
       
       <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
       
-      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='PDB'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'PDB', which must be incorrect.</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
       

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1807,9 +1807,9 @@
       
       <assert test="mml:math" role="error" id="inline-formula-test-1">inline-formula must contain an mml:math element.</assert>
       
-      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$') and not(matches(.,'^\s+'))" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
+      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$')" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
-      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]') and not(matches(.,'\s+$'))" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
+      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]')" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
       
       <assert test="parent::p or parent::td or parent::th or parent::title" role="error" id="inline-formula-test-4">
         <name/> must be a child of p, td,  th or title. The formula containing <value-of select="."/> is a child of <value-of select="parent::*/local-name()"/>
@@ -4511,6 +4511,17 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-asbtract-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/abstract" id="insight-asbtract-tests">
+     <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value"/>
+     <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value/*)"/>
+     
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4813,11 +4824,11 @@
       
       <report test="matches($post-text,'^ of [\p{Lu}][\p{Ll}]+[\-]?[\p{Ll}]? et al[\.]?')" role="warning" id="fig-xref-test-9">Is this figure citation a reference to a figure from other content (and as such should be captured instead as plain text)? - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="error" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="warning" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="error" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="warning" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="error" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="warning" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
       
       <report test="matches($post-text,'^[\s]?[Ss]upplement|^[\s]?[Ff]igure [Ss]upplement|^[\s]?[Ss]ource|^[\s]?[Vv]ideo')" role="warning" id="fig-xref-test-13">Figure citation is followed by text which suggests it could be an incomplete citation - <value-of select="concat(.,$post-text)"/>'. Is this OK?</report>
     </rule>
@@ -5726,18 +5737,195 @@
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
+      
+    </rule>
+  </pattern>
+  <pattern id="data-ref-tests-pattern">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/geo') and not(source[1]='NCBI Gene Expression Omnibus')" role="warning" id="data-geo-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/geo' type link, but the database name is not 'NCBI Gene Expression Omnibus' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/nuccore') and not(source[1]='NCBI GenBank') and not(source[1]='NCBI Nucleotide')" role="warning" id="data-nucleotide-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/nuccore' type link, but the database name is not 'NCBI Nucleotide' or 'NCBI GenBank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/bioproject') and not(source[1]='NCBI BioProject')" role="warning" id="data-bioproject-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/bioproject' type link, but the database name is not 'NCBI BioProject' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/gap') and not(source[1]='NCBI dbGaP')" role="warning" id="data-dbgap-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/gap' type link, but the database name is not 'NCBI dbGaP' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/popset') and not(source[1]='NCBI PopSet')" role="warning" id="data-popset-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/popset' type link, but the database name is not 'NCBI PopSet' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/sra') and not(source[1]='NCBI Sequence Read Archive')" role="warning" id="data-sra-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/sra' type link, but the database name is not 'NCBI Sequence Read Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/biosample') and not(source[1]='NCBI BioSample')" role="warning" id="data-biosample-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/biosample' type link, but the database name is not 'NCBI BioSample' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/assembly') and not(source[1]='NCBI Assembly')" role="warning" id="data-assembly-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/assembly' type link, but the database name is not 'NCBI Assembly' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-1">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked as an accession number, which is likely incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-2">Data reference with the database source '<value-of select="source[1]"/>' is not marked as an accession number, which is very likely incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-3">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-4">Data reference with the database source '<value-of select="source[1]"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (source[1]!='Dryad Digital Repository')" role="warning" id="data-dryad-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5061/dryad' but the database name is not 'Dryad Digital Repository' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad')) and (source[1]='Dryad Digital Repository')" role="warning" id="data-dryad-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5061/dryad', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (pub-id[1][@assigning-authority!='Dryad' or not(@assigning-authority)])" role="warning" id="data-dryad-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Dryad type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Dryad, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and not(source[1]='RCSB Protein Data Bank')" role="warning" id="data-rcsbpbd-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but the database name is not 'RCSB Protein Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and  pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]" role="warning" id="data-rcsbpbd-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but is not marked with PBD as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-arrayexpress-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-arrayexpress-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ArrayExpress 'www.ebi.ac.uk/arrayexpress' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and not(source[1]='PRIDE')" role="warning" id="data-pride-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but the database name is not 'PRIDE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-pride-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-pride-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PRIDE 'www.ebi.ac.uk/pride' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (source[1]!='Zenodo')" role="warning" id="data-zenodo-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5281/zenodo' but the database name is not 'Zenodo' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo')) and (source[1]='Zenodo')" role="warning" id="data-zenodo-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5281/zenodo', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (pub-id[1][@assigning-authority!='Zenodo'  or not(@assigning-authority)])" role="warning" id="data-zenodo-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Zenodo type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Zenodo, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and not(source[1]='Open Science Framework')" role="warning" id="data-osf-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (pub-id[1][@assigning-authority!='Open Science Framework'  or not(@assigning-authority)])" role="warning" id="data-osf-test-5">Data reference with the title '<value-of select="data-title[1]"/>' has a OSF type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Open Science Framework, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (source[1]!='figshare')" role="warning" id="data-figshare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6084/m9.figshare' but the database name is not 'figshare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare')) and (source[1]='figshare')" role="warning" id="data-figshare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6084/m9.figshare' - is this correct? Figshare sometimes host for other organisations (example http://doi.org/10.1184/R1/9963566), so this may be fine.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (pub-id[1][@assigning-authority!='figshare'  or not(@assigning-authority)])" role="warning" id="data-figshare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a figshare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not figshare, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and not(source[1]='ProteomeXchange')" role="warning" id="data-proteomexchange-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but the database name is not 'ProteomeXchange' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-proteomexchange-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but is not marked with 'other' as its assigning authority, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-proteomexchange-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ProteomeXchange 'http://proteomecentral.proteomexchange.org/' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (source[1]!='OpenNeuro')" role="warning" id="data-openneuro-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.18112/openneuro' but the database name is not 'OpenNeuro' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro')) and not(contains(pub-id[1]/@xlink:href,'openneuro.org/datasets')) and (source[1]='OpenNeuro')" role="warning" id="data-openneuro-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.18112/openneuro' or 'openneuro.org/datasets' type link, which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-openneuro-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a OpenNeuro type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (source[1]!='Synapse')" role="warning" id="data-synapse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7303/syn' but the database name is not 'Synapse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn')) and (source[1]='Synapse')" role="warning" id="data-synapse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7303/syn', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-synapse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Synapse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and not(source[1]='Biological Magnetic Resonance Data Bank')" role="warning" id="data-bmrb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but the database name is not 'Biological Magnetic Resonance Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-bmrb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-bmrb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a BMRB 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and not(source[1]='Morph D Base')" role="warning" id="data-morphdbase-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but the database name is not 'Morph D Base' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-morphdbase-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-morphdbase-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Morph D Base 'www.morphdbase.de' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (source[1]!='Mendeley Data')" role="warning" id="data-mendeley-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17632' but the database name is not 'Mendeley Data' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17632')) and (source[1]='Mendeley Data')" role="warning" id="data-mendeley-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17632', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-mendeley-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Mendeley Data type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (source[1]!='Edinburgh DataShare')" role="warning" id="data-edatashare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7488' but the database name is not 'Edinburgh DataShare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7488')) and (source[1]='Edinburgh DataShare')" role="warning" id="data-edatashare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7488', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (pub-id[1][@assigning-authority!='Edinburgh University'  or not(@assigning-authority)])" role="warning" id="data-edatashare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Edinburgh DataShare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'Edinburgh University', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (source[1]!='ETH Library research collection')" role="warning" id="data-eth-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.3929' but the database name is not 'ETH Library research collection' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.3929')) and (source[1]='ETH Library research collection')" role="warning" id="data-eth-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.3929', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-eth-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ETH Library research collection type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (source[1]!='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6080' but the database name is not 'Collaborative Research in Computational Neuroscience' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6080')) and (source[1]='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6080', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-crcns-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a CRCNS type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (source[1]!='MorphoSource')" role="warning" id="data-morphosource-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17602' but the database name is not 'MorphoSource' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17602')) and (source[1]='MorphoSource')" role="warning" id="data-morphosource-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17602', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-morphosource-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a MorphoSource type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and not(source[1]='NeuroVault')" role="warning" id="data-neurovault-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but the database name is not 'NeuroVault' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID')) and (source[1]='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.15785/SBGRID', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-sbgdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a SBGrid Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (source[1]!='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7910' but the database name is not 'Harvard Dataverse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7910')) and (source[1]='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7910', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-harvard-dataverse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Harvard Dataverse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and not(source[1]='ENCODE')" role="warning" id="data-encode-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but the database name is not 'ENCODE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-emdr-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdr-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an EMDataResource 'www.emdataresource.org' type link, but is not marked as an accession type link.</report>
       
     </rule>
   </pattern>
@@ -5921,9 +6109,9 @@
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="italic-house-style-pattern">
@@ -6014,14 +6202,6 @@
       <report test="matches(.,'[Ii]n [Oo]vo')" role="warning" id="final-in-ovo-italic-test">
         <name/> element contains 'In Ovo' - this should not be in italics (eLife house style).</report>
       
-    </rule>
-  </pattern>
-  <pattern id="list-house-style-pattern">
-    <rule context="list[@list-type]" id="list-house-style">
-      <let name="usual-types" value="('bullet','simple','order')"/>
-      
-      <assert test="@list-type = $usual-types" role="warning" id="list-type-house-style-test">
-        <name/> element is a list-type='<value-of select="@list-type"/>'. According to house style, bullets, numbers or no indicators should be used. Usual values - ('bullet','simple','order').</assert>
     </rule>
   </pattern>
   <pattern id="pubmed-link-pattern">

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -5896,7 +5896,7 @@
       
       <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
       
-      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='PDB'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'PDB', which must be incorrect.</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
       

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1802,9 +1802,9 @@
       
       <assert test="mml:math" role="error" id="inline-formula-test-1">inline-formula must contain an mml:math element.</assert>
       
-      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$') and not(matches(.,'^\s+'))" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
+      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$')" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
-      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]') and not(matches(.,'\s+$'))" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
+      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]')" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
       
       <assert test="parent::p or parent::td or parent::th or parent::title" role="error" id="inline-formula-test-4">
         <name/> must be a child of p, td,  th or title. The formula containing <value-of select="."/> is a child of <value-of select="parent::*/local-name()"/>
@@ -4506,6 +4506,17 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-asbtract-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/abstract" id="insight-asbtract-tests">
+     <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value"/>
+     <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value/*)"/>
+     
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4808,11 +4819,11 @@
       
       <report test="matches($post-text,'^ of [\p{Lu}][\p{Ll}]+[\-]?[\p{Ll}]? et al[\.]?')" role="warning" id="fig-xref-test-9">Is this figure citation a reference to a figure from other content (and as such should be captured instead as plain text)? - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="error" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="warning" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="error" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="warning" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="error" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="warning" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
       
       <report test="matches($post-text,'^[\s]?[Ss]upplement|^[\s]?[Ff]igure [Ss]upplement|^[\s]?[Ss]ource|^[\s]?[Vv]ideo')" role="warning" id="fig-xref-test-13">Figure citation is followed by text which suggests it could be an incomplete citation - <value-of select="concat(.,$post-text)"/>'. Is this OK?</report>
     </rule>
@@ -5721,18 +5732,195 @@
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
+      
+    </rule>
+  </pattern>
+  <pattern id="data-ref-tests-pattern">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/geo') and not(source[1]='NCBI Gene Expression Omnibus')" role="warning" id="data-geo-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/geo' type link, but the database name is not 'NCBI Gene Expression Omnibus' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/nuccore') and not(source[1]='NCBI GenBank') and not(source[1]='NCBI Nucleotide')" role="warning" id="data-nucleotide-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/nuccore' type link, but the database name is not 'NCBI Nucleotide' or 'NCBI GenBank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/bioproject') and not(source[1]='NCBI BioProject')" role="warning" id="data-bioproject-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/bioproject' type link, but the database name is not 'NCBI BioProject' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/gap') and not(source[1]='NCBI dbGaP')" role="warning" id="data-dbgap-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/gap' type link, but the database name is not 'NCBI dbGaP' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/popset') and not(source[1]='NCBI PopSet')" role="warning" id="data-popset-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/popset' type link, but the database name is not 'NCBI PopSet' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/sra') and not(source[1]='NCBI Sequence Read Archive')" role="warning" id="data-sra-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/sra' type link, but the database name is not 'NCBI Sequence Read Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/biosample') and not(source[1]='NCBI BioSample')" role="warning" id="data-biosample-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/biosample' type link, but the database name is not 'NCBI BioSample' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/assembly') and not(source[1]='NCBI Assembly')" role="warning" id="data-assembly-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/assembly' type link, but the database name is not 'NCBI Assembly' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-1">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked as an accession number, which is likely incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-2">Data reference with the database source '<value-of select="source[1]"/>' is not marked as an accession number, which is very likely incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-3">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-4">Data reference with the database source '<value-of select="source[1]"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (source[1]!='Dryad Digital Repository')" role="warning" id="data-dryad-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5061/dryad' but the database name is not 'Dryad Digital Repository' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad')) and (source[1]='Dryad Digital Repository')" role="warning" id="data-dryad-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5061/dryad', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (pub-id[1][@assigning-authority!='Dryad' or not(@assigning-authority)])" role="warning" id="data-dryad-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Dryad type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Dryad, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and not(source[1]='RCSB Protein Data Bank')" role="warning" id="data-rcsbpbd-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but the database name is not 'RCSB Protein Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and  pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]" role="warning" id="data-rcsbpbd-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but is not marked with PBD as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-arrayexpress-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-arrayexpress-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ArrayExpress 'www.ebi.ac.uk/arrayexpress' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and not(source[1]='PRIDE')" role="warning" id="data-pride-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but the database name is not 'PRIDE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-pride-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-pride-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PRIDE 'www.ebi.ac.uk/pride' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (source[1]!='Zenodo')" role="warning" id="data-zenodo-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5281/zenodo' but the database name is not 'Zenodo' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo')) and (source[1]='Zenodo')" role="warning" id="data-zenodo-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5281/zenodo', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (pub-id[1][@assigning-authority!='Zenodo'  or not(@assigning-authority)])" role="warning" id="data-zenodo-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Zenodo type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Zenodo, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and not(source[1]='Open Science Framework')" role="warning" id="data-osf-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (pub-id[1][@assigning-authority!='Open Science Framework'  or not(@assigning-authority)])" role="warning" id="data-osf-test-5">Data reference with the title '<value-of select="data-title[1]"/>' has a OSF type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Open Science Framework, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (source[1]!='figshare')" role="warning" id="data-figshare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6084/m9.figshare' but the database name is not 'figshare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare')) and (source[1]='figshare')" role="warning" id="data-figshare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6084/m9.figshare' - is this correct? Figshare sometimes host for other organisations (example http://doi.org/10.1184/R1/9963566), so this may be fine.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (pub-id[1][@assigning-authority!='figshare'  or not(@assigning-authority)])" role="warning" id="data-figshare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a figshare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not figshare, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and not(source[1]='ProteomeXchange')" role="warning" id="data-proteomexchange-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but the database name is not 'ProteomeXchange' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-proteomexchange-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but is not marked with 'other' as its assigning authority, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-proteomexchange-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ProteomeXchange 'http://proteomecentral.proteomexchange.org/' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (source[1]!='OpenNeuro')" role="warning" id="data-openneuro-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.18112/openneuro' but the database name is not 'OpenNeuro' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro')) and not(contains(pub-id[1]/@xlink:href,'openneuro.org/datasets')) and (source[1]='OpenNeuro')" role="warning" id="data-openneuro-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.18112/openneuro' or 'openneuro.org/datasets' type link, which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-openneuro-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a OpenNeuro type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (source[1]!='Synapse')" role="warning" id="data-synapse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7303/syn' but the database name is not 'Synapse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn')) and (source[1]='Synapse')" role="warning" id="data-synapse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7303/syn', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-synapse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Synapse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and not(source[1]='Biological Magnetic Resonance Data Bank')" role="warning" id="data-bmrb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but the database name is not 'Biological Magnetic Resonance Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-bmrb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-bmrb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a BMRB 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and not(source[1]='Morph D Base')" role="warning" id="data-morphdbase-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but the database name is not 'Morph D Base' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-morphdbase-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-morphdbase-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Morph D Base 'www.morphdbase.de' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (source[1]!='Mendeley Data')" role="warning" id="data-mendeley-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17632' but the database name is not 'Mendeley Data' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17632')) and (source[1]='Mendeley Data')" role="warning" id="data-mendeley-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17632', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-mendeley-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Mendeley Data type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (source[1]!='Edinburgh DataShare')" role="warning" id="data-edatashare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7488' but the database name is not 'Edinburgh DataShare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7488')) and (source[1]='Edinburgh DataShare')" role="warning" id="data-edatashare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7488', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (pub-id[1][@assigning-authority!='Edinburgh University'  or not(@assigning-authority)])" role="warning" id="data-edatashare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Edinburgh DataShare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'Edinburgh University', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (source[1]!='ETH Library research collection')" role="warning" id="data-eth-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.3929' but the database name is not 'ETH Library research collection' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.3929')) and (source[1]='ETH Library research collection')" role="warning" id="data-eth-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.3929', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-eth-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ETH Library research collection type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (source[1]!='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6080' but the database name is not 'Collaborative Research in Computational Neuroscience' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6080')) and (source[1]='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6080', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-crcns-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a CRCNS type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (source[1]!='MorphoSource')" role="warning" id="data-morphosource-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17602' but the database name is not 'MorphoSource' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17602')) and (source[1]='MorphoSource')" role="warning" id="data-morphosource-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17602', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-morphosource-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a MorphoSource type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and not(source[1]='NeuroVault')" role="warning" id="data-neurovault-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but the database name is not 'NeuroVault' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID')) and (source[1]='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.15785/SBGRID', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-sbgdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a SBGrid Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (source[1]!='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7910' but the database name is not 'Harvard Dataverse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7910')) and (source[1]='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7910', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-harvard-dataverse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Harvard Dataverse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and not(source[1]='ENCODE')" role="warning" id="data-encode-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but the database name is not 'ENCODE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-emdr-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdr-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an EMDataResource 'www.emdataresource.org' type link, but is not marked as an accession type link.</report>
       
     </rule>
   </pattern>
@@ -5916,9 +6104,9 @@
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="italic-house-style-pattern">
@@ -6009,14 +6197,6 @@
       
       
       
-    </rule>
-  </pattern>
-  <pattern id="list-house-style-pattern">
-    <rule context="list[@list-type]" id="list-house-style">
-      <let name="usual-types" value="('bullet','simple','order')"/>
-      
-      <assert test="@list-type = $usual-types" role="warning" id="list-type-house-style-test">
-        <name/> element is a list-type='<value-of select="@list-type"/>'. According to house style, bullets, numbers or no indicators should be used. Usual values - ('bullet','simple','order').</assert>
     </rule>
   </pattern>
   <pattern id="pubmed-link-pattern">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2410,11 +2410,11 @@
         role="error"
         id="inline-formula-test-1">inline-formula must contain an mml:math element.</assert>
       
-      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$') and not(matches(.,'^\s+'))"
+      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$')"
         role="warning"
         id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
-      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]') and not(matches(.,'\s+$'))"
+      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]')"
         role="warning"
         id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
       
@@ -5815,6 +5815,21 @@
        id="feature-template-test-4"><value-of select="$type"/> is a template <value-of select="$template"/> but it does not (currently) have an author response. Is that OK?</report>
      
    </rule>
+   
+   <rule context="article[@article-type='article-commentary']//article-meta/abstract"
+     id="insight-asbtract-tests">
+     <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value"/>
+     <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value/*)"/>
+     
+     <assert test=". = $impact-statement"
+       role="warning"
+       id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     
+     <assert test="count(p/*) = $impact-statement-element-count"
+       role="warning"
+       id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     
+   </rule>
   </pattern>
   
   <pattern
@@ -6314,15 +6329,15 @@
         id="fig-xref-test-9">Is this figure citation a reference to a figure from other content (and as such should be captured instead as plain text)? - <value-of select="concat(.,$post-text)"/>'.</report>
       
       <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" 
-        role="error" 
+        role="warning" 
         id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
       <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" 
-        role="error" 
+        role="warning" 
         id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
       <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" 
-        role="error" 
+        role="warning" 
         id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
       
       <report test="matches($post-text,'^[\s]?[Ss]upplement|^[\s]?[Ff]igure [Ss]upplement|^[\s]?[Ss]ource|^[\s]?[Vv]ideo')" 
@@ -7643,19 +7658,19 @@
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))"
         role="error" 
-        id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
+        id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)"
         role="error" 
-        id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
+        id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)"
         role="error"
-        id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
+        id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" 
         role="error" 
-        id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+        id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')"
         role="error" 
@@ -7664,6 +7679,355 @@
       <report test="matches(.,'�')"
         role="error"
         id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/></report>
+      
+    </rule>
+    
+    <rule context="element-citation[@publication-type='data']" 
+      id="data-ref-tests">
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/geo') and not(source[1]='NCBI Gene Expression Omnibus')"
+        role="warning" 
+        id="data-geo-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/geo' type link, but the database name is not 'NCBI Gene Expression Omnibus' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/nuccore') and not(source[1]='NCBI GenBank') and not(source[1]='NCBI Nucleotide')"
+        role="warning" 
+        id="data-nucleotide-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/nuccore' type link, but the database name is not 'NCBI Nucleotide' or 'NCBI GenBank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/bioproject') and not(source[1]='NCBI BioProject')"
+        role="warning" 
+        id="data-bioproject-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/bioproject' type link, but the database name is not 'NCBI BioProject' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/gap') and not(source[1]='NCBI dbGaP')"
+        role="warning" 
+        id="data-dbgap-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/gap' type link, but the database name is not 'NCBI dbGaP' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/popset') and not(source[1]='NCBI PopSet')"
+        role="warning" 
+        id="data-popset-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/popset' type link, but the database name is not 'NCBI PopSet' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/sra') and not(source[1]='NCBI Sequence Read Archive')"
+        role="warning" 
+        id="data-sra-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/sra' type link, but the database name is not 'NCBI Sequence Read Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/biosample') and not(source[1]='NCBI BioSample')"
+        role="warning" 
+        id="data-biosample-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/biosample' type link, but the database name is not 'NCBI BioSample' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/assembly') and not(source[1]='NCBI Assembly')"
+        role="warning" 
+        id="data-assembly-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/assembly' type link, but the database name is not 'NCBI Assembly' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[@pub-id-type!='accession']"
+        role="warning" 
+        id="data-ncbi-test-1">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked as an accession number, which is likely incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[@pub-id-type!='accession']"
+        role="warning" 
+        id="data-ncbi-test-2">Data reference with the database source '<value-of select="source[1]"/>' is not marked as an accession number, which is very likely incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-ncbi-test-3">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-ncbi-test-4">Data reference with the database source '<value-of select="source[1]"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (source[1]!='Dryad Digital Repository')"
+        role="warning" 
+        id="data-dryad-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5061/dryad' but the database name is not 'Dryad Digital Repository' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad')) and (source[1]='Dryad Digital Repository')"
+        role="warning" 
+        id="data-dryad-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5061/dryad', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (pub-id[1][@assigning-authority!='Dryad' or not(@assigning-authority)])"
+        role="warning" 
+        id="data-dryad-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Dryad type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Dryad, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and not(source[1]='RCSB Protein Data Bank')"
+        role="warning" 
+        id="data-rcsbpbd-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but the database name is not 'RCSB Protein Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and  pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-rcsbpbd-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but is not marked with PBD as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')"
+        role="warning" 
+        id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')"
+        role="warning" 
+        id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-arrayexpress-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-arrayexpress-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ArrayExpress 'www.ebi.ac.uk/arrayexpress' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and not(source[1]='PRIDE')"
+        role="warning" 
+        id="data-pride-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but the database name is not 'PRIDE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-pride-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-pride-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PRIDE 'www.ebi.ac.uk/pride' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (source[1]!='Zenodo')"
+        role="warning" 
+        id="data-zenodo-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5281/zenodo' but the database name is not 'Zenodo' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo')) and (source[1]='Zenodo')"
+        role="warning" 
+        id="data-zenodo-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5281/zenodo', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (pub-id[1][@assigning-authority!='Zenodo'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-zenodo-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Zenodo type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Zenodo, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and not(source[1]='Open Science Framework')"
+        role="warning" 
+        id="data-osf-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-osf-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')"
+        role="warning" 
+        id="data-osf-test-4">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (pub-id[1][@assigning-authority!='Open Science Framework'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-osf-test-5">Data reference with the title '<value-of select="data-title[1]"/>' has a OSF type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Open Science Framework, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (source[1]!='figshare')"
+        role="warning" 
+        id="data-figshare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6084/m9.figshare' but the database name is not 'figshare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare')) and (source[1]='figshare')"
+        role="warning" 
+        id="data-figshare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6084/m9.figshare' - is this correct? Figshare sometimes host for other organisations (example http://doi.org/10.1184/R1/9963566), so this may be fine.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (pub-id[1][@assigning-authority!='figshare'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-figshare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a figshare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not figshare, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and not(source[1]='ProteomeXchange')"
+        role="warning" 
+        id="data-proteomexchange-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but the database name is not 'ProteomeXchange' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-proteomexchange-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but is not marked with 'other' as its assigning authority, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-proteomexchange-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ProteomeXchange 'http://proteomecentral.proteomexchange.org/' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (source[1]!='OpenNeuro')"
+        role="warning" 
+        id="data-openneuro-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.18112/openneuro' but the database name is not 'OpenNeuro' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro')) and not(contains(pub-id[1]/@xlink:href,'openneuro.org/datasets')) and (source[1]='OpenNeuro')"
+        role="warning" 
+        id="data-openneuro-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.18112/openneuro' or 'openneuro.org/datasets' type link, which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-openneuro-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a OpenNeuro type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (source[1]!='Synapse')"
+        role="warning" 
+        id="data-synapse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7303/syn' but the database name is not 'Synapse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn')) and (source[1]='Synapse')"
+        role="warning" 
+        id="data-synapse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7303/syn', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-synapse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Synapse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and not(source[1]='Biological Magnetic Resonance Data Bank')"
+        role="warning" 
+        id="data-bmrb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but the database name is not 'Biological Magnetic Resonance Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-bmrb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-bmrb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a BMRB 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and not(source[1]='Morph D Base')"
+        role="warning" 
+        id="data-morphdbase-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but the database name is not 'Morph D Base' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-morphdbase-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-morphdbase-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Morph D Base 'www.morphdbase.de' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (source[1]!='Mendeley Data')"
+        role="warning" 
+        id="data-mendeley-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17632' but the database name is not 'Mendeley Data' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17632')) and (source[1]='Mendeley Data')"
+        role="warning" 
+        id="data-mendeley-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17632', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-mendeley-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Mendeley Data type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (source[1]!='Edinburgh DataShare')"
+        role="warning" 
+        id="data-edatashare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7488' but the database name is not 'Edinburgh DataShare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7488')) and (source[1]='Edinburgh DataShare')"
+        role="warning" 
+        id="data-edatashare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7488', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (pub-id[1][@assigning-authority!='Edinburgh University'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-edatashare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Edinburgh DataShare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'Edinburgh University', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (source[1]!='ETH Library research collection')"
+        role="warning" 
+        id="data-eth-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.3929' but the database name is not 'ETH Library research collection' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.3929')) and (source[1]='ETH Library research collection')"
+        role="warning" 
+        id="data-eth-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.3929', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-eth-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ETH Library research collection type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (source[1]!='Collaborative Research in Computational Neuroscience')"
+        role="warning" 
+        id="data-crcns-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6080' but the database name is not 'Collaborative Research in Computational Neuroscience' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6080')) and (source[1]='Collaborative Research in Computational Neuroscience')"
+        role="warning" 
+        id="data-crcns-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6080', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-crcns-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a CRCNS type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (source[1]!='MorphoSource')"
+        role="warning" 
+        id="data-morphosource-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17602' but the database name is not 'MorphoSource' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17602')) and (source[1]='MorphoSource')"
+        role="warning" 
+        id="data-morphosource-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17602', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-morphosource-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a MorphoSource type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and not(source[1]='NeuroVault')"
+        role="warning" 
+        id="data-neurovault-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but the database name is not 'NeuroVault' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-neurovault-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')"
+        role="warning" 
+        id="data-wwpdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')"
+        role="warning" 
+        id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')"
+        role="warning" 
+        id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID')) and (source[1]='SBGrid Data Bank')"
+        role="warning" 
+        id="data-sbgdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.15785/SBGRID', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-sbgdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a SBGrid Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (source[1]!='Harvard Dataverse')"
+        role="warning" 
+        id="data-harvard-dataverse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7910' but the database name is not 'Harvard Dataverse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7910')) and (source[1]='Harvard Dataverse')"
+        role="warning" 
+        id="data-harvard-dataverse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7910', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+        role="warning" 
+        id="data-harvard-dataverse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Harvard Dataverse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and not(source[1]='ENCODE')"
+        role="warning" 
+        id="data-encode-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but the database name is not 'ENCODE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-encode-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')"
+        role="warning" 
+        id="data-emdr-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-emdr-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
+        role="warning" 
+        id="data-emdr-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an EMDataResource 'www.emdataresource.org' type link, but is not marked as an accession type link.</report>
       
     </rule>
     
@@ -7920,11 +8284,11 @@
       id="p-punctuation">
       <let name="para" value="replace(.,'&#x00A0;',' ')"/>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))"
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\p{P}\s*?$'))"
         role="warning" 
         id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))"
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))"
         role="warning" 
         id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
@@ -8068,15 +8432,6 @@
         role="warning"
         id="final-in-ovo-italic-test"><name/> element contains 'In Ovo' - this should not be in italics (eLife house style).</report>
       
-    </rule>
-    
-    <rule context="list[@list-type]" 
-      id="list-house-style">
-      <let name="usual-types" value="('bullet','simple','order')"/>
-      
-      <assert test="@list-type = $usual-types"
-        role="warning" 
-        id="list-type-house-style-test"><name/> element is a list-type='<value-of select="@list-type"/>'. According to house style, bullets, numbers or no indicators should be used. Usual values - ('bullet','simple','order').</assert>
     </rule>
     
     <rule context="p//ext-link[not(ancestor::table-wrap) and not(ancestor::sub-article)]" 

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -7977,9 +7977,9 @@
         role="warning" 
         id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
       
-      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])"
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='PDB'  or not(@assigning-authority)])"
         role="warning" 
-        id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+        id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'PDB', which must be incorrect.</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')"
         role="warning" 

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-1/data-arrayexpress-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-1/data-arrayexpress-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-arrayexpress-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')
+Message: Data reference with the title '' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Reconstructing the human first trimester fetal-maternal interface using single cell transcriptomics - 10x data</data-title>
+      <source>ArrayExpress database</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-6701/">E-MTAB-6701</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-arrayexpress-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')
+Message: Data reference with the title '' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Reconstructing the human first trimester fetal-maternal interface using single cell transcriptomics - 10x data</data-title>
+      <source>ArrayExpress</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-6701/">E-MTAB-6701</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-2/data-arrayexpress-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-2/data-arrayexpress-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-arrayexpress-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-arrayexpress-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.ebi.ac.uk/arrayexpress' type link, but is not marked with EBI as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Reconstructing the human first trimester fetal-maternal interface using single cell transcriptomics - 10x data</data-title>
+      <source>ArrayExpress</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-6701/">E-MTAB-6701</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-arrayexpress-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.ebi.ac.uk/arrayexpress' type link, but is not marked with EBI as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Reconstructing the human first trimester fetal-maternal interface using single cell transcriptomics - 10x data</data-title>
+      <source>ArrayExpress</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-6701/">E-MTAB-6701</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-3/data-arrayexpress-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-3/data-arrayexpress-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-arrayexpress-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ArrayExpress 'www.ebi.ac.uk/arrayexpress' type link, but is not marked as an accession type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-arrayexpress-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has an ArrayExpress 'www.ebi.ac.uk/arrayexpress' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Reconstructing the human first trimester fetal-maternal interface using single cell transcriptomics - 10x data</data-title>
+      <source>ArrayExpress</source>
+      <pub-id assigning-authority="EBI" pub-id-type="archive" xlink:href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-6701/">E-MTAB-6701</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-arrayexpress-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has an ArrayExpress 'www.ebi.ac.uk/arrayexpress' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Reconstructing the human first trimester fetal-maternal interface using single cell transcriptomics - 10x data</data-title>
+      <source>ArrayExpress</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/arrayexpress/experiments/E-MTAB-6701/">E-MTAB-6701</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-assembly-test/data-assembly-test.sch
+++ b/test/tests/gen/data-ref-tests/data-assembly-test/data-assembly-test.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/assembly') and not(source[1]='NCBI Assembly')" role="warning" id="data-assembly-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/assembly' type link, but the database name is not 'NCBI Assembly' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-assembly-test/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-assembly-test/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-assembly-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/assembly') and not(source[1]='NCBI Assembly')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/assembly' type link, but the database name is not 'NCBI Assembly'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Improved reference genome of Aedes aegypti informs arbovirus vector control.</data-title>
+      <source>Assembly</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/assembly/GCF_002204515.2/">GCF_002204515.2</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-assembly-test/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-assembly-test/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-assembly-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/assembly') and not(source[1]='NCBI Assembly')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/assembly' type link, but the database name is not 'NCBI Assembly'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Improved reference genome of Aedes aegypti informs arbovirus vector control.</data-title>
+      <source>NCBI Assembly</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/assembly/GCF_002204515.2/">GCF_002204515.2</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-bioproject-test/data-bioproject-test.sch
+++ b/test/tests/gen/data-ref-tests/data-bioproject-test/data-bioproject-test.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/bioproject') and not(source[1]='NCBI BioProject')" role="warning" id="data-bioproject-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/bioproject' type link, but the database name is not 'NCBI BioProject' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-bioproject-test/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-bioproject-test/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-bioproject-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/bioproject') and not(source[1]='NCBI BioProject')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/bioproject' type link, but the database name is not 'NCBI BioProject'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Bianco</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Mohr</surname>
+          <given-names>I</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Impact of TIFIA and UBF depletion on genome wide responses to dsDNA</data-title>
+      <source>NCBI SRA BioProject</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA528082">PRJNA528082</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-bioproject-test/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-bioproject-test/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-bioproject-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/bioproject') and not(source[1]='NCBI BioProject')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/bioproject' type link, but the database name is not 'NCBI BioProject'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Bianco</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Mohr</surname>
+          <given-names>I</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Impact of TIFIA and UBF depletion on genome wide responses to dsDNA</data-title>
+      <source>NCBI BioProject</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/bioproject/PRJNA528082">PRJNA528082</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-biosample-test/data-biosample-test.sch
+++ b/test/tests/gen/data-ref-tests/data-biosample-test/data-biosample-test.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/biosample') and not(source[1]='NCBI BioSample')" role="warning" id="data-biosample-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/biosample' type link, but the database name is not 'NCBI BioSample' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-biosample-test/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-biosample-test/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-biosample-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/biosample') and not(source[1]='NCBI BioSample')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/biosample' type link, but the database name is not 'NCBI BioSample'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset7" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Mutational antigenic profiling sera controls</data-title>
+      <source>Sequence Read Archive</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/biosample/SAMN11310373">SAMN11310373</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-biosample-test/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-biosample-test/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-biosample-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/biosample') and not(source[1]='NCBI BioSample')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/biosample' type link, but the database name is not 'NCBI BioSample'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset7" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Mutational antigenic profiling sera controls</data-title>
+      <source>NCBI BioSample</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/biosample/SAMN11310373">SAMN11310373</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-1/data-bmrb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-1/data-bmrb-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and not(source[1]='Biological Magnetic Resonance Data Bank')" role="warning" id="data-bmrb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but the database name is not 'Biological Magnetic Resonance Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-bmrb-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and not(source[1]='Biological Magnetic Resonance Data Bank')
+Message: Data reference with the title '' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but the database name is not 'Biological Magnetic Resonance Data Bank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset9" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Red abalone lysin F104A</data-title>
+      <source>Biological Magnetic Resonance Data-Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="http://www.bmrb.wisc.edu/data_library/summary/index.php?bmrbId=30246">30246</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-bmrb-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and not(source[1]='Biological Magnetic Resonance Data Bank')
+Message: Data reference with the title '' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but the database name is not 'Biological Magnetic Resonance Data Bank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset9" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Red abalone lysin F104A</data-title>
+      <source>Biological Magnetic Resonance Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="http://www.bmrb.wisc.edu/data_library/summary/index.php?bmrbId=30246">30246</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-2/data-bmrb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-2/data-bmrb-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-bmrb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-bmrb-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset9" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Red abalone lysin F104A</data-title>
+      <source>Biological Magnetic Resonance Data Bank</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.bmrb.wisc.edu/data_library/summary/index.php?bmrbId=30246">30246</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-bmrb-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset9" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Red abalone lysin F104A</data-title>
+      <source>Biological Magnetic Resonance Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="http://www.bmrb.wisc.edu/data_library/summary/index.php?bmrbId=30246">30246</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-3/data-bmrb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-3/data-bmrb-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-bmrb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a BMRB 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked as an accession type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-bmrb-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a BMRB 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset9" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Red abalone lysin F104A</data-title>
+      <source>Biological Magnetic Resonance Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="http://www.bmrb.wisc.edu/data_library/summary/index.php?bmrbId=30246">30246</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-bmrb-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a BMRB 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset9" publication-type="data" specific-use="references">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Red abalone lysin F104A</data-title>
+      <source>Biological Magnetic Resonance Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="http://www.bmrb.wisc.edu/data_library/summary/index.php?bmrbId=30246">30246</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-1/data-crcns-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-1/data-crcns-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (source[1]!='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6080' but the database name is not 'Collaborative Research in Computational Neuroscience' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-1/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-crcns-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (source[1]!='Collaborative Research in Computational Neuroscience')
+Message: Data reference with the title '' has a doi starting with '10.6080' but the database name is not 'Collaborative Research in Computational Neuroscience'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Amy</surname>
+          <given-names>M LeMessurier</given-names>
+        </name>
+        <name>
+          <surname>Daniel</surname>
+          <given-names>E Feldman</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>2-photon calcium imaging in S1 of enriched and normally housed mice during individual deflection of 9 whiskers</data-title>
+      <source>CRCNS - Collaborative Research in Computational Neuroscience</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.6080/K0DB801M</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-1/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-crcns-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (source[1]!='Collaborative Research in Computational Neuroscience')
+Message: Data reference with the title '' has a doi starting with '10.6080' but the database name is not 'Collaborative Research in Computational Neuroscience'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Amy</surname>
+          <given-names>M LeMessurier</given-names>
+        </name>
+        <name>
+          <surname>Daniel</surname>
+          <given-names>E Feldman</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>2-photon calcium imaging in S1 of enriched and normally housed mice during individual deflection of 9 whiskers</data-title>
+      <source>Collaborative Research in Computational Neuroscience</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.6080/K0DB801M</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-2/data-crcns-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-2/data-crcns-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6080')) and (source[1]='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6080', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-2/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-crcns-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6080')) and (source[1]='Collaborative Research in Computational Neuroscience')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.6080', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Amy</surname>
+          <given-names>M LeMessurier</given-names>
+        </name>
+        <name>
+          <surname>Daniel</surname>
+          <given-names>E Feldman</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>2-photon calcium imaging in S1 of enriched and normally housed mice during individual deflection of 9 whiskers</data-title>
+      <source>Collaborative Research in Computational Neuroscience</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.vfdavfed/K0DB801M</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-2/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-crcns-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6080')) and (source[1]='Collaborative Research in Computational Neuroscience')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.6080', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Amy</surname>
+          <given-names>M LeMessurier</given-names>
+        </name>
+        <name>
+          <surname>Daniel</surname>
+          <given-names>E Feldman</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>2-photon calcium imaging in S1 of enriched and normally housed mice during individual deflection of 9 whiskers</data-title>
+      <source>Collaborative Research in Computational Neuroscience</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.6080/K0DB801M</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-3/data-crcns-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-3/data-crcns-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-crcns-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a CRCNS type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-3/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-crcns-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a CRCNS type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Amy</surname>
+          <given-names>M LeMessurier</given-names>
+        </name>
+        <name>
+          <surname>Daniel</surname>
+          <given-names>E Feldman</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>2-photon calcium imaging in S1 of enriched and normally housed mice during individual deflection of 9 whiskers</data-title>
+      <source>Collaborative Research in Computational Neuroscience</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.6080/K0DB801M</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-crcns-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-3/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-crcns-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a CRCNS type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Amy</surname>
+          <given-names>M LeMessurier</given-names>
+        </name>
+        <name>
+          <surname>Daniel</surname>
+          <given-names>E Feldman</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>2-photon calcium imaging in S1 of enriched and normally housed mice during individual deflection of 9 whiskers</data-title>
+      <source>Collaborative Research in Computational Neuroscience</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.6080/K0DB801M</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-dbgap-test/data-dbgap-test.sch
+++ b/test/tests/gen/data-ref-tests/data-dbgap-test/data-dbgap-test.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/gap') and not(source[1]='NCBI dbGaP')" role="warning" id="data-dbgap-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/gap' type link, but the database name is not 'NCBI dbGaP' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-dbgap-test/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-dbgap-test/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-dbgap-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/gap') and not(source[1]='NCBI dbGaP')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/gap' type link, but the database name is not 'NCBI dbGaP'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset3" publication-type="data" specific-use="references">
+      <year iso-8601-date="2015">2015</year>
+      <data-title>Integrative clinical genomics of advanced prostate cancer</data-title>
+      <source>NCBI dbGap</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/gap/?term=phs000915.v1.p1">phs000915.v1.p1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-dbgap-test/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-dbgap-test/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-dbgap-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/gap') and not(source[1]='NCBI dbGaP')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/gap' type link, but the database name is not 'NCBI dbGaP'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset3" publication-type="data" specific-use="references">
+      <year iso-8601-date="2015">2015</year>
+      <data-title>Integrative clinical genomics of advanced prostate cancer</data-title>
+      <source>NCBI dbGaP</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/gap/?term=phs000915.v1.p1">phs000915.v1.p1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-1/data-dryad-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-1/data-dryad-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (source[1]!='Dryad Digital Repository')" role="warning" id="data-dryad-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5061/dryad' but the database name is not 'Dryad Digital Repository' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-dryad-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (source[1]!='Dryad Digital Repository')
+Message: Data reference with the title '' has a doi starting with '10.5061/dryad' but the database name is not 'Dryad Digital Repository'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Vasohibin1, a new IRES trans-acting factor for induction of (lymph)angiogenic factors in early hypoxia</data-title>
+      <source>Dryad</source>
+      <pub-id assigning-authority="Dryad" pub-id-type="doi">10.5061/dryad.2330r1b</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-dryad-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (source[1]!='Dryad Digital Repository')
+Message: Data reference with the title '' has a doi starting with '10.5061/dryad' but the database name is not 'Dryad Digital Repository'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Vasohibin1, a new IRES trans-acting factor for induction of (lymph)angiogenic factors in early hypoxia</data-title>
+      <source>Dryad Digital Repository</source>
+      <pub-id assigning-authority="Dryad" pub-id-type="doi">10.5061/dryad.2330r1b</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-2/data-dryad-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-2/data-dryad-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad')) and (source[1]='Dryad Digital Repository')" role="warning" id="data-dryad-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5061/dryad', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-dryad-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad')) and (source[1]='Dryad Digital Repository')
+Message: Data reference with the title '' has the database name  , but no doi starting with '10.5061/dryad', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Vasohibin1, a new IRES trans-acting factor for induction of (lymph)angiogenic factors in early hypoxia</data-title>
+      <source>Dryad Digital Repository</source>
+      <pub-id assigning-authority="Dryad" pub-id-type="doi">10.5555/dryad.2330r1b</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-dryad-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad')) and (source[1]='Dryad Digital Repository')
+Message: Data reference with the title '' has the database name  , but no doi starting with '10.5061/dryad', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Vasohibin1, a new IRES trans-acting factor for induction of (lymph)angiogenic factors in early hypoxia</data-title>
+      <source>Dryad Digital Repository</source>
+      <pub-id assigning-authority="Dryad" pub-id-type="doi">10.5061/dryad.2330r1b</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-3/data-dryad-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-3/data-dryad-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (pub-id[1][@assigning-authority!='Dryad' or not(@assigning-authority)])" role="warning" id="data-dryad-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Dryad type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Dryad, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-dryad-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (pub-id[1][@assigning-authority!='Dryad' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Dryad type doi  , but the assigning authority is not Dryad, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Vasohibin1, a new IRES trans-acting factor for induction of (lymph)angiogenic factors in early hypoxia</data-title>
+      <source>Dryad Digital Repository</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.5061/dryad.2330r1b</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-dryad-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-dryad-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (pub-id[1][@assigning-authority!='Dryad' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Dryad type doi  , but the assigning authority is not Dryad, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Vasohibin1, a new IRES trans-acting factor for induction of (lymph)angiogenic factors in early hypoxia</data-title>
+      <source>Dryad Digital Repository</source>
+      <pub-id assigning-authority="Dryad" pub-id-type="doi">10.5061/dryad.2330r1b</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-1/data-edatashare-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-1/data-edatashare-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (source[1]!='Edinburgh DataShare')" role="warning" id="data-edatashare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7488' but the database name is not 'Edinburgh DataShare' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-edatashare-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (source[1]!='Edinburgh DataShare')
+Message: Data reference with the title '' has a doi starting with '10.7488' but the database name is not 'Edinburgh DataShare'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Genomic underpinnings of lifespan allow prediction and reveal basis in modern risks</data-title>
+      <source>Edinburgh DataShare vfeq</source>
+      <pub-id assigning-authority="Edinburgh University" pub-id-type="doi">10.7488/ds/2463</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-edatashare-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (source[1]!='Edinburgh DataShare')
+Message: Data reference with the title '' has a doi starting with '10.7488' but the database name is not 'Edinburgh DataShare'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Genomic underpinnings of lifespan allow prediction and reveal basis in modern risks</data-title>
+      <source>Edinburgh DataShare</source>
+      <pub-id assigning-authority="Edinburgh University" pub-id-type="doi">10.7488/ds/2463</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-2/data-edatashare-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-2/data-edatashare-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7488')) and (source[1]='Edinburgh DataShare')" role="warning" id="data-edatashare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7488', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-edatashare-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7488')) and (source[1]='Edinburgh DataShare')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.7488', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Genomic underpinnings of lifespan allow prediction and reveal basis in modern risks</data-title>
+      <source>Edinburgh DataShare</source>
+      <pub-id assigning-authority="Edinburgh University" pub-id-type="doi">10.74788/ds/2463</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-edatashare-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7488')) and (source[1]='Edinburgh DataShare')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.7488', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Genomic underpinnings of lifespan allow prediction and reveal basis in modern risks</data-title>
+      <source>Edinburgh DataShare</source>
+      <pub-id assigning-authority="Edinburgh University" pub-id-type="doi">10.7488/ds/2463</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-3/data-edatashare-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-3/data-edatashare-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (pub-id[1][@assigning-authority!='Edinburgh University'  or not(@assigning-authority)])" role="warning" id="data-edatashare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Edinburgh DataShare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'Edinburgh University', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-edatashare-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (pub-id[1][@assigning-authority!='Edinburgh University' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Edinburgh DataShare type doi  , but the assigning authority is not 'Edinburgh University', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Genomic underpinnings of lifespan allow prediction and reveal basis in modern risks</data-title>
+      <source>Edinburgh DataShare</source>
+      <pub-id assigning-authority="other University" pub-id-type="doi">10.7488/ds/2463</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-edatashare-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (pub-id[1][@assigning-authority!='Edinburgh University' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Edinburgh DataShare type doi  , but the assigning authority is not 'Edinburgh University', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Genomic underpinnings of lifespan allow prediction and reveal basis in modern risks</data-title>
+      <source>Edinburgh DataShare</source>
+      <pub-id assigning-authority="Edinburgh University" pub-id-type="doi">10.7488/ds/2463</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-1/data-emdb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-1/data-emdb-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-1/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-emdb-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')
+Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset8" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>EMDataBank</source>
+      <pub-id assigning-authority="EMDB" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/entry/emdb/EMD-21036">EMD-21036</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-1/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-emdb-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')
+Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset8" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>Electron Microscopy Data Bank</source>
+      <pub-id assigning-authority="EMDB" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/entry/emdb/EMD-21036">EMD-21036</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-2/data-emdb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-2/data-emdb-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-2/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-emdb-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset8" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>Electron Microscopy Data Bank</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/entry/emdb/EMD-21036">EMD-21036</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-2/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-emdb-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset8" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>Electron Microscopy Data Bank</source>
+      <pub-id assigning-authority="EMDB" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/entry/emdb/EMD-21036">EMD-21036</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-3/data-emdb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-3/data-emdb-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-3/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-emdb-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset8" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>Electron Microscopy Data Bank</source>
+      <pub-id assigning-authority="EMDB" pub-id-type="archive" xlink:href="https://www.ebi.ac.uk/pdbe/entry/emdb/EMD-21036">EMD-21036</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-3/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-emdb-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset8" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>Electron Microscopy Data Bank</source>
+      <pub-id assigning-authority="EMDB" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/entry/emdb/EMD-21036">EMD-21036</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-1/data-emdr-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-1/data-emdr-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-1/fail.xml
@@ -1,0 +1,30 @@
+<?oxygen SCHSchema="data-emdr-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')
+Message: Data reference with the title '' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource'  . Is that correct?-->
+<article>
+  <element-citation xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:xlink="http://www.w3.org/1999/xlink" id="dataset10" publication-type="data" specific-use="isSupplementedBy">
+    <person-group person-group-type="author">
+      <name>
+        <surname>Shyng</surname>
+        <given-names>SL</given-names>
+      </name>
+      <name>
+        <surname>Yoshioka</surname>
+        <given-names>C</given-names>
+      </name>
+      <name>
+        <surname>Martin</surname>
+        <given-names>GM</given-names>
+      </name>
+      <name>
+        <surname>Sung</surname>
+        <given-names>MW</given-names>
+      </name>
+    </person-group>
+    <year iso-8601-date="2019">2019</year>
+    <data-title>Cryo-EM structure of the pancreatic beta-cell SUR1 bound to ATP only</data-title>
+    <source>Electron Microscopy Data Bank</source>
+    <pub-id assigning-authority="EMDB" pub-id-type="accession" xlink:href="https://www.emdataresource.org/EMD-20535">EMD-20535</pub-id>
+  </element-citation>
+</article>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-1/pass.xml
@@ -1,0 +1,32 @@
+<?oxygen SCHSchema="data-emdr-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')
+Message: Data reference with the title '' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Shyng</surname>
+          <given-names>SL</given-names>
+        </name>
+        <name>
+          <surname>Yoshioka</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Martin</surname>
+          <given-names>GM</given-names>
+        </name>
+        <name>
+          <surname>Sung</surname>
+          <given-names>MW</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cryo-EM structure of the pancreatic beta-cell SUR1 bound to ATP only</data-title>
+      <source>EMDataResource</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.emdataresource.org/EMD-20535">EMD-20535</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-2/data-emdr-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-2/data-emdr-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-emdr-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-2/fail.xml
@@ -1,0 +1,32 @@
+<?oxygen SCHSchema="data-emdr-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.emdataresource.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Shyng</surname>
+          <given-names>SL</given-names>
+        </name>
+        <name>
+          <surname>Yoshioka</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Martin</surname>
+          <given-names>GM</given-names>
+        </name>
+        <name>
+          <surname>Sung</surname>
+          <given-names>MW</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cryo-EM structure of the pancreatic beta-cell SUR1 bound to ATP only</data-title>
+      <source>Electron Microscopy Data Bank</source>
+      <pub-id assigning-authority="EMDB" pub-id-type="accession" xlink:href="https://www.emdataresource.org/EMD-20535">EMD-20535</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-2/pass.xml
@@ -1,0 +1,32 @@
+<?oxygen SCHSchema="data-emdr-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.emdataresource.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Shyng</surname>
+          <given-names>SL</given-names>
+        </name>
+        <name>
+          <surname>Yoshioka</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Martin</surname>
+          <given-names>GM</given-names>
+        </name>
+        <name>
+          <surname>Sung</surname>
+          <given-names>MW</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cryo-EM structure of the pancreatic beta-cell SUR1 bound to ATP only</data-title>
+      <source>EMDataResource</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.emdataresource.org/EMD-20535">EMD-20535</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-3/data-emdr-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-3/data-emdr-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdr-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an EMDataResource 'www.emdataresource.org' type link, but is not marked as an accession type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-3/fail.xml
@@ -1,0 +1,32 @@
+<?oxygen SCHSchema="data-emdr-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has an EMDataResource 'www.emdataresource.org' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Shyng</surname>
+          <given-names>SL</given-names>
+        </name>
+        <name>
+          <surname>Yoshioka</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Martin</surname>
+          <given-names>GM</given-names>
+        </name>
+        <name>
+          <surname>Sung</surname>
+          <given-names>MW</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cryo-EM structure of the pancreatic beta-cell SUR1 bound to ATP only</data-title>
+      <source>Electron Microscopy Data Bank</source>
+      <pub-id assigning-authority="EMDB" xlink:href="https://www.emdataresource.org/EMD-20535">EMD-20535</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-emdr-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-3/pass.xml
@@ -1,0 +1,32 @@
+<?oxygen SCHSchema="data-emdr-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has an EMDataResource 'www.emdataresource.org' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Shyng</surname>
+          <given-names>SL</given-names>
+        </name>
+        <name>
+          <surname>Yoshioka</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Martin</surname>
+          <given-names>GM</given-names>
+        </name>
+        <name>
+          <surname>Sung</surname>
+          <given-names>MW</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cryo-EM structure of the pancreatic beta-cell SUR1 bound to ATP only</data-title>
+      <source>EMDataResource</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.emdataresource.org/EMD-20535">EMD-20535</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-encode-test-1/data-encode-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-encode-test-1/data-encode-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and not(source[1]='ENCODE')" role="warning" id="data-encode-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but the database name is not 'ENCODE' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-encode-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-1/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-encode-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and not(source[1]='ENCODE')
+Message: Data reference with the title '' has a 'www.encodeproject.org' type link, but the database name is not 'ENCODE'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset7" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>John</surname>
+          <given-names>Stamatoyannopoulos</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2012">2012</year>
+      <data-title>DNase-seq and DGF on 8 week adult mouse heart</data-title>
+      <source>nvjrfowb</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-encode-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-1/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-encode-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and not(source[1]='ENCODE')
+Message: Data reference with the title '' has a 'www.encodeproject.org' type link, but the database name is not 'ENCODE'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset7" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>John</surname>
+          <given-names>Stamatoyannopoulos</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2012">2012</year>
+      <data-title>DNase-seq and DGF on 8 week adult mouse heart</data-title>
+      <source>ENCODE</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-encode-test-2/data-encode-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-encode-test-2/data-encode-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-encode-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-2/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-encode-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset7" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>John</surname>
+          <given-names>Stamatoyannopoulos</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2012">2012</year>
+      <data-title>DNase-seq and DGF on 8 week adult mouse heart</data-title>
+      <source>ENCODE</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="archive" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-encode-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-2/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-encode-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset7" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>John</surname>
+          <given-names>Stamatoyannopoulos</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2012">2012</year>
+      <data-title>DNase-seq and DGF on 8 week adult mouse heart</data-title>
+      <source>ENCODE</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/data-encode-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/data-encode-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-encode-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
+Message: Data reference with the title '' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset7" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>John</surname>
+          <given-names>Stamatoyannopoulos</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2012">2012</year>
+      <data-title>DNase-seq and DGF on 8 week adult mouse heart</data-title>
+      <source>ENCODE</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-encode-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
+Message: Data reference with the title '' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset7" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>John</surname>
+          <given-names>Stamatoyannopoulos</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2012">2012</year>
+      <data-title>DNase-seq and DGF on 8 week adult mouse heart</data-title>
+      <source>ENCODE</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-eth-test-1/data-eth-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-eth-test-1/data-eth-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (source[1]!='ETH Library research collection')" role="warning" id="data-eth-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.3929' but the database name is not 'ETH Library research collection' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-eth-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-eth-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-eth-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (source[1]!='ETH Library research collection')
+Message: Data reference with the title '' has a doi starting with '10.3929' but the database name is not 'ETH Library research collection'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>MEP neurofeedback</data-title>
+      <source>ETH Librcdeqvary research collection</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.3929/ethz-b-000300799</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-eth-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-eth-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-eth-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (source[1]!='ETH Library research collection')
+Message: Data reference with the title '' has a doi starting with '10.3929' but the database name is not 'ETH Library research collection'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>MEP neurofeedback</data-title>
+      <source>ETH Library research collection</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.3929/ethz-b-000300799</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-eth-test-2/data-eth-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-eth-test-2/data-eth-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.3929')) and (source[1]='ETH Library research collection')" role="warning" id="data-eth-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.3929', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-eth-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-eth-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-eth-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.3929')) and (source[1]='ETH Library research collection')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.3929', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>MEP neurofeedback</data-title>
+      <source>ETH Library research collection</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.39d29/ethz-b-000300799</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-eth-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-eth-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-eth-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.3929')) and (source[1]='ETH Library research collection')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.3929', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>MEP neurofeedback</data-title>
+      <source>ETH Library research collection</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.3929/ethz-b-000300799</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-eth-test-3/data-eth-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-eth-test-3/data-eth-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-eth-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ETH Library research collection type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-eth-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-eth-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-eth-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a ETH Library research collection type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>MEP neurofeedback</data-title>
+      <source>ETH Library research collection</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.3929/ethz-b-000300799</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-eth-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-eth-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-eth-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a ETH Library research collection type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>MEP neurofeedback</data-title>
+      <source>ETH Library research collection</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.3929/ethz-b-000300799</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-1/data-figshare-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-1/data-figshare-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (source[1]!='figshare')" role="warning" id="data-figshare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6084/m9.figshare' but the database name is not 'figshare' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-1/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-figshare-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (source[1]!='figshare')
+Message: Data reference with the title '' has a doi starting with '10.6084/m9.figshare' but the database name is not 'figshare'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Jacob</surname>
+          <given-names>J Hughey</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Reproducible results for: Releasing a preprint is associated with more attention and citations for the peer-reviewed article</data-title>
+      <source>Figshare</source>
+      <pub-id assigning-authority="figshare" pub-id-type="doi">10.6084/m9.figshare.8855795</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-1/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-figshare-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (source[1]!='figshare')
+Message: Data reference with the title '' has a doi starting with '10.6084/m9.figshare' but the database name is not 'figshare'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Jacob</surname>
+          <given-names>J Hughey</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Reproducible results for: Releasing a preprint is associated with more attention and citations for the peer-reviewed article</data-title>
+      <source>figshare</source>
+      <pub-id assigning-authority="figshare" pub-id-type="doi">10.6084/m9.figshare.8855795</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-2/data-figshare-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-2/data-figshare-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare')) and (source[1]='figshare')" role="warning" id="data-figshare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6084/m9.figshare' - is this correct? Figshare sometimes host for other organisations (example http://doi.org/10.1184/R1/9963566), so this may be fine.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-2/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-figshare-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare')) and (source[1]='figshare')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.6084/m9.figshare'  is this correct? Figshare sometimes host for other organisations (example http://doi.org/10.1184/R1/9963566), so this may be fine.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Jacob</surname>
+          <given-names>J Hughey</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Reproducible results for: Releasing a preprint is associated with more attention and citations for the peer-reviewed article</data-title>
+      <source>figshare</source>
+      <pub-id assigning-authority="figshare" pub-id-type="doi">10.60d84/m9.figshare.8855795</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-2/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-figshare-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare')) and (source[1]='figshare')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.6084/m9.figshare'  is this correct? Figshare sometimes host for other organisations (example http://doi.org/10.1184/R1/9963566), so this may be fine.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Jacob</surname>
+          <given-names>J Hughey</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Reproducible results for: Releasing a preprint is associated with more attention and citations for the peer-reviewed article</data-title>
+      <source>figshare</source>
+      <pub-id assigning-authority="figshare" pub-id-type="doi">10.6084/m9.figshare.8855795</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-3/data-figshare-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-3/data-figshare-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (pub-id[1][@assigning-authority!='figshare'  or not(@assigning-authority)])" role="warning" id="data-figshare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a figshare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not figshare, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-3/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-figshare-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (pub-id[1][@assigning-authority!='figshare' or not(@assigning-authority)])
+Message: Data reference with the title '' has a figshare type doi  , but the assigning authority is not figshare, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Jacob</surname>
+          <given-names>J Hughey</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Reproducible results for: Releasing a preprint is associated with more attention and citations for the peer-reviewed article</data-title>
+      <source>figshare</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.6084/m9.figshare.8855795</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-figshare-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-3/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-figshare-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (pub-id[1][@assigning-authority!='figshare' or not(@assigning-authority)])
+Message: Data reference with the title '' has a figshare type doi  , but the assigning authority is not figshare, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Jacob</surname>
+          <given-names>J Hughey</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Reproducible results for: Releasing a preprint is associated with more attention and citations for the peer-reviewed article</data-title>
+      <source>figshare</source>
+      <pub-id assigning-authority="figshare" pub-id-type="doi">10.6084/m9.figshare.8855795</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-geo-test/data-geo-test.sch
+++ b/test/tests/gen/data-ref-tests/data-geo-test/data-geo-test.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/geo') and not(source[1]='NCBI Gene Expression Omnibus')" role="warning" id="data-geo-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/geo' type link, but the database name is not 'NCBI Gene Expression Omnibus' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-geo-test/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-geo-test/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-geo-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/geo') and not(source[1]='NCBI Gene Expression Omnibus')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/geo' type link, but the database name is not 'NCBI Gene Expression Omnibus'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset3" publication-type="data" specific-use="references">
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Genome Scale Analysis of miRNA and mRNA regulation during preterm labor</data-title>
+      <source>Gene Expression Omnibus</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE96083">GSE96083</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-geo-test/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-geo-test/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-geo-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/geo') and not(source[1]='NCBI Gene Expression Omnibus')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/geo' type link, but the database name is not 'NCBI Gene Expression Omnibus'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset3" publication-type="data" specific-use="references">
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Genome Scale Analysis of miRNA and mRNA regulation during preterm labor</data-title>
+      <source>NCBI Gene Expression Omnibus</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE96083">GSE96083</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-1/data-harvard-dataverse-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-1/data-harvard-dataverse-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (source[1]!='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7910' but the database name is not 'Harvard Dataverse' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-harvard-dataverse-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (source[1]!='Harvard Dataverse')
+Message: Data reference with the title '' has a doi starting with '10.7910' but the database name is not 'Harvard Dataverse'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>MDN-GAL4 UAS-CsChrimson</data-title>
+      <source>Harvard Datavverse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7910/DVN/8SUC9U</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-harvard-dataverse-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (source[1]!='Harvard Dataverse')
+Message: Data reference with the title '' has a doi starting with '10.7910' but the database name is not 'Harvard Dataverse'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>MDN-GAL4 UAS-CsChrimson</data-title>
+      <source>Harvard Dataverse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7910/DVN/8SUC9U</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-2/data-harvard-dataverse-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-2/data-harvard-dataverse-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7910')) and (source[1]='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7910', which is likely incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-harvard-dataverse-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7910')) and (source[1]='Harvard Dataverse')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.7910', which is likely incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>MDN-GAL4 UAS-CsChrimson</data-title>
+      <source>Harvard Dataverse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.79s10/DVN/8SUC9U</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-harvard-dataverse-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7910')) and (source[1]='Harvard Dataverse')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.7910', which is likely incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>MDN-GAL4 UAS-CsChrimson</data-title>
+      <source>Harvard Dataverse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7910/DVN/8SUC9U</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-3/data-harvard-dataverse-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-3/data-harvard-dataverse-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-harvard-dataverse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Harvard Dataverse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-harvard-dataverse-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Harvard Dataverse type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>MDN-GAL4 UAS-CsChrimson</data-title>
+      <source>Harvard Dataverse</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.7910/DVN/8SUC9U</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-harvard-dataverse-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Harvard Dataverse type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>MDN-GAL4 UAS-CsChrimson</data-title>
+      <source>Harvard Dataverse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7910/DVN/8SUC9U</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-1/data-mendeley-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-1/data-mendeley-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (source[1]!='Mendeley Data')" role="warning" id="data-mendeley-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17632' but the database name is not 'Mendeley Data' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-mendeley-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (source[1]!='Mendeley Data')
+Message: Data reference with the title '' has a doi starting with '10.17632' but the database name is not 'Mendeley Data'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Code &amp; Data for: Environmental heterogeneity can tip the population genetics of range expansions</data-title>
+      <source>Mendeley</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17632/2fkhp73bc6.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-mendeley-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (source[1]!='Mendeley Data')
+Message: Data reference with the title '' has a doi starting with '10.17632' but the database name is not 'Mendeley Data'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Code &amp; Data for: Environmental heterogeneity can tip the population genetics of range expansions</data-title>
+      <source>Mendeley Data</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17632/2fkhp73bc6.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-2/data-mendeley-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-2/data-mendeley-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17632')) and (source[1]='Mendeley Data')" role="warning" id="data-mendeley-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17632', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-mendeley-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17632')) and (source[1]='Mendeley Data')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.17632', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Code &amp; Data for: Environmental heterogeneity can tip the population genetics of range expansions</data-title>
+      <source>Mendeley Data</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.176d32/2fkhp73bc6.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-mendeley-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17632')) and (source[1]='Mendeley Data')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.17632', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Code &amp; Data for: Environmental heterogeneity can tip the population genetics of range expansions</data-title>
+      <source>Mendeley Data</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17632/2fkhp73bc6.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-3/data-mendeley-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-3/data-mendeley-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-mendeley-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Mendeley Data type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-mendeley-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Mendeley Data type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Code &amp; Data for: Environmental heterogeneity can tip the population genetics of range expansions</data-title>
+      <source>Mendeley Data</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.17632/2fkhp73bc6.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-mendeley-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Mendeley Data type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Code &amp; Data for: Environmental heterogeneity can tip the population genetics of range expansions</data-title>
+      <source>Mendeley Data</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17632/2fkhp73bc6.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-1/data-morphdbase-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-1/data-morphdbase-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and not(source[1]='Morph D Base')" role="warning" id="data-morphdbase-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but the database name is not 'Morph D Base' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphdbase-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and not(source[1]='Morph D Base')
+Message: Data reference with the title '' has a 'www.morphdbase.de' type link, but the database name is not 'Morph D Base'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset5" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Neuroanatomy of a hydrothermal vent shrimp provides insights into the evolution of crustacean integrative brain centers</data-title>
+      <source>Morph D vreqBase</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.morphdbase.de/?J_Machon_20190502-M-7.1">J_Machon_20190502-M-7.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphdbase-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and not(source[1]='Morph D Base')
+Message: Data reference with the title '' has a 'www.morphdbase.de' type link, but the database name is not 'Morph D Base'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset5" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Neuroanatomy of a hydrothermal vent shrimp provides insights into the evolution of crustacean integrative brain centers</data-title>
+      <source>Morph D Base</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.morphdbase.de/?J_Machon_20190502-M-7.1">J_Machon_20190502-M-7.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-2/data-morphdbase-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-2/data-morphdbase-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-morphdbase-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphdbase-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.morphdbase.de' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset5" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Neuroanatomy of a hydrothermal vent shrimp provides insights into the evolution of crustacean integrative brain centers</data-title>
+      <source>Morph D Base</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.morphdbase.de/?J_Machon_20190502-M-7.1">J_Machon_20190502-M-7.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphdbase-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.morphdbase.de' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset5" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Neuroanatomy of a hydrothermal vent shrimp provides insights into the evolution of crustacean integrative brain centers</data-title>
+      <source>Morph D Base</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.morphdbase.de/?J_Machon_20190502-M-7.1">J_Machon_20190502-M-7.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-3/data-morphdbase-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-3/data-morphdbase-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-morphdbase-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Morph D Base 'www.morphdbase.de' type link, but is not marked as an accession type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphdbase-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a Morph D Base 'www.morphdbase.de' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset5" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Neuroanatomy of a hydrothermal vent shrimp provides insights into the evolution of crustacean integrative brain centers</data-title>
+      <source>Morph D Base</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://www.morphdbase.de/?J_Machon_20190502-M-7.1">J_Machon_20190502-M-7.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphdbase-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a Morph D Base 'www.morphdbase.de' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset5" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Data from: Neuroanatomy of a hydrothermal vent shrimp provides insights into the evolution of crustacean integrative brain centers</data-title>
+      <source>Morph D Base</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.morphdbase.de/?J_Machon_20190502-M-7.1">J_Machon_20190502-M-7.1</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-1/data-morphosource-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-1/data-morphosource-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (source[1]!='MorphoSource')" role="warning" id="data-morphosource-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17602' but the database name is not 'MorphoSource' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphosource-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (source[1]!='MorphoSource')
+Message: Data reference with the title '' has a doi starting with '10.17602' but the database name is not 'MorphoSource'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset21" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Head, labelled volume (Specimen: LU:4_14:BT_F_5, Bombus terrestris)</data-title>
+      <source>MorphoSourced</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17602/M2/M65327</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphosource-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (source[1]!='MorphoSource')
+Message: Data reference with the title '' has a doi starting with '10.17602' but the database name is not 'MorphoSource'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset21" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Head, labelled volume (Specimen: LU:4_14:BT_F_5, Bombus terrestris)</data-title>
+      <source>MorphoSource</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17602/M2/M65327</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-2/data-morphosource-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-2/data-morphosource-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17602')) and (source[1]='MorphoSource')" role="warning" id="data-morphosource-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17602', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphosource-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17602')) and (source[1]='MorphoSource')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.17602', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset21" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Head, labelled volume (Specimen: LU:4_14:BT_F_5, Bombus terrestris)</data-title>
+      <source>MorphoSource</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17d602/M2/M65327</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphosource-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17602')) and (source[1]='MorphoSource')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.17602', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset21" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Head, labelled volume (Specimen: LU:4_14:BT_F_5, Bombus terrestris)</data-title>
+      <source>MorphoSource</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17602/M2/M65327</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-3/data-morphosource-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-3/data-morphosource-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-morphosource-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a MorphoSource type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphosource-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a MorphoSource type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset21" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Head, labelled volume (Specimen: LU:4_14:BT_F_5, Bombus terrestris)</data-title>
+      <source>MorphoSource</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.17602/M2/M65327</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-morphosource-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a MorphoSource type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset21" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Head, labelled volume (Specimen: LU:4_14:BT_F_5, Bombus terrestris)</data-title>
+      <source>MorphoSource</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17602/M2/M65327</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-1/data-ncbi-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-1/data-ncbi-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-1">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked as an accession number, which is likely incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-ncbi-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[@pub-id-type!='accession']
+Message: Data reference with an NCBI link '' is not marked as an accession number, which is likely incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="archive" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-ncbi-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[@pub-id-type!='accession']
+Message: Data reference with an NCBI link '' is not marked as an accession number, which is likely incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-2/data-ncbi-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-2/data-ncbi-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-2">Data reference with the database source '<value-of select="source[1]"/>' is not marked as an accession number, which is very likely incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-ncbi-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[@pub-id-type!='accession']
+Message: Data reference with the database source '' is not marked as an accession number, which is very likely incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="archive" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-ncbi-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[@pub-id-type!='accession']
+Message: Data reference with the database source '' is not marked as an accession number, which is very likely incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-3/data-ncbi-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-3/data-ncbi-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-3">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-ncbi-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]
+Message: Data reference with an NCBI link '' is not marked with NCBI as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-ncbi-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]
+Message: Data reference with an NCBI link '' is not marked with NCBI as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-4/data-ncbi-test-4.sch
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-4/data-ncbi-test-4.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-4">Data reference with the database source '<value-of select="source[1]"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-4/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-4/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-ncbi-test-4.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]
+Message: Data reference with the database source '' is not marked with NCBI as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-4/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-4/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-ncbi-test-4.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]
+Message: Data reference with the database source '' is not marked with NCBI as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-1/data-neurovault-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-1/data-neurovault-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and not(source[1]='NeuroVault')" role="warning" id="data-neurovault-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but the database name is not 'NeuroVault' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-neurovault-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and not(source[1]='NeuroVault')
+Message: Data reference with the title '' has a 'neurovault.org/collections' type link, but the database name is not 'NeuroVault'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Differential Fear Conditioning Paradigm at 7T with Cerebellar Focus</data-title>
+      <source>NeuroVaults</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-neurovault-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and not(source[1]='NeuroVault')
+Message: Data reference with the title '' has a 'neurovault.org/collections' type link, but the database name is not 'NeuroVault'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Differential Fear Conditioning Paradigm at 7T with Cerebellar Focus</data-title>
+      <source>NeuroVault</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-2/data-neurovault-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-2/data-neurovault-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-neurovault-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Differential Fear Conditioning Paradigm at 7T with Cerebellar Focus</data-title>
+      <source>NeuroVault</source>
+      <pub-id assigning-authority="EBI" pub-id-type="archive" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-neurovault-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Differential Fear Conditioning Paradigm at 7T with Cerebellar Focus</data-title>
+      <source>NeuroVault</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/data-neurovault-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/data-neurovault-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-neurovault-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
+Message: Data reference with the title '' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Differential Fear Conditioning Paradigm at 7T with Cerebellar Focus</data-title>
+      <source>NeuroVault</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-neurovault-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
+Message: Data reference with the title '' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Differential Fear Conditioning Paradigm at 7T with Cerebellar Focus</data-title>
+      <source>NeuroVault</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-nucleotide-test/data-nucleotide-test.sch
+++ b/test/tests/gen/data-ref-tests/data-nucleotide-test/data-nucleotide-test.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/nuccore') and not(source[1]='NCBI GenBank') and not(source[1]='NCBI Nucleotide')" role="warning" id="data-nucleotide-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/nuccore' type link, but the database name is not 'NCBI Nucleotide' or 'NCBI GenBank' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-nucleotide-test/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-nucleotide-test/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-nucleotide-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/nuccore') and not(source[1]='NCBI GenBank') and not(source[1]='NCBI Nucleotide')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/nuccore' type link, but the database name is not 'NCBI Nucleotide' or 'NCBI GenBank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI Genbank</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-nucleotide-test/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-nucleotide-test/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-nucleotide-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/nuccore') and not(source[1]='NCBI GenBank') and not(source[1]='NCBI Nucleotide')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/nuccore' type link, but the database name is not 'NCBI Nucleotide' or 'NCBI GenBank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset30" publication-type="data" specific-use="references">
+      <year iso-8601-date="2013">2013</year>
+      <data-title>Haliotis cracherodii sperm protein 6kDa mRNA, complete cds</data-title>
+      <source>NCBI GenBank</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/nuccore/KC752602">KC752602</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-1/data-openneuro-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-1/data-openneuro-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (source[1]!='OpenNeuro')" role="warning" id="data-openneuro-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.18112/openneuro' but the database name is not 'OpenNeuro' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-openneuro-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (source[1]!='OpenNeuro')
+Message: Data reference with the title '' has a doi starting with '10.18112/openneuro' but the database name is not 'OpenNeuro'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Alpha/beta power decreases track the fidelity of stimulus-specific information</data-title>
+      <source>OpenNeurod</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.18112/openneuro.ds002000.v1.0.0</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-openneuro-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (source[1]!='OpenNeuro')
+Message: Data reference with the title '' has a doi starting with '10.18112/openneuro' but the database name is not 'OpenNeuro'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Alpha/beta power decreases track the fidelity of stimulus-specific information</data-title>
+      <source>OpenNeuro</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.18112/openneuro.ds002000.v1.0.0</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-2/data-openneuro-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-2/data-openneuro-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro')) and not(contains(pub-id[1]/@xlink:href,'openneuro.org/datasets')) and (source[1]='OpenNeuro')" role="warning" id="data-openneuro-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.18112/openneuro' or 'openneuro.org/datasets' type link, which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-openneuro-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro')) and not(contains(pub-id[1]/@xlink:href,'openneuro.org/datasets')) and (source[1]='OpenNeuro')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.18112/openneuro' or 'openneuro.org/datasets' type link, which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Alpha/beta power decreases track the fidelity of stimulus-specific information</data-title>
+      <source>OpenNeuro</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.18d112/openneuro.ds002000.v1.0.0</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-openneuro-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro')) and not(contains(pub-id[1]/@xlink:href,'openneuro.org/datasets')) and (source[1]='OpenNeuro')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.18112/openneuro' or 'openneuro.org/datasets' type link, which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Alpha/beta power decreases track the fidelity of stimulus-specific information</data-title>
+      <source>OpenNeuro</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.18112/openneuro.ds002000.v1.0.0</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-3/data-openneuro-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-3/data-openneuro-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-openneuro-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a OpenNeuro type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-openneuro-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a OpenNeuro type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Alpha/beta power decreases track the fidelity of stimulus-specific information</data-title>
+      <source>OpenNeuro</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.18112/openneuro.ds002000.v1.0.0</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-openneuro-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a OpenNeuro type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Alpha/beta power decreases track the fidelity of stimulus-specific information</data-title>
+      <source>OpenNeuro</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.18112/openneuro.ds002000.v1.0.0</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-1/data-osf-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-1/data-osf-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and not(source[1]='Open Science Framework')" role="warning" id="data-osf-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-osf-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-1/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and not(source[1]='Open Science Framework')
+Message: Data reference with the title '' has a 'https://osf.io' type link, but the database name is not 'Open Science Framework'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Leonhard</surname>
+          <given-names>Waschke</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>RealNoi</data-title>
+      <source>Open Science Frameworks</source>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="archive" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-1/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and not(source[1]='Open Science Framework')
+Message: Data reference with the title '' has a 'https://osf.io' type link, but the database name is not 'Open Science Framework'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Leonhard</surname>
+          <given-names>Waschke</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>RealNoi</data-title>
+      <source>Open Science Framework</source>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="archive" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-2/data-osf-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-2/data-osf-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-osf-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-2/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Leonhard</surname>
+          <given-names>Waschke</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>RealNoi</data-title>
+      <source>Open Science Framework</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-2/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Leonhard</surname>
+          <given-names>Waschke</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>RealNoi</data-title>
+      <source>Open Science Framework</source>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="archive" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/data-osf-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/data-osf-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
+Message: Data reference with the title '' has an OSF 'https://osf.io' type link, but is not marked as an archive type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Leonhard</surname>
+          <given-names>Waschke</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>RealNoi</data-title>
+      <source>Open Science Framework</source>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="accession" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
+Message: Data reference with the title '' has an OSF 'https://osf.io' type link, but is not marked as an archive type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Leonhard</surname>
+          <given-names>Waschke</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>RealNoi</data-title>
+      <source>Open Science Framework</source>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="archive" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-4/data-osf-test-4.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-4/data-osf-test-4.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-osf-test-4/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-4/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-4.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')
+Message: Data reference with the title '' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Hutchinson</surname>
+          <given-names>JR</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2016">2016</year>
+      <data-title>Hatchling Palaeosuchus palpebrosus RVC-JRH-PP1 whole body</data-title>
+      <source>CrocBase</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17605/OSF.IO/X38NH</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-4/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-4/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-4.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')
+Message: Data reference with the title '' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Hutchinson</surname>
+          <given-names>JR</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2016">2016</year>
+      <data-title>Hatchling Palaeosuchus palpebrosus RVC-JRH-PP1 whole body</data-title>
+      <source>Open Science Framework</source>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="doi">10.17605/OSF.IO/X38NH</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-5/data-osf-test-5.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-5/data-osf-test-5.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (pub-id[1][@assigning-authority!='Open Science Framework'  or not(@assigning-authority)])" role="warning" id="data-osf-test-5">Data reference with the title '<value-of select="data-title[1]"/>' has a OSF type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Open Science Framework, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-osf-test-5/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-5/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-5.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)])
+Message: Data reference with the title '' has a OSF type doi  , but the assigning authority is not Open Science Framework, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Hutchinson</surname>
+          <given-names>JR</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2016">2016</year>
+      <data-title>Hatchling Palaeosuchus palpebrosus RVC-JRH-PP1 whole body</data-title>
+      <source>Open Science Framework</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.17605/OSF.IO/X38NH</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-5/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-5/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-osf-test-5.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)])
+Message: Data reference with the title '' has a OSF type doi  , but the assigning authority is not Open Science Framework, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Hutchinson</surname>
+          <given-names>JR</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2016">2016</year>
+      <data-title>Hatchling Palaeosuchus palpebrosus RVC-JRH-PP1 whole body</data-title>
+      <source>Open Science Framework</source>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="doi">10.17605/OSF.IO/X38NH</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pbd-test-1/data-pbd-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-pbd-test-1/data-pbd-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1]/@xlink:href,'http://www.rcsb.org/pdb') and not(source[1]='RCSB Protein Data Bank')" role="warning" id="data-pbd-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org/pdb' type link, but the database name is not 'RCSB Protein Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-pbd-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-pbd-test-1/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-pbd-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1]/@xlink:href,'http://www.rcsb.org/pdb') and not(source[1]='RCSB Protein Data Bank')
+Message: Data reference with the title '' has a 'http://www.rcsb.org/pdb' type link, but the database name is not 'RCSB Protein Data Bank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Lü</surname>
+          <given-names>W</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Cryo-EM density map and coordinate of TRPC3</data-title>
+      <source>RCSB Protein Data Banks</source>
+      <pub-id assigning-authority="RCSB" pub-id-type="accession" xlink:href="http://www.rcsb.org/pdb/search/structidSearch.do?structureId=6CUD">6CUD</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pbd-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-pbd-test-1/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-pbd-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1]/@xlink:href,'http://www.rcsb.org/pdb') and not(source[1]='RCSB Protein Data Bank')
+Message: Data reference with the title '' has a 'http://www.rcsb.org/pdb' type link, but the database name is not 'RCSB Protein Data Bank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Lü</surname>
+          <given-names>W</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Cryo-EM density map and coordinate of TRPC3</data-title>
+      <source>RCSB Protein Data Bank</source>
+      <pub-id assigning-authority="RCSB" pub-id-type="accession" xlink:href="http://www.rcsb.org/pdb/search/structidSearch.do?structureId=6CUD">6CUD</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pbd-test-2/data-pbd-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-pbd-test-2/data-pbd-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1]/@xlink:href,'http://www.rcsb.org/pdb') and  pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]" role="warning" id="data-pbd-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org/pdb' type link, but is not marked with PBD as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-pbd-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-pbd-test-2/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-pbd-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1]/@xlink:href,'http://www.rcsb.org/pdb') and pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://www.rcsb.org/pdb' type link, but is not marked with PBD as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Lü</surname>
+          <given-names>W</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Cryo-EM density map and coordinate of TRPC3</data-title>
+      <source>RCSB Protein Data Bank</source>
+      <pub-id assigning-authority="RCSB" pub-id-type="accession" xlink:href="http://www.rcsb.org/pdb/search/structidSearch.do?structureId=6CUD">6CUD</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pbd-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-pbd-test-2/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="data-pbd-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1]/@xlink:href,'http://www.rcsb.org/pdb') and pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://www.rcsb.org/pdb' type link, but is not marked with PBD as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Lü</surname>
+          <given-names>W</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2018">2018</year>
+      <data-title>Cryo-EM density map and coordinate of TRPC3</data-title>
+      <source>RCSB Protein Data Bank</source>
+      <pub-id assigning-authority="PBD" pub-id-type="accession" xlink:href="http://www.rcsb.org/pdb/search/structidSearch.do?structureId=6CUD">6CUD</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-popset-test/data-popset-test.sch
+++ b/test/tests/gen/data-ref-tests/data-popset-test/data-popset-test.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/popset') and not(source[1]='NCBI PopSet')" role="warning" id="data-popset-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/popset' type link, but the database name is not 'NCBI PopSet' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-popset-test/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-popset-test/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-popset-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/popset') and not(source[1]='NCBI PopSet')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/popset' type link, but the database name is not 'NCBI PopSet'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="references">
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Pinguinus impennis mitochondrion, complete genome</data-title>
+      <source>PopSet</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/popset/?term=1208276182">1208276182</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-popset-test/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-popset-test/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-popset-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/popset') and not(source[1]='NCBI PopSet')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/popset' type link, but the database name is not 'NCBI PopSet'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="references">
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Pinguinus impennis mitochondrion, complete genome</data-title>
+      <source>NCBI PopSet</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/popset/?term=1208276182">1208276182</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pride-test-1/data-pride-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-pride-test-1/data-pride-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and not(source[1]='PRIDE')" role="warning" id="data-pride-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but the database name is not 'PRIDE' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-pride-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-pride-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-pride-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and not(source[1]='PRIDE')
+Message: Data reference with the title '' has a 'www.ebi.ac.uk/pride' type link, but the database name is not 'PRIDE'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cell-specific non-canonical amino acid labelling identifies changes in the hippocampal de novo proteome during memory formation</data-title>
+      <source>pride</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pride/archive/projects/PXD015820">PXD015820</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pride-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-pride-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-pride-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and not(source[1]='PRIDE')
+Message: Data reference with the title '' has a 'www.ebi.ac.uk/pride' type link, but the database name is not 'PRIDE'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cell-specific non-canonical amino acid labelling identifies changes in the hippocampal de novo proteome during memory formation</data-title>
+      <source>PRIDE</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pride/archive/projects/PXD015820">PXD015820</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pride-test-2/data-pride-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-pride-test-2/data-pride-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-pride-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-pride-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-pride-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-pride-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.ebi.ac.uk/pride' type link, but is not marked with EBI as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cell-specific non-canonical amino acid labelling identifies changes in the hippocampal de novo proteome during memory formation</data-title>
+      <source>PRIDE</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pride/archive/projects/PXD015820">PXD015820</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pride-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-pride-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-pride-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'www.ebi.ac.uk/pride' type link, but is not marked with EBI as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cell-specific non-canonical amino acid labelling identifies changes in the hippocampal de novo proteome during memory formation</data-title>
+      <source>PRIDE</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pride/archive/projects/PXD015820">PXD015820</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pride-test-3/data-pride-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-pride-test-3/data-pride-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-pride-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PRIDE 'www.ebi.ac.uk/pride' type link, but is not marked as an accession type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-pride-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-pride-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-pride-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a PRIDE 'www.ebi.ac.uk/pride' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cell-specific non-canonical amino acid labelling identifies changes in the hippocampal de novo proteome during memory formation</data-title>
+      <source>PRIDE</source>
+      <pub-id assigning-authority="EBI" pub-id-type="archive" xlink:href="https://www.ebi.ac.uk/pride/archive/projects/PXD015820">PXD015820</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-pride-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-pride-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-pride-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a PRIDE 'www.ebi.ac.uk/pride' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Cell-specific non-canonical amino acid labelling identifies changes in the hippocampal de novo proteome during memory formation</data-title>
+      <source>PRIDE</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pride/archive/projects/PXD015820">PXD015820</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-1/data-proteomexchange-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-1/data-proteomexchange-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and not(source[1]='ProteomeXchange')" role="warning" id="data-proteomexchange-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but the database name is not 'ProteomeXchange' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-proteomexchange-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and not(source[1]='ProteomeXchange')
+Message: Data reference with the title '' has a 'http://proteomecentral.proteomexchange.org/' type link, but the database name is not 'ProteomeXchange'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Genome-wide CRISPR screening reveals genetic modifiers of mutant EGFR dependence in NSCLC</data-title>
+      <source>Pride</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD014198">PXD014198</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-proteomexchange-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and not(source[1]='ProteomeXchange')
+Message: Data reference with the title '' has a 'http://proteomecentral.proteomexchange.org/' type link, but the database name is not 'ProteomeXchange'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Genome-wide CRISPR screening reveals genetic modifiers of mutant EGFR dependence in NSCLC</data-title>
+      <source>ProteomeXchange</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD014198">PXD014198</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-2/data-proteomexchange-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-2/data-proteomexchange-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-proteomexchange-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but is not marked with 'other' as its assigning authority, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-proteomexchange-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://proteomecentral.proteomexchange.org/' type link, but is not marked with 'other' as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Genome-wide CRISPR screening reveals genetic modifiers of mutant EGFR dependence in NSCLC</data-title>
+      <source>ProteomeXchange</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD014198">PXD014198</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-proteomexchange-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://proteomecentral.proteomexchange.org/' type link, but is not marked with 'other' as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Genome-wide CRISPR screening reveals genetic modifiers of mutant EGFR dependence in NSCLC</data-title>
+      <source>ProteomeXchange</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD014198">PXD014198</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-3/data-proteomexchange-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-3/data-proteomexchange-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-proteomexchange-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ProteomeXchange 'http://proteomecentral.proteomexchange.org/' type link, but is not marked as an accession type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-proteomexchange-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a ProteomeXchange 'http://proteomecentral.proteomexchange.org/' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Genome-wide CRISPR screening reveals genetic modifiers of mutant EGFR dependence in NSCLC</data-title>
+      <source>ProteomeXchange</source>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD014198">PXD014198</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-proteomexchange-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a ProteomeXchange 'http://proteomecentral.proteomexchange.org/' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Genome-wide CRISPR screening reveals genetic modifiers of mutant EGFR dependence in NSCLC</data-title>
+      <source>ProteomeXchange</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=PXD014198">PXD014198</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-1/data-rcsbpbd-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-1/data-rcsbpbd-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and not(source[1]='RCSB Protein Data Bank')" role="warning" id="data-rcsbpbd-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but the database name is not 'RCSB Protein Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-1/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-rcsbpbd-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.rcsb.org') and not(source[1]='RCSB Protein Data Bank')
+Message: Data reference with the title '' has a 'http://www.rcsb.org' type link, but the database name is not 'RCSB Protein Data Bank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>Protein Data Bank</source>
+      <pub-id assigning-authority="PDB" pub-id-type="accession" xlink:href="https://www.rcsb.org/structure/6V3G">PDB 6V3G</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-1/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-rcsbpbd-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.rcsb.org') and not(source[1]='RCSB Protein Data Bank')
+Message: Data reference with the title '' has a 'http://www.rcsb.org' type link, but the database name is not 'RCSB Protein Data Bank'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>RCSB Protein Data Bank</source>
+      <pub-id assigning-authority="PDB" pub-id-type="accession" xlink:href="https://www.rcsb.org/structure/6V3G">PDB 6V3G</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-2/data-rcsbpbd-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-2/data-rcsbpbd-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and  pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]" role="warning" id="data-rcsbpbd-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but is not marked with PBD as its assigning authority, which must be incorrect</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-2/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-rcsbpbd-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://www.rcsb.org' type link, but is not marked with PBD as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>RCSB Protein Data Bank</source>
+      <pub-id assigning-authority="PDB" pub-id-type="accession" xlink:href="https://www.rcsb.org/structure/6V3G">PDB 6V3G</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-2/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-rcsbpbd-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://www.rcsb.org' type link, but is not marked with PBD as its assigning authority, which must be incorrect-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>RCSB Protein Data Bank</source>
+      <pub-id assigning-authority="PBD" pub-id-type="accession" xlink:href="https://www.rcsb.org/structure/6V3G">PDB 6V3G</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-3/data-rcsbpbd-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-3/data-rcsbpbd-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-3/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-rcsbpbd-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>RCSB Protein Data Bank</source>
+      <pub-id assigning-authority="PBD" pub-id-type="archive" xlink:href="https://www.rcsb.org/structure/6V3G">PDB 6V3G</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-3/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-rcsbpbd-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset4" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Tao</surname>
+          <given-names>X</given-names>
+        </name>
+        <name>
+          <surname>MacKinnon</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Single particle cryo-EM structure of Ca2+-free (closed) hsSlo1</data-title>
+      <source>RCSB Protein Data Bank</source>
+      <pub-id assigning-authority="PBD" pub-id-type="accession" xlink:href="https://www.rcsb.org/structure/6V3G">PDB 6V3G</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-1/data-sbgdb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-1/data-sbgdb-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-1/fail.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-sbgdb-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')
+Message: Data reference with the title '' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Bane</surname>
+          <given-names>LB</given-names>
+        </name>
+        <name>
+          <surname>Weihofen</surname>
+          <given-names>WA</given-names>
+        </name>
+        <name>
+          <surname>Gaudet</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2011">2011</year>
+      <data-title>X-Ray Diffraction data from Deinococcus radiodurans MntH in complex with Fab, source of 5KTE structure</data-title>
+      <source>SBGrid Data Banks</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.15785/SBGRID/334</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-1/pass.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-sbgdb-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')
+Message: Data reference with the title '' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Bane</surname>
+          <given-names>LB</given-names>
+        </name>
+        <name>
+          <surname>Weihofen</surname>
+          <given-names>WA</given-names>
+        </name>
+        <name>
+          <surname>Gaudet</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2011">2011</year>
+      <data-title>X-Ray Diffraction data from Deinococcus radiodurans MntH in complex with Fab, source of 5KTE structure</data-title>
+      <source>SBGrid Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.15785/SBGRID/334</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-2/data-sbgdb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-2/data-sbgdb-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID')) and (source[1]='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.15785/SBGRID', which is likely incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-2/fail.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-sbgdb-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID')) and (source[1]='SBGrid Data Bank')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.15785/SBGRID', which is likely incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Bane</surname>
+          <given-names>LB</given-names>
+        </name>
+        <name>
+          <surname>Weihofen</surname>
+          <given-names>WA</given-names>
+        </name>
+        <name>
+          <surname>Gaudet</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2011">2011</year>
+      <data-title>X-Ray Diffraction data from Deinococcus radiodurans MntH in complex with Fab, source of 5KTE structure</data-title>
+      <source>SBGrid Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.1d5785/SBGRID/334</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-2/pass.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-sbgdb-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID')) and (source[1]='SBGrid Data Bank')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.15785/SBGRID', which is likely incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Bane</surname>
+          <given-names>LB</given-names>
+        </name>
+        <name>
+          <surname>Weihofen</surname>
+          <given-names>WA</given-names>
+        </name>
+        <name>
+          <surname>Gaudet</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2011">2011</year>
+      <data-title>X-Ray Diffraction data from Deinococcus radiodurans MntH in complex with Fab, source of 5KTE structure</data-title>
+      <source>SBGrid Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.15785/SBGRID/334</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-3/data-sbgdb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-3/data-sbgdb-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-sbgdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a SBGrid Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-3/fail.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-sbgdb-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a SBGrid Data Bank type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Bane</surname>
+          <given-names>LB</given-names>
+        </name>
+        <name>
+          <surname>Weihofen</surname>
+          <given-names>WA</given-names>
+        </name>
+        <name>
+          <surname>Gaudet</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2011">2011</year>
+      <data-title>X-Ray Diffraction data from Deinococcus radiodurans MntH in complex with Fab, source of 5KTE structure</data-title>
+      <source>SBGrid Data Bank</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.15785/SBGRID/334</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-3/pass.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-sbgdb-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a SBGrid Data Bank type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset10" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Bane</surname>
+          <given-names>LB</given-names>
+        </name>
+        <name>
+          <surname>Weihofen</surname>
+          <given-names>WA</given-names>
+        </name>
+        <name>
+          <surname>Gaudet</surname>
+          <given-names>R</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2011">2011</year>
+      <data-title>X-Ray Diffraction data from Deinococcus radiodurans MntH in complex with Fab, source of 5KTE structure</data-title>
+      <source>SBGrid Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.15785/SBGRID/334</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-sra-test/data-sra-test.sch
+++ b/test/tests/gen/data-ref-tests/data-sra-test/data-sra-test.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/sra') and not(source[1]='NCBI Sequence Read Archive')" role="warning" id="data-sra-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/sra' type link, but the database name is not 'NCBI Sequence Read Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-sra-test/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-sra-test/fail.xml
@@ -1,0 +1,32 @@
+<?oxygen SCHSchema="data-sra-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/sra') and not(source[1]='NCBI Sequence Read Archive')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/sra' type link, but the database name is not 'NCBI Sequence Read Archive'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Greenblatt</surname>
+          <given-names>EJ</given-names>
+        </name>
+        <name>
+          <surname>Obniski</surname>
+          <given-names>R</given-names>
+        </name>
+        <name>
+          <surname>Michael</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Spradling</surname>
+          <given-names>AC</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Ribosome profiling and mRNA sequencing of aging oocytes in Drosophila.</data-title>
+      <source>NCBI Bioprojects</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/sra/PRJNA573922">PRJNA57392</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-sra-test/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-sra-test/pass.xml
@@ -1,0 +1,32 @@
+<?oxygen SCHSchema="data-sra-test.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/sra') and not(source[1]='NCBI Sequence Read Archive')
+Message: Data reference with the title '' has a 'https://www.ncbi.nlm.nih.gov/sra' type link, but the database name is not 'NCBI Sequence Read Archive'  . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Greenblatt</surname>
+          <given-names>EJ</given-names>
+        </name>
+        <name>
+          <surname>Obniski</surname>
+          <given-names>R</given-names>
+        </name>
+        <name>
+          <surname>Michael</surname>
+          <given-names>C</given-names>
+        </name>
+        <name>
+          <surname>Spradling</surname>
+          <given-names>AC</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Ribosome profiling and mRNA sequencing of aging oocytes in Drosophila.</data-title>
+      <source>NCBI Sequence Read Archive</source>
+      <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/sra/PRJNA573922">PRJNA57392</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-1/data-synapse-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-1/data-synapse-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (source[1]!='Synapse')" role="warning" id="data-synapse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7303/syn' but the database name is not 'Synapse' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-1/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-synapse-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (source[1]!='Synapse')
+Message: Data reference with the title '' has a doi starting with '10.7303/syn' but the database name is not 'Synapse'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Source Data: Optical dopamine monitoring with dLight1 reveals mesolimbic phenotypes in a mouse model of neurofibromatosis type 1</data-title>
+      <source>Synapses</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7303/syn18904024</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-1/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-synapse-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (source[1]!='Synapse')
+Message: Data reference with the title '' has a doi starting with '10.7303/syn' but the database name is not 'Synapse'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Source Data: Optical dopamine monitoring with dLight1 reveals mesolimbic phenotypes in a mouse model of neurofibromatosis type 1</data-title>
+      <source>Synapse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7303/syn18904024</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-2/data-synapse-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-2/data-synapse-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn')) and (source[1]='Synapse')" role="warning" id="data-synapse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7303/syn', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-2/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-synapse-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn')) and (source[1]='Synapse')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.7303/syn', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Source Data: Optical dopamine monitoring with dLight1 reveals mesolimbic phenotypes in a mouse model of neurofibromatosis type 1</data-title>
+      <source>Synapse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7s303/syn18904024</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-2/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-synapse-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn')) and (source[1]='Synapse')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.7303/syn', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Source Data: Optical dopamine monitoring with dLight1 reveals mesolimbic phenotypes in a mouse model of neurofibromatosis type 1</data-title>
+      <source>Synapse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7303/syn18904024</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-3/data-synapse-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-3/data-synapse-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-synapse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Synapse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-3/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-synapse-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Synapse type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Source Data: Optical dopamine monitoring with dLight1 reveals mesolimbic phenotypes in a mouse model of neurofibromatosis type 1</data-title>
+      <source>Synapse</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.7303/syn18904024</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-synapse-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-3/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="data-synapse-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Synapse type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Source Data: Optical dopamine monitoring with dLight1 reveals mesolimbic phenotypes in a mouse model of neurofibromatosis type 1</data-title>
+      <source>Synapse</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.7303/syn18904024</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-1/data-wwpdb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-1/data-wwpdb-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-1/fail.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-wwpdb-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')
+Message: Data reference with the title '' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Qingfeng</surname>
+          <given-names>Chen</given-names>
+        </name>
+        <name>
+          <surname>Xiao-chen</surname>
+          <given-names>Bai</given-names>
+        </name>
+        <name>
+          <surname>Youxing</surname>
+          <given-names>Jiang</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Atomic coordinates of OTOP3 from xenopus tropicalis</data-title>
+      <source>Protein Data Bank</source>
+      <pub-id assigning-authority="RCSB" pub-id-type="doi">10.2210/pdb6O84/pdb</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-1/pass.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-wwpdb-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')
+Message: Data reference with the title '' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Qingfeng</surname>
+          <given-names>Chen</given-names>
+        </name>
+        <name>
+          <surname>Xiao-chen</surname>
+          <given-names>Bai</given-names>
+        </name>
+        <name>
+          <surname>Youxing</surname>
+          <given-names>Jiang</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Atomic coordinates of OTOP3 from xenopus tropicalis</data-title>
+      <source>Worldwide Protein Data Bank</source>
+      <pub-id assigning-authority="RCSB" pub-id-type="doi">10.2210/pdb6O84/pdb</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-2/data-wwpdb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-2/data-wwpdb-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-2/fail.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-wwpdb-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.2210', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Qingfeng</surname>
+          <given-names>Chen</given-names>
+        </name>
+        <name>
+          <surname>Xiao-chen</surname>
+          <given-names>Bai</given-names>
+        </name>
+        <name>
+          <surname>Youxing</surname>
+          <given-names>Jiang</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Atomic coordinates of OTOP3 from xenopus tropicalis</data-title>
+      <source>Worldwide Protein Data Bank</source>
+      <pub-id assigning-authority="RCSB" pub-id-type="doi">10.22d10/pdb6O84/pdb</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-2/pass.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-wwpdb-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')
+Message: Data reference with the title '' has the database name , but no doi starting with '10.2210', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Qingfeng</surname>
+          <given-names>Chen</given-names>
+        </name>
+        <name>
+          <surname>Xiao-chen</surname>
+          <given-names>Bai</given-names>
+        </name>
+        <name>
+          <surname>Youxing</surname>
+          <given-names>Jiang</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Atomic coordinates of OTOP3 from xenopus tropicalis</data-title>
+      <source>Worldwide Protein Data Bank</source>
+      <pub-id assigning-authority="RCSB" pub-id-type="doi">10.2210/pdb6O84/pdb</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-3/data-wwpdb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-3/data-wwpdb-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-3/data-wwpdb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-3/data-wwpdb-test-3.sch
@@ -685,7 +685,7 @@
   </xsl:function>
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
-      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='PDB'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'PDB', which must be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-3/fail.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-wwpdb-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Worldwide Protein Data Bank type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Qingfeng</surname>
+          <given-names>Chen</given-names>
+        </name>
+        <name>
+          <surname>Xiao-chen</surname>
+          <given-names>Bai</given-names>
+        </name>
+        <name>
+          <surname>Youxing</surname>
+          <given-names>Jiang</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Atomic coordinates of OTOP3 from xenopus tropicalis</data-title>
+      <source>Worldwide Protein Data Bank</source>
+      <pub-id assigning-authority="RCSB" pub-id-type="doi">10.2210/pdb6O84/pdb</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="data-wwpdb-test-3.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
-Message: Data reference with the title '' has a Worldwide Protein Data Bank type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='PDB' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Worldwide Protein Data Bank type doi  , but the assigning authority is not 'PDB', which must be incorrect.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="data-wwpdb-test-3.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
-Message: Data reference with the title '' has a Worldwide Protein Data Bank type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='PDB' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Worldwide Protein Data Bank type doi  , but the assigning authority is not 'PDB', which must be incorrect.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
@@ -22,7 +22,7 @@ Message: Data reference with the title '' has a Worldwide Protein Data Bank type
       <year iso-8601-date="2019">2019</year>
       <data-title>Atomic coordinates of OTOP3 from xenopus tropicalis</data-title>
       <source>Worldwide Protein Data Bank</source>
-      <pub-id assigning-authority="other" pub-id-type="doi">10.2210/pdb6O84/pdb</pub-id>
+      <pub-id assigning-authority="PDB" pub-id-type="doi">10.2210/pdb6O84/pdb</pub-id>
     </element-citation>
   </article>
 </root>

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-3/pass.xml
@@ -1,0 +1,28 @@
+<?oxygen SCHSchema="data-wwpdb-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Worldwide Protein Data Bank type doi  , but the assigning authority is not 'other', which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="isSupplementedBy">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Qingfeng</surname>
+          <given-names>Chen</given-names>
+        </name>
+        <name>
+          <surname>Xiao-chen</surname>
+          <given-names>Bai</given-names>
+        </name>
+        <name>
+          <surname>Youxing</surname>
+          <given-names>Jiang</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2019">2019</year>
+      <data-title>Atomic coordinates of OTOP3 from xenopus tropicalis</data-title>
+      <source>Worldwide Protein Data Bank</source>
+      <pub-id assigning-authority="other" pub-id-type="doi">10.2210/pdb6O84/pdb</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-1/data-zenodo-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-1/data-zenodo-test-1.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (source[1]!='Zenodo')" role="warning" id="data-zenodo-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5281/zenodo' but the database name is not 'Zenodo' - <value-of select="source[1]"/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-1/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-zenodo-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (source[1]!='Zenodo')
+Message: Data reference with the title '' has a doi starting with '10.5281/zenodo' but the database name is not 'Zenodo'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Massimini</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Laureys</surname>
+          <given-names>S</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Rest EEG recordings in healthy subjects during wakefulness, sleep and anesthesia with ketamine, propofol, and xenon</data-title>
+      <source>Zenodos</source>
+      <pub-id assigning-authority="Zenodo" pub-id-type="doi">10.5281/zenodo.806176</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-1/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-zenodo-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (source[1]!='Zenodo')
+Message: Data reference with the title '' has a doi starting with '10.5281/zenodo' but the database name is not 'Zenodo'  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Massimini</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Laureys</surname>
+          <given-names>S</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Rest EEG recordings in healthy subjects during wakefulness, sleep and anesthesia with ketamine, propofol, and xenon</data-title>
+      <source>Zenodo</source>
+      <pub-id assigning-authority="Zenodo" pub-id-type="doi">10.5281/zenodo.806176</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-2/data-zenodo-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-2/data-zenodo-test-2.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo')) and (source[1]='Zenodo')" role="warning" id="data-zenodo-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5281/zenodo', which is incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-2/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-zenodo-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo')) and (source[1]='Zenodo')
+Message: Data reference with the title '' has the database name  , but no doi starting with '10.5281/zenodo', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Massimini</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Laureys</surname>
+          <given-names>S</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Rest EEG recordings in healthy subjects during wakefulness, sleep and anesthesia with ketamine, propofol, and xenon</data-title>
+      <source>Zenodo</source>
+      <pub-id assigning-authority="Zenodo" pub-id-type="doi">10.528d1/zenodo.806176</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-2/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-zenodo-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo')) and (source[1]='Zenodo')
+Message: Data reference with the title '' has the database name  , but no doi starting with '10.5281/zenodo', which is incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Massimini</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Laureys</surname>
+          <given-names>S</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Rest EEG recordings in healthy subjects during wakefulness, sleep and anesthesia with ketamine, propofol, and xenon</data-title>
+      <source>Zenodo</source>
+      <pub-id assigning-authority="Zenodo" pub-id-type="doi">10.5281/zenodo.806176</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-3/data-zenodo-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-3/data-zenodo-test-3.sch
@@ -1,0 +1,696 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (pub-id[1][@assigning-authority!='Zenodo'  or not(@assigning-authority)])" role="warning" id="data-zenodo-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Zenodo type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Zenodo, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-3/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-zenodo-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (pub-id[1][@assigning-authority!='Zenodo' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Zenodo type doi  , but the assigning authority is not Zenodo, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Massimini</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Laureys</surname>
+          <given-names>S</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Rest EEG recordings in healthy subjects during wakefulness, sleep and anesthesia with ketamine, propofol, and xenon</data-title>
+      <source>Zenodo</source>
+      <pub-id assigning-authority="EBI" pub-id-type="doi">10.5281/zenodo.806176</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-3/pass.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="data-zenodo-test-3.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (pub-id[1][@assigning-authority!='Zenodo' or not(@assigning-authority)])
+Message: Data reference with the title '' has a Zenodo type doi  , but the assigning authority is not Zenodo, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation id="dataset2" publication-type="data" specific-use="references">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Massimini</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Laureys</surname>
+          <given-names>S</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2017">2017</year>
+      <data-title>Rest EEG recordings in healthy subjects during wakefulness, sleep and anesthesia with ketamine, propofol, and xenon</data-title>
+      <source>Zenodo</source>
+      <pub-id assigning-authority="Zenodo" pub-id-type="doi">10.5281/zenodo.806176</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-10/fig-xref-test-10.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-10/fig-xref-test-10.sch
@@ -691,7 +691,7 @@
       <let name="target-no" value="replace($rid,'[^0-9]+','')"/>
       <let name="pre-text" value="preceding-sibling::text()[1]"/>
       <let name="post-text" value="following-sibling::text()[1]"/>
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="error" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="warning" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-11/fig-xref-test-11.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-11/fig-xref-test-11.sch
@@ -691,7 +691,7 @@
       <let name="target-no" value="replace($rid,'[^0-9]+','')"/>
       <let name="pre-text" value="preceding-sibling::text()[1]"/>
       <let name="post-text" value="following-sibling::text()[1]"/>
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="error" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="warning" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-12/fig-xref-test-12.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-12/fig-xref-test-12.sch
@@ -691,7 +691,7 @@
       <let name="target-no" value="replace($rid,'[^0-9]+','')"/>
       <let name="pre-text" value="preceding-sibling::text()[1]"/>
       <let name="post-text" value="following-sibling::text()[1]"/>
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="error" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="warning" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-2/fail.xml
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-2/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="inline-formula-test-2.sch"?>
 <!--Context: inline-formula
-Test: report    matches($pre-text,'[\p{L}\p{N}\p{M}]$') and not(matches(.,'^\s+'))
+Test: report    matches($pre-text,'[\p{L}\p{N}\p{M}]$')
 Message: There is no space between inlineformula and the preceding text    Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-2/inline-formula-test-2.sch
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-2/inline-formula-test-2.sch
@@ -687,7 +687,7 @@
     <rule context="inline-formula" id="inline-formula-tests">
       <let name="pre-text" value="preceding-sibling::text()[1]"/>
       <let name="post-text" value="following-sibling::text()[1]"/>
-      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$') and not(matches(.,'^\s+'))" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
+      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$')" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-2/pass.xml
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-2/pass.xml
@@ -1,11 +1,9 @@
 <?oxygen SCHSchema="inline-formula-test-2.sch"?>
 <!--Context: inline-formula
-Test: report    matches($pre-text,'[\p{L}\p{N}\p{M}]$') and not(matches(.,'^\s+'))
+Test: report    matches($pre-text,'[\p{L}\p{N}\p{M}]$')
 Message: There is no space between inlineformula and the preceding text    Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
-    <p>test<inline-formula>
-        <mml:math/>
-      </inline-formula>test</p>
+    <p>test <italic>test</italic> test <inline-formula><mml:math/></inline-formula>test</p>
   </article>
 </root>

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-3/fail.xml
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-3/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="inline-formula-test-3.sch"?>
 <!--Context: inline-formula
-Test: report    matches($post-text,'^[\p{L}\p{N}\p{M}]') and not(matches(.,'\s+$'))
+Test: report    matches($post-text,'^[\p{L}\p{N}\p{M}]')
 Message: There is no space between inlineformula and the following text    Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-3/inline-formula-test-3.sch
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-3/inline-formula-test-3.sch
@@ -687,7 +687,7 @@
     <rule context="inline-formula" id="inline-formula-tests">
       <let name="pre-text" value="preceding-sibling::text()[1]"/>
       <let name="post-text" value="following-sibling::text()[1]"/>
-      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]') and not(matches(.,'\s+$'))" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
+      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]')" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-3/pass.xml
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-3/pass.xml
@@ -1,11 +1,9 @@
 <?oxygen SCHSchema="inline-formula-test-3.sch"?>
 <!--Context: inline-formula
-Test: report    matches($post-text,'^[\p{L}\p{N}\p{M}]') and not(matches(.,'\s+$'))
+Test: report    matches($post-text,'^[\p{L}\p{N}\p{M}]')
 Message: There is no space between inlineformula and the following text    Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
-    <p>test<inline-formula>
-        <mml:math/>
-      </inline-formula>test</p>
+    <p>test <italic>test</italic> test <inline-formula><mml:math/></inline-formula> test <italic>test</italic> test </p>
   </article>
 </root>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/fail.xml
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/fail.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="insight-asbtract-impact-test-1.sch"?>
+<!--Context: article[@article-type='article-commentary']//article-meta/abstract
+Test: assert    . = $impact-statement
+Message: In insights, abtsracts must be the same as impact statements. Here the abstract reads "", whereas the impact statement reads "".-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="article-commentary">
+    <article-meta>
+      <abstract><p>Two studies suggest that a determined adversary may be able to obtain genetic information without permission from some genealogy databases.</p></abstract>
+      <custom-meta-group><custom-meta specific-use="meta-only"><meta-name>Author impact statement</meta-name><meta-value>Two studies suggest that a determined adversary may be able to obtain genetic information that they should not have permission to access from some genealogy databases.</meta-value></custom-meta></custom-meta-group>
+    </article-meta>
+  </article>
+</root>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/insight-asbtract-impact-test-1.sch
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/insight-asbtract-impact-test-1.sch
@@ -1,0 +1,698 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="features">
+    <rule context="article[@article-type='article-commentary']//article-meta/abstract" id="insight-asbtract-tests">
+      <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value"/>
+      <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value/*)"/>
+      <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::article[@article-type='article-commentary']//article-meta/abstract" role="error" id="insight-asbtract-tests-xspec-assert">article[@article-type='article-commentary']//article-meta/abstract must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/pass.xml
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/pass.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="insight-asbtract-impact-test-1.sch"?>
+<!--Context: article[@article-type='article-commentary']//article-meta/abstract
+Test: assert    . = $impact-statement
+Message: In insights, abtsracts must be the same as impact statements. Here the abstract reads "", whereas the impact statement reads "".-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="article-commentary">
+    <article-meta>
+      <abstract><p>Two studies suggest that a determined adversary may be able to obtain genetic information without permission from some genealogy databases.</p></abstract>
+      <custom-meta-group><custom-meta specific-use="meta-only"><meta-name>Author impact statement</meta-name><meta-value>Two studies suggest that a determined adversary may be able to obtain genetic information without permission from some genealogy databases.</meta-value></custom-meta></custom-meta-group>
+    </article-meta>
+  </article>
+</root>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/fail.xml
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/fail.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="insight-asbtract-impact-test-2.sch"?>
+<!--Context: article[@article-type='article-commentary']//article-meta/abstract
+Test: assert    count(p/*) = $impact-statement-element-count
+Message: In insights, abtsracts must be the same as impact statements. Here the abstract has  child element(s), whereas the impact statement has  child element(s). Check for possible missing formatting.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="article-commentary">
+    <article-meta>
+      <abstract><p>Two studies suggest that a <italic>determined</italic> adversary may be able to obtain genetic information without permission from some genealogy databases.</p></abstract>
+      <custom-meta-group><custom-meta specific-use="meta-only"><meta-name>Author impact statement</meta-name><meta-value>Two studies suggest that a determined adversary may be able to obtain genetic information without permission from some genealogy databases.</meta-value></custom-meta></custom-meta-group>
+    </article-meta>
+  </article>
+</root>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/insight-asbtract-impact-test-2.sch
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/insight-asbtract-impact-test-2.sch
@@ -1,0 +1,698 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(translate($string,'àáâãäåăçčèéêěëęħìíîïłñňòóôõöőøřšśşùúûüýÿž','aaaaaaacceeeeeehiiiilnnooooooorsssuuuuyyz'),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="features">
+    <rule context="article[@article-type='article-commentary']//article-meta/abstract" id="insight-asbtract-tests">
+      <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value"/>
+      <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value/*)"/>
+      <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::article[@article-type='article-commentary']//article-meta/abstract" role="error" id="insight-asbtract-tests-xspec-assert">article[@article-type='article-commentary']//article-meta/abstract must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/pass.xml
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/pass.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="insight-asbtract-impact-test-2.sch"?>
+<!--Context: article[@article-type='article-commentary']//article-meta/abstract
+Test: assert    count(p/*) = $impact-statement-element-count
+Message: In insights, abtsracts must be the same as impact statements. Here the abstract has  child element(s), whereas the impact statement has  child element(s). Check for possible missing formatting.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="article-commentary">
+    <article-meta>
+      <abstract><p>Two studies suggest that a <italic>determined</italic> adversary may be able to obtain genetic information without permission from some genealogy databases.</p></abstract>
+      <custom-meta-group><custom-meta specific-use="meta-only"><meta-name>Author impact statement</meta-name><meta-value>Two studies suggest that a <italic>determined</italic> adversary may be able to obtain genetic information without permission from some genealogy databases.</meta-value></custom-meta></custom-meta-group>
+    </article-meta>
+  </article>
+</root>

--- a/test/tests/gen/math-tests/math-test-17/fail.xml
+++ b/test/tests/gen/math-tests/math-test-17/fail.xml
@@ -4,7 +4,7 @@ Test: report    child::mml:msqrt and matches($data,'^±\d+%$|^+\d+%$|^-\d+%$|^\d
 Message: mml:math only contains number(s) and square root symbol(s) '', which is likely unnecessary. Should this be captured as normal text instead? Such as ?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+    <root>
       <article>
         <mml:math>
           <mml:msqrt><mml:mn>2</mml:mn></mml:msqrt>

--- a/test/tests/gen/p-punctuation/p-bracket-test/fail.xml
+++ b/test/tests/gen/p-punctuation/p-bracket-test/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-bracket-test.sch"?>
 <!--Context: article/body//p[not(parent::list-item)]
-Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\."\s*?'))
+Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\."\s*?'))
 Message: paragraph doesn't end with a full stop, colon, question or excalamation mark  Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/p-punctuation/p-bracket-test/p-bracket-test.sch
+++ b/test/tests/gen/p-punctuation/p-bracket-test/p-bracket-test.sch
@@ -686,7 +686,7 @@
   <pattern id="house-style">
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/p-punctuation/p-bracket-test/pass.xml
+++ b/test/tests/gen/p-punctuation/p-bracket-test/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-bracket-test.sch"?>
 <!--Context: article/body//p[not(parent::list-item)]
-Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\."\s*?'))
+Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\."\s*?'))
 Message: paragraph doesn't end with a full stop, colon, question or excalamation mark  Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/p-punctuation/p-punctuation-test/fail.xml
+++ b/test/tests/gen/p-punctuation/p-punctuation-test/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-punctuation-test.sch"?>
 <!--Context: article/body//p[not(parent::list-item)]
-Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))
+Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\p{P}\s*?$'))
 Message: paragraph doesn't end with punctuation  Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/p-punctuation/p-punctuation-test/p-punctuation-test.sch
+++ b/test/tests/gen/p-punctuation/p-punctuation-test/p-punctuation-test.sch
@@ -686,7 +686,7 @@
   <pattern id="house-style">
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/p-punctuation/p-punctuation-test/pass.xml
+++ b/test/tests/gen/p-punctuation/p-punctuation-test/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="p-punctuation-test.sch"?>
 <!--Context: article/body//p[not(parent::list-item)]
-Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))
+Test: report    if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\p{P}\s*?$'))
 Message: paragraph doesn't end with punctuation  Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/software-ref-tests/R-test-1/R-test-1.sch
+++ b/test/tests/gen/software-ref-tests/R-test-1/R-test-1.sch
@@ -686,7 +686,7 @@
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/software-ref-tests/R-test-2/R-test-2.sch
+++ b/test/tests/gen/software-ref-tests/R-test-2/R-test-2.sch
@@ -686,7 +686,7 @@
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/software-ref-tests/R-test-3/R-test-3.sch
+++ b/test/tests/gen/software-ref-tests/R-test-3/R-test-3.sch
@@ -686,7 +686,7 @@
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/software-ref-tests/R-test-4/R-test-4.sch
+++ b/test/tests/gen/software-ref-tests/R-test-4/R-test-4.sch
@@ -686,7 +686,7 @@
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -5891,7 +5891,7 @@
       
       <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
       
-      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='PDB'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'PDB', which must be incorrect.</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
       

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1805,9 +1805,9 @@
       
       <assert test="mml:math" role="error" id="inline-formula-test-1">inline-formula must contain an mml:math element.</assert>
       
-      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$') and not(matches(.,'^\s+'))" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
+      <report test="matches($pre-text,'[\p{L}\p{N}\p{M}]$')" role="warning" id="inline-formula-test-2">There is no space between inline-formula and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
-      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]') and not(matches(.,'\s+$'))" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
+      <report test="matches($post-text,'^[\p{L}\p{N}\p{M}]')" role="warning" id="inline-formula-test-3">There is no space between inline-formula and the following text - <value-of select="concat(.,substring($post-text,1,15))"/> - Is this correct?</report>
       
       <assert test="parent::p or parent::td or parent::th or parent::title" role="error" id="inline-formula-test-4">
         <name/> must be a child of p, td,  th or title. The formula containing <value-of select="."/> is a child of <value-of select="parent::*/local-name()"/>
@@ -4513,6 +4513,17 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-asbtract-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/abstract" id="insight-asbtract-tests">
+     <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value"/>
+     <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value/*)"/>
+     
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4803,11 +4814,11 @@
       
       <report test="matches($post-text,'^ of [\p{Lu}][\p{Ll}]+[\-]?[\p{Ll}]? et al[\.]?')" role="warning" id="fig-xref-test-9">Is this figure citation a reference to a figure from other content (and as such should be captured instead as plain text)? - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="error" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ff]igure supplement')" role="warning" id="fig-xref-test-10">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a Figure supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="error" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Vv]ideo')" role="warning" id="fig-xref-test-11">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to a video supplement - <value-of select="concat(.,$post-text)"/>'.</report>
       
-      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="error" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
+      <report test="matches($post-text,'^[\s]?[\s—\-][\s]?[Ss]ource')" role="warning" id="fig-xref-test-12">Incomplete citation. Figure citation is followed by text which suggests it should instead be a link to source data or code - <value-of select="concat(.,$post-text)"/>'.</report>
       
       <report test="matches($post-text,'^[\s]?[Ss]upplement|^[\s]?[Ff]igure [Ss]upplement|^[\s]?[Ss]ource|^[\s]?[Vv]ideo')" role="warning" id="fig-xref-test-13">Figure citation is followed by text which suggests it could be an incomplete citation - <value-of select="concat(.,$post-text)"/>'. Is this OK?</report>
     </rule>
@@ -5716,18 +5727,195 @@
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(person-group[@person-group-type='author']/collab[1],'^R Development Core Team$'))" role="error" id="R-test-1">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it does not have one collab element containing 'R Development Core Team'.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count(person-group[@person-group-type='author']/collab) != 1)" role="error" id="R-test-2">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but it has <value-of select="count(person-group[@person-group-type='author']/collab)"/> collab element(s).</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
+      
+    </rule>
+  </pattern>
+  <pattern id="data-ref-tests-pattern">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/geo') and not(source[1]='NCBI Gene Expression Omnibus')" role="warning" id="data-geo-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/geo' type link, but the database name is not 'NCBI Gene Expression Omnibus' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/nuccore') and not(source[1]='NCBI GenBank') and not(source[1]='NCBI Nucleotide')" role="warning" id="data-nucleotide-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/nuccore' type link, but the database name is not 'NCBI Nucleotide' or 'NCBI GenBank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/bioproject') and not(source[1]='NCBI BioProject')" role="warning" id="data-bioproject-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/bioproject' type link, but the database name is not 'NCBI BioProject' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/gap') and not(source[1]='NCBI dbGaP')" role="warning" id="data-dbgap-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/gap' type link, but the database name is not 'NCBI dbGaP' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/popset') and not(source[1]='NCBI PopSet')" role="warning" id="data-popset-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/popset' type link, but the database name is not 'NCBI PopSet' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/sra') and not(source[1]='NCBI Sequence Read Archive')" role="warning" id="data-sra-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/sra' type link, but the database name is not 'NCBI Sequence Read Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/biosample') and not(source[1]='NCBI BioSample')" role="warning" id="data-biosample-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/biosample' type link, but the database name is not 'NCBI BioSample' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/assembly') and not(source[1]='NCBI Assembly')" role="warning" id="data-assembly-test">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://www.ncbi.nlm.nih.gov/assembly' type link, but the database name is not 'NCBI Assembly' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-1">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked as an accession number, which is likely incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[@pub-id-type!='accession']" role="warning" id="data-ncbi-test-2">Data reference with the database source '<value-of select="source[1]"/>' is not marked as an accession number, which is very likely incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ncbi.nlm.nih.gov/') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-3">Data reference with an NCBI link '<value-of select="pub-id[1]/@xlink:href"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(lower-case(source[1]),'^ncbi gene expression omnibus$|^ncbi nucleotide$|^ncbi genbank$|^ncbi assembly$|^ncbi bioproject$|^ncbi dbgap$|^ncbi sequence read archive$|^ncbi popset$|^ncbi biosample$') and pub-id[1][@assigning-authority!='NCBI' or not(@assigning-authority)]" role="warning" id="data-ncbi-test-4">Data reference with the database source '<value-of select="source[1]"/>' is not marked with NCBI as its assigning authority, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (source[1]!='Dryad Digital Repository')" role="warning" id="data-dryad-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5061/dryad' but the database name is not 'Dryad Digital Repository' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad')) and (source[1]='Dryad Digital Repository')" role="warning" id="data-dryad-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5061/dryad', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5061/dryad') and (pub-id[1][@assigning-authority!='Dryad' or not(@assigning-authority)])" role="warning" id="data-dryad-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Dryad type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Dryad, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and not(source[1]='RCSB Protein Data Bank')" role="warning" id="data-rcsbpbd-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but the database name is not 'RCSB Protein Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and  pub-id[1][@assigning-authority!='PBD' or not(@assigning-authority)]" role="warning" id="data-rcsbpbd-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.rcsb.org' type link, but is not marked with PBD as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-arrayexpress-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-arrayexpress-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ArrayExpress 'www.ebi.ac.uk/arrayexpress' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and not(source[1]='PRIDE')" role="warning" id="data-pride-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but the database name is not 'PRIDE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-pride-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/pride' type link, but is not marked with EBI as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pride') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-pride-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PRIDE 'www.ebi.ac.uk/pride' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (source[1]!='Zenodo')" role="warning" id="data-zenodo-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.5281/zenodo' but the database name is not 'Zenodo' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo')) and (source[1]='Zenodo')" role="warning" id="data-zenodo-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name  <value-of select="source[1]"/>, but no doi starting with '10.5281/zenodo', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.5281/zenodo') and (pub-id[1][@assigning-authority!='Zenodo'  or not(@assigning-authority)])" role="warning" id="data-zenodo-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Zenodo type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Zenodo, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and not(source[1]='Open Science Framework')" role="warning" id="data-osf-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect.</report>
+      
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (pub-id[1][@assigning-authority!='Open Science Framework'  or not(@assigning-authority)])" role="warning" id="data-osf-test-5">Data reference with the title '<value-of select="data-title[1]"/>' has a OSF type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not Open Science Framework, which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (source[1]!='figshare')" role="warning" id="data-figshare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6084/m9.figshare' but the database name is not 'figshare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare')) and (source[1]='figshare')" role="warning" id="data-figshare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6084/m9.figshare' - is this correct? Figshare sometimes host for other organisations (example http://doi.org/10.1184/R1/9963566), so this may be fine.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6084/m9.figshare') and (pub-id[1][@assigning-authority!='figshare'  or not(@assigning-authority)])" role="warning" id="data-figshare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a figshare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not figshare, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and not(source[1]='ProteomeXchange')" role="warning" id="data-proteomexchange-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but the database name is not 'ProteomeXchange' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-proteomexchange-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://proteomecentral.proteomexchange.org/' type link, but is not marked with 'other' as its assigning authority, which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'proteomecentral.proteomexchange.org/') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-proteomexchange-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ProteomeXchange 'http://proteomecentral.proteomexchange.org/' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (source[1]!='OpenNeuro')" role="warning" id="data-openneuro-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.18112/openneuro' but the database name is not 'OpenNeuro' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro')) and not(contains(pub-id[1]/@xlink:href,'openneuro.org/datasets')) and (source[1]='OpenNeuro')" role="warning" id="data-openneuro-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.18112/openneuro' or 'openneuro.org/datasets' type link, which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.18112/openneuro') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-openneuro-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a OpenNeuro type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (source[1]!='Synapse')" role="warning" id="data-synapse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7303/syn' but the database name is not 'Synapse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn')) and (source[1]='Synapse')" role="warning" id="data-synapse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7303/syn', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7303/syn') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-synapse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Synapse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and not(source[1]='Biological Magnetic Resonance Data Bank')" role="warning" id="data-bmrb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but the database name is not 'Biological Magnetic Resonance Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-bmrb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.bmrb.wisc.edu/data_library/summary') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-bmrb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a BMRB 'www.bmrb.wisc.edu/data_library/summary' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and not(source[1]='Morph D Base')" role="warning" id="data-morphdbase-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but the database name is not 'Morph D Base' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-morphdbase-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.morphdbase.de' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.morphdbase.de') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-morphdbase-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Morph D Base 'www.morphdbase.de' type link, but is not marked as an accession type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (source[1]!='Mendeley Data')" role="warning" id="data-mendeley-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17632' but the database name is not 'Mendeley Data' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17632')) and (source[1]='Mendeley Data')" role="warning" id="data-mendeley-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17632', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17632') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-mendeley-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Mendeley Data type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (source[1]!='Edinburgh DataShare')" role="warning" id="data-edatashare-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7488' but the database name is not 'Edinburgh DataShare' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7488')) and (source[1]='Edinburgh DataShare')" role="warning" id="data-edatashare-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7488', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7488') and (pub-id[1][@assigning-authority!='Edinburgh University'  or not(@assigning-authority)])" role="warning" id="data-edatashare-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Edinburgh DataShare type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'Edinburgh University', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (source[1]!='ETH Library research collection')" role="warning" id="data-eth-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.3929' but the database name is not 'ETH Library research collection' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.3929')) and (source[1]='ETH Library research collection')" role="warning" id="data-eth-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.3929', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.3929') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-eth-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a ETH Library research collection type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (source[1]!='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.6080' but the database name is not 'Collaborative Research in Computational Neuroscience' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.6080')) and (source[1]='Collaborative Research in Computational Neuroscience')" role="warning" id="data-crcns-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.6080', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.6080') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-crcns-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a CRCNS type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (source[1]!='MorphoSource')" role="warning" id="data-morphosource-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17602' but the database name is not 'MorphoSource' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.17602')) and (source[1]='MorphoSource')" role="warning" id="data-morphosource-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.17602', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17602') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-morphosource-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a MorphoSource type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and not(source[1]='NeuroVault')" role="warning" id="data-neurovault-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but the database name is not 'NeuroVault' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.2210')) and (source[1]='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.2210', which is incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-wwpdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Worldwide Protein Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (source[1]!='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.15785/SBGRID' but the database name is not 'SBGrid Data Bank' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID')) and (source[1]='SBGrid Data Bank')" role="warning" id="data-sbgdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.15785/SBGRID', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.15785/SBGRID') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-sbgdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a SBGrid Data Bank type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (source[1]!='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.7910' but the database name is not 'Harvard Dataverse' - <value-of select="source[1]"/>.</report>
+      
+      <report test="pub-id and not(starts-with(pub-id[1][@pub-id-type='doi'],'10.7910')) and (source[1]='Harvard Dataverse')" role="warning" id="data-harvard-dataverse-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has the database name <value-of select="source[1]"/>, but no doi starting with '10.7910', which is likely incorrect.</report>
+      
+      <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.7910') and (pub-id[1][@assigning-authority!='other'  or not(@assigning-authority)])" role="warning" id="data-harvard-dataverse-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a Harvard Dataverse type doi - <value-of select="pub-id[1][@pub-id-type='doi']"/>, but the assigning authority is not 'other', which must be incorrect.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and not(source[1]='ENCODE')" role="warning" id="data-encode-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but the database name is not 'ENCODE' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-emdr-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdr-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an EMDataResource 'www.emdataresource.org' type link, but is not marked as an accession type link.</report>
       
     </rule>
   </pattern>
@@ -5911,9 +6099,9 @@
     <rule context="article/body//p[not(parent::list-item)]" id="p-punctuation">
       <let name="para" value="replace(.,' ',' ')"/>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\p{P}\s*?$'))" role="warning" id="p-punctuation-test">paragraph doesn't end with punctuation - Is this correct?</report>
       
-      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
+      <report test="if (ancestor::article[@article-type=('correction','retraction')]) then () else if ((ancestor::article[@article-type='article-commentary']) and (parent::boxed-text)) then () else if (descendant::*[last()]/ancestor::disp-formula) then () else if (table-wrap) then () else not(matches($para,'\.\)?\s*?$|:\s*?$|\?\s*?$|!\s*?$|\.”\s*?|\.&quot;\s*?'))" role="warning" id="p-bracket-test">paragraph doesn't end with a full stop, colon, question or excalamation mark - Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="italic-house-style-pattern">
@@ -6021,14 +6209,6 @@
       <report test="matches(.,'[Ii]n [Oo]vo')" role="warning" id="final-in-ovo-italic-test">
         <name/> element contains 'In Ovo' - this should not be in italics (eLife house style).</report>
       
-    </rule>
-  </pattern>
-  <pattern id="list-house-style-pattern">
-    <rule context="list[@list-type]" id="list-house-style">
-      <let name="usual-types" value="('bullet','simple','order')"/>
-      
-      <assert test="@list-type = $usual-types" role="warning" id="list-type-house-style-test">
-        <name/> element is a list-type='<value-of select="@list-type"/>'. According to house style, bullets, numbers or no indicators should be used. Usual values - ('bullet','simple','order').</assert>
     </rule>
   </pattern>
   <pattern id="pubmed-link-pattern">
@@ -6379,6 +6559,7 @@
       <assert test="descendant::article[@article-type = $features-article-types]//article-meta//contrib[@contrib-type='author']" role="error" id="feature-author-tests-xspec-assert">article[@article-type = $features-article-types]//article-meta//contrib[@contrib-type='author'] must be present.</assert>
       <assert test="descendant::article[@article-type = $features-article-types]//article-meta//contrib[@contrib-type='author']/bio" role="error" id="feature-bio-tests-xspec-assert">article[@article-type = $features-article-types]//article-meta//contrib[@contrib-type='author']/bio must be present.</assert>
       <assert test="descendant::article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = $features-subj]" role="error" id="feature-template-tests-xspec-assert">article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = $features-subj] must be present.</assert>
+      <assert test="descendant::article[@article-type='article-commentary']//article-meta/abstract" role="error" id="insight-asbtract-tests-xspec-assert">article[@article-type='article-commentary']//article-meta/abstract must be present.</assert>
       <assert test="descendant::article[@article-type = 'correction']" role="error" id="correction-tests-xspec-assert">article[@article-type = 'correction'] must be present.</assert>
       <assert test="descendant::article[@article-type = 'retraction']" role="error" id="retraction-tests-xspec-assert">article[@article-type = 'retraction'] must be present.</assert>
       <assert test="descendant::p" role="error" id="final-gene-primer-sequence-xspec-assert">p must be present.</assert>
@@ -6405,6 +6586,7 @@
       <assert test="descendant::element-citation[@publication-type='preprint']/source" role="error" id="preprint-title-tests-xspec-assert">element-citation[@publication-type='preprint']/source must be present.</assert>
       <assert test="descendant::element-citation[@publication-type='web']" role="error" id="website-tests-xspec-assert">element-citation[@publication-type='web'] must be present.</assert>
       <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
       <assert test="descendant::element-citation/publisher-name" role="error" id="publisher-name-tests-xspec-assert">element-citation/publisher-name must be present.</assert>
       <assert test="descendant::element-citation//name" role="error" id="ref-name-tests-xspec-assert">element-citation//name must be present.</assert>
       <assert test="descendant::element-citation[(@publication-type='journal') and (fpage or lpage)]" role="error" id="page-conformity-xspec-assert">element-citation[(@publication-type='journal') and (fpage or lpage)] must be present.</assert>
@@ -6421,7 +6603,6 @@
       <assert test="descendant::named-content" role="error" id="colour-named-content-xspec-assert">named-content must be present.</assert>
       <assert test="descendant::article/body//p[not(parent::list-item)]" role="error" id="p-punctuation-xspec-assert">article/body//p[not(parent::list-item)] must be present.</assert>
       <assert test="descendant::italic[not(ancestor::ref)]" role="error" id="italic-house-style-xspec-assert">italic[not(ancestor::ref)] must be present.</assert>
-      <assert test="descendant::list[@list-type]" role="error" id="list-house-style-xspec-assert">list[@list-type] must be present.</assert>
       <assert test="descendant::p//ext-link[not(ancestor::table-wrap) and not(ancestor::sub-article)]" role="error" id="pubmed-link-xspec-assert">p//ext-link[not(ancestor::table-wrap) and not(ancestor::sub-article)] must be present.</assert>
       <assert test="descendant::ref-list/ref" role="error" id="ref-link-mandate-xspec-assert">ref-list/ref must be present.</assert>
       <assert test="descendant::fig or descendant::media[@mimetype='video']" role="error" id="fig-permissions-check-xspec-assert">fig|media[@mimetype='video'] must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -8058,6 +8058,28 @@
         <x:expect-not-assert id="feature-template-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="insight-asbtract-tests">
+      <x:scenario label="insight-asbtract-impact-test-1-pass">
+        <x:context href="../tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/pass.xml"/>
+        <x:expect-not-assert id="insight-asbtract-impact-test-1" role="warning"/>
+        <x:expect-not-assert id="insight-asbtract-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="insight-asbtract-impact-test-1-fail">
+        <x:context href="../tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/fail.xml"/>
+        <x:expect-assert id="insight-asbtract-impact-test-1" role="warning"/>
+        <x:expect-not-assert id="insight-asbtract-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="insight-asbtract-impact-test-2-pass">
+        <x:context href="../tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/pass.xml"/>
+        <x:expect-not-assert id="insight-asbtract-impact-test-2" role="warning"/>
+        <x:expect-not-assert id="insight-asbtract-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="insight-asbtract-impact-test-2-fail">
+        <x:context href="../tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/fail.xml"/>
+        <x:expect-assert id="insight-asbtract-impact-test-2" role="warning"/>
+        <x:expect-not-assert id="insight-asbtract-tests-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
     <x:scenario label="correction-tests">
       <x:scenario label="corr-aff-presence-pass">
         <x:context href="../tests/gen/correction-tests/corr-aff-presence/pass.xml"/>
@@ -8887,32 +8909,32 @@
       </x:scenario>
       <x:scenario label="fig-xref-test-10-pass">
         <x:context href="../tests/gen/fig-xref-conformance/fig-xref-test-10/pass.xml"/>
-        <x:expect-not-report id="fig-xref-test-10" role="error"/>
+        <x:expect-not-report id="fig-xref-test-10" role="warning"/>
         <x:expect-not-assert id="fig-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="fig-xref-test-10-fail">
         <x:context href="../tests/gen/fig-xref-conformance/fig-xref-test-10/fail.xml"/>
-        <x:expect-report id="fig-xref-test-10" role="error"/>
+        <x:expect-report id="fig-xref-test-10" role="warning"/>
         <x:expect-not-assert id="fig-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="fig-xref-test-11-pass">
         <x:context href="../tests/gen/fig-xref-conformance/fig-xref-test-11/pass.xml"/>
-        <x:expect-not-report id="fig-xref-test-11" role="error"/>
+        <x:expect-not-report id="fig-xref-test-11" role="warning"/>
         <x:expect-not-assert id="fig-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="fig-xref-test-11-fail">
         <x:context href="../tests/gen/fig-xref-conformance/fig-xref-test-11/fail.xml"/>
-        <x:expect-report id="fig-xref-test-11" role="error"/>
+        <x:expect-report id="fig-xref-test-11" role="warning"/>
         <x:expect-not-assert id="fig-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="fig-xref-test-12-pass">
         <x:context href="../tests/gen/fig-xref-conformance/fig-xref-test-12/pass.xml"/>
-        <x:expect-not-report id="fig-xref-test-12" role="error"/>
+        <x:expect-not-report id="fig-xref-test-12" role="warning"/>
         <x:expect-not-assert id="fig-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="fig-xref-test-12-fail">
         <x:context href="../tests/gen/fig-xref-conformance/fig-xref-test-12/fail.xml"/>
-        <x:expect-report id="fig-xref-test-12" role="error"/>
+        <x:expect-report id="fig-xref-test-12" role="warning"/>
         <x:expect-not-assert id="fig-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="fig-xref-test-13-pass">
@@ -11970,6 +11992,868 @@
         <x:expect-not-assert id="software-ref-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="data-ref-tests">
+      <x:scenario label="data-geo-test-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-geo-test/pass.xml"/>
+        <x:expect-not-report id="data-geo-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-geo-test-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-geo-test/fail.xml"/>
+        <x:expect-report id="data-geo-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-nucleotide-test-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-nucleotide-test/pass.xml"/>
+        <x:expect-not-report id="data-nucleotide-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-nucleotide-test-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-nucleotide-test/fail.xml"/>
+        <x:expect-report id="data-nucleotide-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-bioproject-test-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-bioproject-test/pass.xml"/>
+        <x:expect-not-report id="data-bioproject-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-bioproject-test-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-bioproject-test/fail.xml"/>
+        <x:expect-report id="data-bioproject-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-dbgap-test-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-dbgap-test/pass.xml"/>
+        <x:expect-not-report id="data-dbgap-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-dbgap-test-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-dbgap-test/fail.xml"/>
+        <x:expect-report id="data-dbgap-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-popset-test-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-popset-test/pass.xml"/>
+        <x:expect-not-report id="data-popset-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-popset-test-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-popset-test/fail.xml"/>
+        <x:expect-report id="data-popset-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-sra-test-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-sra-test/pass.xml"/>
+        <x:expect-not-report id="data-sra-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-sra-test-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-sra-test/fail.xml"/>
+        <x:expect-report id="data-sra-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-biosample-test-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-biosample-test/pass.xml"/>
+        <x:expect-not-report id="data-biosample-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-biosample-test-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-biosample-test/fail.xml"/>
+        <x:expect-report id="data-biosample-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-assembly-test-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-assembly-test/pass.xml"/>
+        <x:expect-not-report id="data-assembly-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-assembly-test-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-assembly-test/fail.xml"/>
+        <x:expect-report id="data-assembly-test" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ncbi-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-ncbi-test-1/pass.xml"/>
+        <x:expect-not-report id="data-ncbi-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ncbi-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-ncbi-test-1/fail.xml"/>
+        <x:expect-report id="data-ncbi-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ncbi-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-ncbi-test-2/pass.xml"/>
+        <x:expect-not-report id="data-ncbi-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ncbi-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-ncbi-test-2/fail.xml"/>
+        <x:expect-report id="data-ncbi-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ncbi-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-ncbi-test-3/pass.xml"/>
+        <x:expect-not-report id="data-ncbi-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ncbi-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-ncbi-test-3/fail.xml"/>
+        <x:expect-report id="data-ncbi-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ncbi-test-4-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-ncbi-test-4/pass.xml"/>
+        <x:expect-not-report id="data-ncbi-test-4" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ncbi-test-4-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-ncbi-test-4/fail.xml"/>
+        <x:expect-report id="data-ncbi-test-4" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-dryad-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-dryad-test-1/pass.xml"/>
+        <x:expect-not-report id="data-dryad-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-dryad-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-dryad-test-1/fail.xml"/>
+        <x:expect-report id="data-dryad-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-dryad-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-dryad-test-2/pass.xml"/>
+        <x:expect-not-report id="data-dryad-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-dryad-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-dryad-test-2/fail.xml"/>
+        <x:expect-report id="data-dryad-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-dryad-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-dryad-test-3/pass.xml"/>
+        <x:expect-not-report id="data-dryad-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-dryad-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-dryad-test-3/fail.xml"/>
+        <x:expect-report id="data-dryad-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-rcsbpbd-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-rcsbpbd-test-1/pass.xml"/>
+        <x:expect-not-report id="data-rcsbpbd-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-rcsbpbd-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-rcsbpbd-test-1/fail.xml"/>
+        <x:expect-report id="data-rcsbpbd-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-rcsbpbd-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-rcsbpbd-test-2/pass.xml"/>
+        <x:expect-not-report id="data-rcsbpbd-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-rcsbpbd-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-rcsbpbd-test-2/fail.xml"/>
+        <x:expect-report id="data-rcsbpbd-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-rcsbpbd-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-rcsbpbd-test-3/pass.xml"/>
+        <x:expect-not-report id="data-rcsbpbd-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-rcsbpbd-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-rcsbpbd-test-3/fail.xml"/>
+        <x:expect-report id="data-rcsbpbd-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdb-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-emdb-test-1/pass.xml"/>
+        <x:expect-not-report id="data-emdb-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdb-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-emdb-test-1/fail.xml"/>
+        <x:expect-report id="data-emdb-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdb-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-emdb-test-2/pass.xml"/>
+        <x:expect-not-report id="data-emdb-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdb-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-emdb-test-2/fail.xml"/>
+        <x:expect-report id="data-emdb-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdb-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-emdb-test-3/pass.xml"/>
+        <x:expect-not-report id="data-emdb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdb-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-emdb-test-3/fail.xml"/>
+        <x:expect-report id="data-emdb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-arrayexpress-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-arrayexpress-test-1/pass.xml"/>
+        <x:expect-not-report id="data-arrayexpress-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-arrayexpress-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-arrayexpress-test-1/fail.xml"/>
+        <x:expect-report id="data-arrayexpress-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-arrayexpress-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-arrayexpress-test-2/pass.xml"/>
+        <x:expect-not-report id="data-arrayexpress-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-arrayexpress-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-arrayexpress-test-2/fail.xml"/>
+        <x:expect-report id="data-arrayexpress-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-arrayexpress-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-arrayexpress-test-3/pass.xml"/>
+        <x:expect-not-report id="data-arrayexpress-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-arrayexpress-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-arrayexpress-test-3/fail.xml"/>
+        <x:expect-report id="data-arrayexpress-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-pride-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-pride-test-1/pass.xml"/>
+        <x:expect-not-report id="data-pride-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-pride-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-pride-test-1/fail.xml"/>
+        <x:expect-report id="data-pride-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-pride-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-pride-test-2/pass.xml"/>
+        <x:expect-not-report id="data-pride-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-pride-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-pride-test-2/fail.xml"/>
+        <x:expect-report id="data-pride-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-pride-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-pride-test-3/pass.xml"/>
+        <x:expect-not-report id="data-pride-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-pride-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-pride-test-3/fail.xml"/>
+        <x:expect-report id="data-pride-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-zenodo-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-zenodo-test-1/pass.xml"/>
+        <x:expect-not-report id="data-zenodo-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-zenodo-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-zenodo-test-1/fail.xml"/>
+        <x:expect-report id="data-zenodo-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-zenodo-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-zenodo-test-2/pass.xml"/>
+        <x:expect-not-report id="data-zenodo-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-zenodo-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-zenodo-test-2/fail.xml"/>
+        <x:expect-report id="data-zenodo-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-zenodo-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-zenodo-test-3/pass.xml"/>
+        <x:expect-not-report id="data-zenodo-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-zenodo-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-zenodo-test-3/fail.xml"/>
+        <x:expect-report id="data-zenodo-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-1/pass.xml"/>
+        <x:expect-not-report id="data-osf-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-1/fail.xml"/>
+        <x:expect-report id="data-osf-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-2/pass.xml"/>
+        <x:expect-not-report id="data-osf-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-2/fail.xml"/>
+        <x:expect-report id="data-osf-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-3/pass.xml"/>
+        <x:expect-not-report id="data-osf-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-3/fail.xml"/>
+        <x:expect-report id="data-osf-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-4-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-4/pass.xml"/>
+        <x:expect-not-report id="data-osf-test-4" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-4-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-4/fail.xml"/>
+        <x:expect-report id="data-osf-test-4" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-5-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-5/pass.xml"/>
+        <x:expect-not-report id="data-osf-test-5" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-osf-test-5-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-osf-test-5/fail.xml"/>
+        <x:expect-report id="data-osf-test-5" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-figshare-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-figshare-test-1/pass.xml"/>
+        <x:expect-not-report id="data-figshare-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-figshare-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-figshare-test-1/fail.xml"/>
+        <x:expect-report id="data-figshare-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-figshare-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-figshare-test-2/pass.xml"/>
+        <x:expect-not-report id="data-figshare-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-figshare-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-figshare-test-2/fail.xml"/>
+        <x:expect-report id="data-figshare-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-figshare-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-figshare-test-3/pass.xml"/>
+        <x:expect-not-report id="data-figshare-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-figshare-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-figshare-test-3/fail.xml"/>
+        <x:expect-report id="data-figshare-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-proteomexchange-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-proteomexchange-test-1/pass.xml"/>
+        <x:expect-not-report id="data-proteomexchange-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-proteomexchange-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-proteomexchange-test-1/fail.xml"/>
+        <x:expect-report id="data-proteomexchange-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-proteomexchange-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-proteomexchange-test-2/pass.xml"/>
+        <x:expect-not-report id="data-proteomexchange-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-proteomexchange-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-proteomexchange-test-2/fail.xml"/>
+        <x:expect-report id="data-proteomexchange-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-proteomexchange-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-proteomexchange-test-3/pass.xml"/>
+        <x:expect-not-report id="data-proteomexchange-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-proteomexchange-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-proteomexchange-test-3/fail.xml"/>
+        <x:expect-report id="data-proteomexchange-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-openneuro-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-openneuro-test-1/pass.xml"/>
+        <x:expect-not-report id="data-openneuro-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-openneuro-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-openneuro-test-1/fail.xml"/>
+        <x:expect-report id="data-openneuro-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-openneuro-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-openneuro-test-2/pass.xml"/>
+        <x:expect-not-report id="data-openneuro-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-openneuro-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-openneuro-test-2/fail.xml"/>
+        <x:expect-report id="data-openneuro-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-openneuro-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-openneuro-test-3/pass.xml"/>
+        <x:expect-not-report id="data-openneuro-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-openneuro-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-openneuro-test-3/fail.xml"/>
+        <x:expect-report id="data-openneuro-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-synapse-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-synapse-test-1/pass.xml"/>
+        <x:expect-not-report id="data-synapse-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-synapse-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-synapse-test-1/fail.xml"/>
+        <x:expect-report id="data-synapse-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-synapse-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-synapse-test-2/pass.xml"/>
+        <x:expect-not-report id="data-synapse-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-synapse-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-synapse-test-2/fail.xml"/>
+        <x:expect-report id="data-synapse-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-synapse-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-synapse-test-3/pass.xml"/>
+        <x:expect-not-report id="data-synapse-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-synapse-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-synapse-test-3/fail.xml"/>
+        <x:expect-report id="data-synapse-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-bmrb-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-bmrb-test-1/pass.xml"/>
+        <x:expect-not-report id="data-bmrb-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-bmrb-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-bmrb-test-1/fail.xml"/>
+        <x:expect-report id="data-bmrb-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-bmrb-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-bmrb-test-2/pass.xml"/>
+        <x:expect-not-report id="data-bmrb-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-bmrb-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-bmrb-test-2/fail.xml"/>
+        <x:expect-report id="data-bmrb-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-bmrb-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-bmrb-test-3/pass.xml"/>
+        <x:expect-not-report id="data-bmrb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-bmrb-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-bmrb-test-3/fail.xml"/>
+        <x:expect-report id="data-bmrb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphdbase-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-morphdbase-test-1/pass.xml"/>
+        <x:expect-not-report id="data-morphdbase-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphdbase-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-morphdbase-test-1/fail.xml"/>
+        <x:expect-report id="data-morphdbase-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphdbase-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-morphdbase-test-2/pass.xml"/>
+        <x:expect-not-report id="data-morphdbase-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphdbase-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-morphdbase-test-2/fail.xml"/>
+        <x:expect-report id="data-morphdbase-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphdbase-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-morphdbase-test-3/pass.xml"/>
+        <x:expect-not-report id="data-morphdbase-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphdbase-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-morphdbase-test-3/fail.xml"/>
+        <x:expect-report id="data-morphdbase-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-mendeley-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-mendeley-test-1/pass.xml"/>
+        <x:expect-not-report id="data-mendeley-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-mendeley-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-mendeley-test-1/fail.xml"/>
+        <x:expect-report id="data-mendeley-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-mendeley-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-mendeley-test-2/pass.xml"/>
+        <x:expect-not-report id="data-mendeley-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-mendeley-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-mendeley-test-2/fail.xml"/>
+        <x:expect-report id="data-mendeley-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-mendeley-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-mendeley-test-3/pass.xml"/>
+        <x:expect-not-report id="data-mendeley-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-mendeley-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-mendeley-test-3/fail.xml"/>
+        <x:expect-report id="data-mendeley-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-edatashare-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-edatashare-test-1/pass.xml"/>
+        <x:expect-not-report id="data-edatashare-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-edatashare-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-edatashare-test-1/fail.xml"/>
+        <x:expect-report id="data-edatashare-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-edatashare-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-edatashare-test-2/pass.xml"/>
+        <x:expect-not-report id="data-edatashare-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-edatashare-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-edatashare-test-2/fail.xml"/>
+        <x:expect-report id="data-edatashare-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-edatashare-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-edatashare-test-3/pass.xml"/>
+        <x:expect-not-report id="data-edatashare-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-edatashare-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-edatashare-test-3/fail.xml"/>
+        <x:expect-report id="data-edatashare-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-eth-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-eth-test-1/pass.xml"/>
+        <x:expect-not-report id="data-eth-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-eth-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-eth-test-1/fail.xml"/>
+        <x:expect-report id="data-eth-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-eth-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-eth-test-2/pass.xml"/>
+        <x:expect-not-report id="data-eth-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-eth-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-eth-test-2/fail.xml"/>
+        <x:expect-report id="data-eth-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-eth-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-eth-test-3/pass.xml"/>
+        <x:expect-not-report id="data-eth-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-eth-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-eth-test-3/fail.xml"/>
+        <x:expect-report id="data-eth-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-crcns-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-crcns-test-1/pass.xml"/>
+        <x:expect-not-report id="data-crcns-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-crcns-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-crcns-test-1/fail.xml"/>
+        <x:expect-report id="data-crcns-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-crcns-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-crcns-test-2/pass.xml"/>
+        <x:expect-not-report id="data-crcns-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-crcns-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-crcns-test-2/fail.xml"/>
+        <x:expect-report id="data-crcns-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-crcns-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-crcns-test-3/pass.xml"/>
+        <x:expect-not-report id="data-crcns-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-crcns-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-crcns-test-3/fail.xml"/>
+        <x:expect-report id="data-crcns-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphosource-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-morphosource-test-1/pass.xml"/>
+        <x:expect-not-report id="data-morphosource-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphosource-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-morphosource-test-1/fail.xml"/>
+        <x:expect-report id="data-morphosource-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphosource-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-morphosource-test-2/pass.xml"/>
+        <x:expect-not-report id="data-morphosource-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphosource-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-morphosource-test-2/fail.xml"/>
+        <x:expect-report id="data-morphosource-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphosource-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-morphosource-test-3/pass.xml"/>
+        <x:expect-not-report id="data-morphosource-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-morphosource-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-morphosource-test-3/fail.xml"/>
+        <x:expect-report id="data-morphosource-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-neurovault-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-neurovault-test-1/pass.xml"/>
+        <x:expect-not-report id="data-neurovault-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-neurovault-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-neurovault-test-1/fail.xml"/>
+        <x:expect-report id="data-neurovault-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-neurovault-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-neurovault-test-2/pass.xml"/>
+        <x:expect-not-report id="data-neurovault-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-neurovault-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-neurovault-test-2/fail.xml"/>
+        <x:expect-report id="data-neurovault-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-neurovault-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-neurovault-test-3/pass.xml"/>
+        <x:expect-not-report id="data-neurovault-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-neurovault-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-neurovault-test-3/fail.xml"/>
+        <x:expect-report id="data-neurovault-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-wwpdb-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-wwpdb-test-1/pass.xml"/>
+        <x:expect-not-report id="data-wwpdb-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-wwpdb-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-wwpdb-test-1/fail.xml"/>
+        <x:expect-report id="data-wwpdb-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-wwpdb-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-wwpdb-test-2/pass.xml"/>
+        <x:expect-not-report id="data-wwpdb-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-wwpdb-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-wwpdb-test-2/fail.xml"/>
+        <x:expect-report id="data-wwpdb-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-wwpdb-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-wwpdb-test-3/pass.xml"/>
+        <x:expect-not-report id="data-wwpdb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-wwpdb-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-wwpdb-test-3/fail.xml"/>
+        <x:expect-report id="data-wwpdb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-sbgdb-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-sbgdb-test-1/pass.xml"/>
+        <x:expect-not-report id="data-sbgdb-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-sbgdb-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-sbgdb-test-1/fail.xml"/>
+        <x:expect-report id="data-sbgdb-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-sbgdb-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-sbgdb-test-2/pass.xml"/>
+        <x:expect-not-report id="data-sbgdb-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-sbgdb-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-sbgdb-test-2/fail.xml"/>
+        <x:expect-report id="data-sbgdb-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-sbgdb-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-sbgdb-test-3/pass.xml"/>
+        <x:expect-not-report id="data-sbgdb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-sbgdb-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-sbgdb-test-3/fail.xml"/>
+        <x:expect-report id="data-sbgdb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-harvard-dataverse-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-harvard-dataverse-test-1/pass.xml"/>
+        <x:expect-not-report id="data-harvard-dataverse-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-harvard-dataverse-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-harvard-dataverse-test-1/fail.xml"/>
+        <x:expect-report id="data-harvard-dataverse-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-harvard-dataverse-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-harvard-dataverse-test-2/pass.xml"/>
+        <x:expect-not-report id="data-harvard-dataverse-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-harvard-dataverse-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-harvard-dataverse-test-2/fail.xml"/>
+        <x:expect-report id="data-harvard-dataverse-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-harvard-dataverse-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-harvard-dataverse-test-3/pass.xml"/>
+        <x:expect-not-report id="data-harvard-dataverse-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-harvard-dataverse-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-harvard-dataverse-test-3/fail.xml"/>
+        <x:expect-report id="data-harvard-dataverse-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-encode-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-encode-test-1/pass.xml"/>
+        <x:expect-not-report id="data-encode-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-encode-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-encode-test-1/fail.xml"/>
+        <x:expect-report id="data-encode-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-encode-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-encode-test-2/pass.xml"/>
+        <x:expect-not-report id="data-encode-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-encode-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-encode-test-2/fail.xml"/>
+        <x:expect-report id="data-encode-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-encode-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-encode-test-3/pass.xml"/>
+        <x:expect-not-report id="data-encode-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-encode-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-encode-test-3/fail.xml"/>
+        <x:expect-report id="data-encode-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdr-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-emdr-test-1/pass.xml"/>
+        <x:expect-not-report id="data-emdr-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdr-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-emdr-test-1/fail.xml"/>
+        <x:expect-report id="data-emdr-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdr-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-emdr-test-2/pass.xml"/>
+        <x:expect-not-report id="data-emdr-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdr-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-emdr-test-2/fail.xml"/>
+        <x:expect-report id="data-emdr-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdr-test-3-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-emdr-test-3/pass.xml"/>
+        <x:expect-not-report id="data-emdr-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-emdr-test-3-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-emdr-test-3/fail.xml"/>
+        <x:expect-report id="data-emdr-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
     <x:scenario label="publisher-name-tests">
       <x:scenario label="publisher-name-colon-pass">
         <x:context href="../tests/gen/publisher-name-tests/publisher-name-colon/pass.xml"/>
@@ -12782,18 +13666,6 @@
         <x:context href="../tests/gen/italic-house-style/final-in-ovo-italic-test/fail.xml"/>
         <x:expect-report id="final-in-ovo-italic-test" role="warning"/>
         <x:expect-not-assert id="italic-house-style-xspec-assert" role="error"/>
-      </x:scenario>
-    </x:scenario>
-    <x:scenario label="list-house-style">
-      <x:scenario label="list-type-house-style-test-pass">
-        <x:context href="../tests/gen/list-house-style/list-type-house-style-test/pass.xml"/>
-        <x:expect-not-assert id="list-type-house-style-test" role="warning"/>
-        <x:expect-not-assert id="list-house-style-xspec-assert" role="error"/>
-      </x:scenario>
-      <x:scenario label="list-type-house-style-test-fail">
-        <x:context href="../tests/gen/list-house-style/list-type-house-style-test/fail.xml"/>
-        <x:expect-assert id="list-type-house-style-test" role="warning"/>
-        <x:expect-not-assert id="list-house-style-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
     <x:scenario label="pubmed-link">


### PR DESCRIPTION
- Fix for `inline-formula-test-2` and `inline-formula-test-3` - ignore whitespace within an equation
- Add tests for insight abtract/impact statement conformity
- Downgrade certain 'incomplete citation' type tests
- Add numerois tests in `data-ref-tests` , for dataset ref conformity
- Exclude inline (label-less) tables from `p-punctuation-test` and `p-bracket-test`
- Remove `list-house-style`