### PR TITLE
Improvements

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1646,7 +1646,10 @@
       
       <report test="($article-type = $features-article-types) and not(label)" role="warning" id="feat-fig-test-3">fig doesn't have a label. Is this correct?</report>
       
-      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="error" id="fig-test-4">fig must have a caption.</report>
+      
+      
+      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="error" id="final-fig-test-4">
+        <value-of select="label"/> has no title or caption (caption element).</report>
       
       
       
@@ -1747,7 +1750,7 @@
       <assert test="label" role="error" id="supplementary-material-test-1">supplementary-material must have a label.</assert>
       
       <report test="if (contains(label,'Transparent reporting form')) then ()                      else not(caption)" role="warning" id="supplementary-material-test-2">
-        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material have a child caption.)</report>
+        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material should have a child caption.)</report>
       
       
       
@@ -1760,8 +1763,10 @@
         role="warning"
         id="supplementary-material-test-4">supplementary-material caption does not have a p. Is this correct?</report>-->
       
-      <assert test="media" role="error" id="supplementary-material-test-5">
-        <value-of select="label"/> - supplementary-material must have a media.</assert>		
+      		
+      
+      <assert test="media" role="error" id="final-supplementary-material-test-5">
+        <value-of select="label"/> is missing a file (supplementary-material must have a media).</assert>
       
       <assert test="matches(label,'^Transparent reporting form$|^Figure \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Table \d{1,4}—source data \d{1,4}\.$|^Video \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—source code \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Table \d{1,4}—source code \d{1,4}\.$|^Video \d{1,4}—source code \d{1,4}\.$|^Supplementary file \d{1,4}\.$|^Source data \d{1,4}\.$|^Source code \d{1,4}\.$|^Reporting standard \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source code \d{1,4}\.$')" role="error" id="supplementary-material-test-6">supplementary-material label (<value-of select="label"/>) does not conform to eLife's usual label format.</assert>
       
@@ -1884,6 +1889,9 @@
       
       <report test="($id != 'keyresource') and matches(normalize-space(descendant::thead[1]),'[Rr]eagent\s?type\s?\(species\)\s?or resource\s?[Dd]esignation\s?[Ss]ource\s?or\s?reference\s?[Ii]dentifiers\s?[Aa]dditional\s?information')" role="error" id="kr-table-not-tagged">
         <value-of select="$lab"/> has headings that are for the Key reources table, but it does not have an @id='keyresource'.</report>
+      
+      <report test="matches(caption/title[1],'^[Kk]ey [Rr]esource')" role="warning" id="kr-table-not-tagged-2">
+        <value-of select="$lab"/> has the title <value-of select="caption/title[1]"/> but it is not tagged as a ke resources table. Is this correct?</report>
       
     </rule>
   </pattern>
@@ -2158,7 +2166,9 @@
       
       <report test="label[contains(lower-case(.),'supplement')]" role="error" id="fig-specific-test-1">fig label contains 'supplement', but it does not have a @specific-use='child-fig'. If it is a figure supplement it needs the attribute, if it isn't then it cannot contain 'supplement' in the label.</report>
       
-      <report test="if ($article-type = ('correction','retraction')) then ()                      else if ($count = 0) then ()                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()                     else $no != string($pos)" role="error" id="fig-specific-test-2">
+      
+      
+      <report test="if ($article-type = ('correction','retraction')) then ()          else if ($count = 0) then ()         else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()         else $no != string($pos)" role="error" id="final-fig-specific-test-2">
         <value-of select="$lab"/> does not appear in sequence which is incorrect. Relative to the other figures it is placed in position <value-of select="$pos"/>.</report>
       
       <report test="if ($article-type = ('correction','retraction')) then ()          else not((preceding::p[1]//xref[@rid = $id]) or (preceding::p[parent::sec][1]//xref[@rid = $id]))" role="warning" id="fig-specific-test-3">
@@ -3781,10 +3791,12 @@
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(ext-link)"/> 
         &lt;ext-link&gt; elements.</assert>
       
-      <assert test="count(date-in-citation)=1" role="error" id="err-elem-cit-web-11-1">[err-elem-cit-web-11-1]
-        One and only one &lt;date-in-citation&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> 
-        &lt;date-in-citation&gt; elements.</assert>
+      
+      
+      <report test="count(date-in-citation) lt 1" role="error" id="final-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element) which is required.</report>
+      
+      <report test="count(date-in-citation) gt 1" role="error" id="err-elem-cit-web-11-1-1">Web Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> &lt;date-in-citation&gt; elements. One and only one &lt;date-in-citation&gt; element is required.</report>
       
       <assert test="count(*) = count(person-group|article-title|source|year|ext-link|date-in-citation)" role="error" id="err-elem-cit-web-12">[err-elem-cit-web-12]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="web" are:
@@ -4753,7 +4765,7 @@
       <assert test="matches(.,'\p{N}')" role="error" id="vid-xref-conformity-1">
         <value-of select="."/> - video citation does not contain any numbers which must be incorrect.</assert>
       
-      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to (target video label number is <value-of select="$target-no"/>, but that number is not in the citation).</assert>
+      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to. Target video label number is <value-of select="$target-no"/>, but that number is not in the citation text - <value-of select="."/>.</assert>
       
       <report test="matches($pre-text,'[\p{L}\p{N}\p{M}\p{Pe},;]$')" role="warning" id="vid-xref-test-2">There is no space between citation and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
@@ -5737,7 +5749,7 @@
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1652,7 +1652,10 @@
       
       <report test="($article-type = $features-article-types) and not(label)" role="warning" id="feat-fig-test-3">fig doesn't have a label. Is this correct?</report>
       
-      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="error" id="fig-test-4">fig must have a caption.</report>
+      
+      
+      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="error" id="final-fig-test-4">
+        <value-of select="label"/> has no title or caption (caption element).</report>
       
       
       
@@ -1753,7 +1756,7 @@
       <assert test="label" role="error" id="supplementary-material-test-1">supplementary-material must have a label.</assert>
       
       <report test="if (contains(label,'Transparent reporting form')) then ()                      else not(caption)" role="warning" id="supplementary-material-test-2">
-        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material have a child caption.)</report>
+        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material should have a child caption.)</report>
       
       
       
@@ -1766,8 +1769,10 @@
         role="warning"
         id="supplementary-material-test-4">supplementary-material caption does not have a p. Is this correct?</report>-->
       
-      <assert test="media" role="error" id="supplementary-material-test-5">
-        <value-of select="label"/> - supplementary-material must have a media.</assert>		
+      		
+      
+      <assert test="media" role="error" id="final-supplementary-material-test-5">
+        <value-of select="label"/> is missing a file (supplementary-material must have a media).</assert>
       
       <assert test="matches(label,'^Transparent reporting form$|^Figure \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Table \d{1,4}—source data \d{1,4}\.$|^Video \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—source code \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Table \d{1,4}—source code \d{1,4}\.$|^Video \d{1,4}—source code \d{1,4}\.$|^Supplementary file \d{1,4}\.$|^Source data \d{1,4}\.$|^Source code \d{1,4}\.$|^Reporting standard \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source code \d{1,4}\.$')" role="error" id="supplementary-material-test-6">supplementary-material label (<value-of select="label"/>) does not conform to eLife's usual label format.</assert>
       
@@ -1890,6 +1895,9 @@
       
       <report test="($id != 'keyresource') and matches(normalize-space(descendant::thead[1]),'[Rr]eagent\s?type\s?\(species\)\s?or resource\s?[Dd]esignation\s?[Ss]ource\s?or\s?reference\s?[Ii]dentifiers\s?[Aa]dditional\s?information')" role="error" id="kr-table-not-tagged">
         <value-of select="$lab"/> has headings that are for the Key reources table, but it does not have an @id='keyresource'.</report>
+      
+      <report test="matches(caption/title[1],'^[Kk]ey [Rr]esource')" role="warning" id="kr-table-not-tagged-2">
+        <value-of select="$lab"/> has the title <value-of select="caption/title[1]"/> but it is not tagged as a ke resources table. Is this correct?</report>
       
     </rule>
   </pattern>
@@ -2164,7 +2172,9 @@
       
       <report test="label[contains(lower-case(.),'supplement')]" role="error" id="fig-specific-test-1">fig label contains 'supplement', but it does not have a @specific-use='child-fig'. If it is a figure supplement it needs the attribute, if it isn't then it cannot contain 'supplement' in the label.</report>
       
-      <report test="if ($article-type = ('correction','retraction')) then ()                      else if ($count = 0) then ()                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()                     else $no != string($pos)" role="error" id="fig-specific-test-2">
+      
+      
+      <report test="if ($article-type = ('correction','retraction')) then ()          else if ($count = 0) then ()         else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()         else $no != string($pos)" role="error" id="final-fig-specific-test-2">
         <value-of select="$lab"/> does not appear in sequence which is incorrect. Relative to the other figures it is placed in position <value-of select="$pos"/>.</report>
       
       <report test="if ($article-type = ('correction','retraction')) then ()          else not((preceding::p[1]//xref[@rid = $id]) or (preceding::p[parent::sec][1]//xref[@rid = $id]))" role="warning" id="fig-specific-test-3">
@@ -3787,10 +3797,12 @@
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(ext-link)"/> 
         &lt;ext-link&gt; elements.</assert>
       
-      <assert test="count(date-in-citation)=1" role="error" id="err-elem-cit-web-11-1">[err-elem-cit-web-11-1]
-        One and only one &lt;date-in-citation&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> 
-        &lt;date-in-citation&gt; elements.</assert>
+      
+      
+      <report test="count(date-in-citation) lt 1" role="error" id="final-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element) which is required.</report>
+      
+      <report test="count(date-in-citation) gt 1" role="error" id="err-elem-cit-web-11-1-1">Web Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> &lt;date-in-citation&gt; elements. One and only one &lt;date-in-citation&gt; element is required.</report>
       
       <assert test="count(*) = count(person-group|article-title|source|year|ext-link|date-in-citation)" role="error" id="err-elem-cit-web-12">[err-elem-cit-web-12]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="web" are:
@@ -4759,7 +4771,7 @@
       <assert test="matches(.,'\p{N}')" role="error" id="vid-xref-conformity-1">
         <value-of select="."/> - video citation does not contain any numbers which must be incorrect.</assert>
       
-      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to (target video label number is <value-of select="$target-no"/>, but that number is not in the citation).</assert>
+      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to. Target video label number is <value-of select="$target-no"/>, but that number is not in the citation text - <value-of select="."/>.</assert>
       
       <report test="matches($pre-text,'[\p{L}\p{N}\p{M}\p{Pe},;]$')" role="warning" id="vid-xref-test-2">There is no space between citation and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
@@ -5743,7 +5755,7 @@
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1646,7 +1646,10 @@
       
       <report test="($article-type = $features-article-types) and not(label)" role="warning" id="feat-fig-test-3">fig doesn't have a label. Is this correct?</report>
       
-      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="error" id="fig-test-4">fig must have a caption.</report>
+      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="warning" id="pre-fig-test-4">
+        <value-of select="label"/> has no title or caption (caption element). Esnure this is queried with the author.</report>
+      
+      
       
       <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption/title)" role="warning" id="pre-fig-test-5">
         <value-of select="label"/> does not have a title. Please alert eLife staff.</report>
@@ -1748,7 +1751,7 @@
       <assert test="label" role="error" id="supplementary-material-test-1">supplementary-material must have a label.</assert>
       
       <report test="if (contains(label,'Transparent reporting form')) then ()                      else not(caption)" role="warning" id="supplementary-material-test-2">
-        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material have a child caption.)</report>
+        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material should have a child caption.)</report>
       
       <report test="if (caption) then not(caption/title)                     else ()" role="warning" id="pre-supplementary-material-test-3">
         <value-of select="label"/> does not have a title. Please alert eLife staff.</report>
@@ -1761,8 +1764,10 @@
         role="warning"
         id="supplementary-material-test-4">supplementary-material caption does not have a p. Is this correct?</report>-->
       
-      <assert test="media" role="error" id="supplementary-material-test-5">
-        <value-of select="label"/> - supplementary-material must have a media.</assert>		
+      <assert test="media" role="warning" id="pre-supplementary-material-test-5">
+        <value-of select="label"/> is missing a file (supplementary-material missing a media element) - please ensure that this is queried with the author.</assert>		
+      
+      
       
       <assert test="matches(label,'^Transparent reporting form$|^Figure \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Table \d{1,4}—source data \d{1,4}\.$|^Video \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—source code \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Table \d{1,4}—source code \d{1,4}\.$|^Video \d{1,4}—source code \d{1,4}\.$|^Supplementary file \d{1,4}\.$|^Source data \d{1,4}\.$|^Source code \d{1,4}\.$|^Reporting standard \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source code \d{1,4}\.$')" role="error" id="supplementary-material-test-6">supplementary-material label (<value-of select="label"/>) does not conform to eLife's usual label format.</assert>
       
@@ -1885,6 +1890,9 @@
       
       <report test="($id != 'keyresource') and matches(normalize-space(descendant::thead[1]),'[Rr]eagent\s?type\s?\(species\)\s?or resource\s?[Dd]esignation\s?[Ss]ource\s?or\s?reference\s?[Ii]dentifiers\s?[Aa]dditional\s?information')" role="error" id="kr-table-not-tagged">
         <value-of select="$lab"/> has headings that are for the Key reources table, but it does not have an @id='keyresource'.</report>
+      
+      <report test="matches(caption/title[1],'^[Kk]ey [Rr]esource')" role="warning" id="kr-table-not-tagged-2">
+        <value-of select="$lab"/> has the title <value-of select="caption/title[1]"/> but it is not tagged as a ke resources table. Is this correct?</report>
       
     </rule>
   </pattern>
@@ -2159,8 +2167,10 @@
       
       <report test="label[contains(lower-case(.),'supplement')]" role="error" id="fig-specific-test-1">fig label contains 'supplement', but it does not have a @specific-use='child-fig'. If it is a figure supplement it needs the attribute, if it isn't then it cannot contain 'supplement' in the label.</report>
       
-      <report test="if ($article-type = ('correction','retraction')) then ()                      else if ($count = 0) then ()                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()                     else $no != string($pos)" role="error" id="fig-specific-test-2">
-        <value-of select="$lab"/> does not appear in sequence which is incorrect. Relative to the other figures it is placed in position <value-of select="$pos"/>.</report>
+      <report test="if ($article-type = ('correction','retraction')) then ()                      else if ($count = 0) then ()                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()                     else $no != string($pos)" role="warning" id="pre-fig-specific-test-2">
+        <value-of select="$lab"/> does not appear in sequence. Relative to the other figures it is placed in position <value-of select="$pos"/>. Please query this with the author.</report>
+      
+      
       
       <report test="if ($article-type = ('correction','retraction')) then ()          else not((preceding::p[1]//xref[@rid = $id]) or (preceding::p[parent::sec][1]//xref[@rid = $id]))" role="warning" id="fig-specific-test-3">
         <value-of select="$lab"/> does not appear directly after a paragraph citing it. Is that correct?</report>
@@ -3782,10 +3792,12 @@
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(ext-link)"/> 
         &lt;ext-link&gt; elements.</assert>
       
-      <assert test="count(date-in-citation)=1" role="error" id="err-elem-cit-web-11-1">[err-elem-cit-web-11-1]
-        One and only one &lt;date-in-citation&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> 
-        &lt;date-in-citation&gt; elements.</assert>
+      <report test="count(date-in-citation) lt 1" role="warning" id="pre-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element), which is required. Please ensure this is queried with the author.</report>
+      
+      
+      
+      <report test="count(date-in-citation) gt 1" role="error" id="err-elem-cit-web-11-1-1">Web Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> &lt;date-in-citation&gt; elements. One and only one &lt;date-in-citation&gt; element is required.</report>
       
       <assert test="count(*) = count(person-group|article-title|source|year|ext-link|date-in-citation)" role="error" id="err-elem-cit-web-12">[err-elem-cit-web-12]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="web" are:
@@ -4754,7 +4766,7 @@
       <assert test="matches(.,'\p{N}')" role="error" id="vid-xref-conformity-1">
         <value-of select="."/> - video citation does not contain any numbers which must be incorrect.</assert>
       
-      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to (target video label number is <value-of select="$target-no"/>, but that number is not in the citation).</assert>
+      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to. Target video label number is <value-of select="$target-no"/>, but that number is not in the citation text - <value-of select="."/>.</assert>
       
       <report test="matches($pre-text,'[\p{L}\p{N}\p{M}\p{Pe},;]$')" role="warning" id="vid-xref-test-2">There is no space between citation and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
@@ -5738,7 +5750,7 @@
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2163,8 +2163,13 @@
       
       <report test="if ($article-type = ('correction','retraction')) then () 
         else not(caption)" 
+        role="warning"
+        id="pre-fig-test-4"><value-of select="label"/> has no title or caption (caption element). Esnure this is queried with the author.</report>
+      
+      <report test="if ($article-type = ('correction','retraction')) then () 
+        else not(caption)" 
         role="error"
-        id="fig-test-4">fig must have a caption.</report>
+        id="final-fig-test-4"><value-of select="label"/> has no title or caption (caption element).</report>
       
       <report test="if ($article-type = ('correction','retraction')) then () 
         else not(caption/title)" 
@@ -2337,7 +2342,7 @@
       <report test="if (contains(label,'Transparent reporting form')) then () 
                     else not(caption)" 
         role="warning"
-        id="supplementary-material-test-2"><value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material have a child caption.)</report>
+        id="supplementary-material-test-2"><value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material should have a child caption.)</report>
       
       <report test="if (caption) then not(caption/title)
                     else ()" 
@@ -2356,8 +2361,12 @@
         id="supplementary-material-test-4">supplementary-material caption does not have a p. Is this correct?</report>-->
       
       <assert test="media"
+        role="warning"
+        id="pre-supplementary-material-test-5"><value-of select="label"/> is missing a file (supplementary-material missing a media element) - please ensure that this is queried with the author.</assert>		
+      
+      <assert test="media"
         role="error"
-        id="supplementary-material-test-5"><value-of select="label"/> - supplementary-material must have a media.</assert>		
+        id="final-supplementary-material-test-5"><value-of select="label"/> is missing a file (supplementary-material must have a media).</assert>
       
       <assert test="matches(label,'^Transparent reporting form$|^Figure \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Table \d{1,4}—source data \d{1,4}\.$|^Video \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—source code \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Table \d{1,4}—source code \d{1,4}\.$|^Video \d{1,4}—source code \d{1,4}\.$|^Supplementary file \d{1,4}\.$|^Source data \d{1,4}\.$|^Source code \d{1,4}\.$|^Reporting standard \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source code \d{1,4}\.$')"
         role="error"
@@ -2560,6 +2569,10 @@
       <report test="($id != 'keyresource') and matches(normalize-space(descendant::thead[1]),'[Rr]eagent\s?type\s?\(species\)\s?or resource\s?[Dd]esignation\s?[Ss]ource\s?or\s?reference\s?[Ii]dentifiers\s?[Aa]dditional\s?information')" 
         role="error"
         id="kr-table-not-tagged"><value-of select="$lab"/> has headings that are for the Key reources table, but it does not have an @id='keyresource'.</report>
+      
+      <report test="matches(caption/title[1],'^[Kk]ey [Rr]esource')" 
+        role="warning"
+        id="kr-table-not-tagged-2"><value-of select="$lab"/> has the title <value-of select="caption/title[1]"/> but it is not tagged as a ke resources table. Is this correct?</report>
       
     </rule>
     
@@ -2923,8 +2936,15 @@
                     else if ($count = 0) then ()
                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()
                     else $no != string($pos)" 
+        role="warning"
+        id="pre-fig-specific-test-2"><value-of select="$lab"/> does not appear in sequence. Relative to the other figures it is placed in position <value-of select="$pos"/>. Please query this with the author.</report>
+      
+      <report test="if ($article-type = ('correction','retraction')) then () 
+        else if ($count = 0) then ()
+        else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()
+        else $no != string($pos)" 
         role="error"
-        id="fig-specific-test-2"><value-of select="$lab"/> does not appear in sequence which is incorrect. Relative to the other figures it is placed in position <value-of select="$pos"/>.</report>
+        id="final-fig-specific-test-2"><value-of select="$lab"/> does not appear in sequence which is incorrect. Relative to the other figures it is placed in position <value-of select="$pos"/>.</report>
       
       <report test="if ($article-type = ('correction','retraction')) then () 
         else not((preceding::p[1]//xref[@rid = $id]) or (preceding::p[parent::sec][1]//xref[@rid = $id]))" 
@@ -4993,10 +5013,19 @@
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(ext-link)"/> 
         &lt;ext-link&gt; elements.</assert>
       
-      <assert test="count(date-in-citation)=1" role="error" id="err-elem-cit-web-11-1">[err-elem-cit-web-11-1]
-        One and only one &lt;date-in-citation&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> 
-        &lt;date-in-citation&gt; elements.</assert>
+      <report test="count(date-in-citation) lt 1" 
+        role="warning" 
+        id="pre-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element), which is required. Please ensure this is queried with the author.</report>
+      
+      <report test="count(date-in-citation) lt 1" 
+        role="error" 
+        id="final-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element) which is required.</report>
+      
+      <report test="count(date-in-citation) gt 1" 
+        role="error" 
+        id="err-elem-cit-web-11-1-1">Web Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> &lt;date-in-citation&gt; elements. One and only one &lt;date-in-citation&gt; element is required.</report>
       
       <assert test="count(*) = count(person-group|article-title|source|year|ext-link|date-in-citation)" role="error" id="err-elem-cit-web-12">[err-elem-cit-web-12]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="web" are:
@@ -6226,7 +6255,7 @@
       
       <assert test="contains(.,$target-no)"
         role="error" 
-        id="vid-xref-conformity-2">video citation does not matches the video that it links to (target video label number is <value-of select="$target-no"/>, but that number is not in the citation).</assert>
+        id="vid-xref-conformity-2">video citation does not matches the video that it links to. Target video label number is <value-of select="$target-no"/>, but that number is not in the citation text - <value-of select="."/>.</assert>
       
       <report test="matches($pre-text,'[\p{L}\p{N}\p{M}\p{Pe},;]$')"
         role="warning"
@@ -7670,7 +7699,7 @@
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" 
         role="error" 
-        id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+        id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')"
         role="error" 

--- a/test/tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/err-elem-cit-web-11-1-1.sch
+++ b/test/tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/err-elem-cit-web-11-1-1.sch
@@ -683,18 +683,14 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="content-containers">
-    <rule context="supplementary-material" id="supplementary-material-tests">
-      <let name="link" value="media[1]/@xlink:href"/>
-      <let name="file" value="if (contains($link,'.')) then lower-case(tokenize($link,'\.')[last()]) else ()"/>
-      <let name="code-files" value="('m','py','lib','jl','c','sh','for','cpproj','ipynb','mph','cc','rmd','nlogo','stan','wrl','pl','r','fas','ijm','llb','ipf','mdl','h')"/>
-      <assert test="media" role="error" id="supplementary-material-test-5">
-        <value-of select="label"/> - supplementary-material must have a media.</assert>
+  <pattern id="element-citation-web-tests">
+    <rule context="element-citation[@publication-type='web']" id="elem-citation-web">
+      <report test="count(date-in-citation) gt 1" role="error" id="err-elem-cit-web-11-1-1">Web Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> &lt;date-in-citation&gt; elements. One and only one &lt;date-in-citation&gt; element is required.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::supplementary-material" role="error" id="supplementary-material-tests-xspec-assert">supplementary-material must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='web']" role="error" id="elem-citation-web-xspec-assert">element-citation[@publication-type='web'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/fail.xml
+++ b/test/tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/fail.xml
@@ -1,0 +1,25 @@
+<?oxygen SCHSchema="err-elem-cit-web-11-1-1.sch"?>
+<!--Context: element-citation[@publication-type='web']
+Test: report    count(date-in-citation) gt 1
+Message: Web Reference '' has  <dateincitation> elements. One and only one <dateincitation> element is required.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article>
+    <ref-list>
+      <ref id="bib1">
+        <element-citation publication-type="web">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Walker</surname>
+              <given-names>J</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="1994">1994</year>
+          <article-title>Solar System Live</article-title>
+          <ext-link ext-link-type="uri" xlink:href="https://www.fourmilab.ch/solar/">https://www.fourmilab.ch/solar/</ext-link>
+          <date-in-citation iso-8601-date="1995-09-10">September 10, 1995</date-in-citation>
+          <date-in-citation iso-8601-date="1995-09-10">September 10, 1995</date-in-citation>
+        </element-citation>
+      </ref>
+    </ref-list>
+  </article>
+</root>

--- a/test/tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/pass.xml
+++ b/test/tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/pass.xml
@@ -1,10 +1,7 @@
-<?oxygen SCHSchema="err-elem-cit-web-11-1.sch"?>
+<?oxygen SCHSchema="err-elem-cit-web-11-1-1.sch"?>
 <!--Context: element-citation[@publication-type='web']
-Test: assert    count(date-in-citation)=1
-Message: [errelemcitweb111]
-        One and only one <dateincitation> element is required.
-        Reference '' has  
-        <dateincitation> elements.-->
+Test: report    count(date-in-citation) gt 1
+Message: Web Reference '' has  <dateincitation> elements. One and only one <dateincitation> element is required.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <ref-list>
@@ -19,7 +16,7 @@ Message: [errelemcitweb111]
           <year iso-8601-date="1994">1994</year>
           <article-title>Solar System Live</article-title>
           <ext-link ext-link-type="uri" xlink:href="https://www.fourmilab.ch/solar/">https://www.fourmilab.ch/solar/</ext-link>
-          
+          <date-in-citation iso-8601-date="1995-09-10">September 10, 1995</date-in-citation>
         </element-citation>
       </ref>
     </ref-list>

--- a/test/tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/fail.xml
+++ b/test/tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/fail.xml
@@ -1,0 +1,25 @@
+<?oxygen SCHSchema="final-err-elem-cit-web-11-1.sch"?>
+<!--Context: element-citation[@publication-type='web']
+Test: report    count(date-in-citation) lt 1
+Message: 
+        Web Reference '' has no accessed date (<dateincitation> element) which is required.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article>
+    <ref-list>
+      <ref id="bib1">
+        <element-citation publication-type="web">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Walker</surname>
+              <given-names>J</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="1994">1994</year>
+          <article-title>Solar System Live</article-title>
+          <ext-link ext-link-type="uri" xlink:href="https://www.fourmilab.ch/solar/">https://www.fourmilab.ch/solar/</ext-link>
+          
+        </element-citation>
+      </ref>
+    </ref-list>
+  </article>
+</root>

--- a/test/tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/final-err-elem-cit-web-11-1.sch
+++ b/test/tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/final-err-elem-cit-web-11-1.sch
@@ -683,23 +683,15 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="further-fig-tests">
-    <rule context="article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]" id="fig-specific-tests">
-      <let name="article-type" value="ancestor::article/@article-type"/>
-      <let name="id" value="@id"/>
-      <let name="count" value="count(ancestor::article//fig[matches(label,'^Figure \d{1,4}\.$')])"/>
-      <let name="pos" value="$count - count(following::fig[matches(label,'^Figure \d{1,4}\.$')])"/>
-      <let name="no" value="substring-after($id,'fig')"/>
-      <let name="pre-sib" value="preceding-sibling::*[1]"/>
-      <let name="fol-sib" value="following-sibling::*[1]"/>
-      <let name="lab" value="replace(label,'\.','')"/>
-      <report test="if ($article-type = ('correction','retraction')) then ()                      else if ($count = 0) then ()                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()                     else $no != string($pos)" role="error" id="fig-specific-test-2">
-        <value-of select="$lab"/> does not appear in sequence which is incorrect. Relative to the other figures it is placed in position <value-of select="$pos"/>.</report>
+  <pattern id="element-citation-web-tests">
+    <rule context="element-citation[@publication-type='web']" id="elem-citation-web">
+      <report test="count(date-in-citation) lt 1" role="error" id="final-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element) which is required.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]" role="error" id="fig-specific-tests-xspec-assert">article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)] must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='web']" role="error" id="elem-citation-web-xspec-assert">element-citation[@publication-type='web'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/pass.xml
+++ b/test/tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/pass.xml
@@ -1,0 +1,25 @@
+<?oxygen SCHSchema="final-err-elem-cit-web-11-1.sch"?>
+<!--Context: element-citation[@publication-type='web']
+Test: report    count(date-in-citation) lt 1
+Message: 
+        Web Reference '' has no accessed date (<dateincitation> element) which is required.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article>
+    <ref-list>
+      <ref id="bib1">
+        <element-citation publication-type="web">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Walker</surname>
+              <given-names>J</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="1994">1994</year>
+          <article-title>Solar System Live</article-title>
+          <ext-link ext-link-type="uri" xlink:href="https://www.fourmilab.ch/solar/">https://www.fourmilab.ch/solar/</ext-link>
+          <date-in-citation iso-8601-date="1995-09-10">September 10, 1995</date-in-citation>
+        </element-citation>
+      </ref>
+    </ref-list>
+  </article>
+</root>

--- a/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/fail.xml
+++ b/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/fail.xml
@@ -1,0 +1,25 @@
+<?oxygen SCHSchema="pre-err-elem-cit-web-11-1.sch"?>
+<!--Context: element-citation[@publication-type='web']
+Test: report    count(date-in-citation) lt 1
+Message: 
+        Web Reference '' has no accessed date (<dateincitation> element), which is required. Please ensure this is queried with the author.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article>
+    <ref-list>
+      <ref id="bib1">
+        <element-citation publication-type="web">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Walker</surname>
+              <given-names>J</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="1994">1994</year>
+          <article-title>Solar System Live</article-title>
+          <ext-link ext-link-type="uri" xlink:href="https://www.fourmilab.ch/solar/">https://www.fourmilab.ch/solar/</ext-link>
+          
+        </element-citation>
+      </ref>
+    </ref-list>
+  </article>
+</root>

--- a/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/pass.xml
+++ b/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/pass.xml
@@ -1,10 +1,8 @@
-<?oxygen SCHSchema="err-elem-cit-web-11-1.sch"?>
+<?oxygen SCHSchema="pre-err-elem-cit-web-11-1.sch"?>
 <!--Context: element-citation[@publication-type='web']
-Test: assert    count(date-in-citation)=1
-Message: [errelemcitweb111]
-        One and only one <dateincitation> element is required.
-        Reference '' has  
-        <dateincitation> elements.-->
+Test: report    count(date-in-citation) lt 1
+Message: 
+        Web Reference '' has no accessed date (<dateincitation> element), which is required. Please ensure this is queried with the author.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <ref-list>

--- a/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/pre-err-elem-cit-web-11-1.sch
+++ b/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/pre-err-elem-cit-web-11-1.sch
@@ -683,15 +683,15 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
-      <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
+  <pattern id="element-citation-web-tests">
+    <rule context="element-citation[@publication-type='web']" id="elem-citation-web">
+      <report test="count(date-in-citation) lt 1" role="warning" id="pre-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element), which is required. Please ensure this is queried with the author.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='web']" role="error" id="elem-citation-web-xspec-assert">element-citation[@publication-type='web'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/fig-specific-tests/final-fig-specific-test-2/fail.xml
+++ b/test/tests/gen/fig-specific-tests/final-fig-specific-test-2/fail.xml
@@ -1,20 +1,20 @@
-<?oxygen SCHSchema="fig-specific-test-2.sch"?>
+<?oxygen SCHSchema="final-fig-specific-test-2.sch"?>
 <!--Context: article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]
 Test: report    if ($article-type = ('correction','retraction')) then () else if ($count = 0) then () else if (not(matches($id,'^fig[0-9]{1,3}$'))) then () else $no != string($pos)
 Message:  does not appear in sequence which is incorrect. Relative to the other figures it is placed in position .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="discussion">
     <body>
-      <xref ref-type="fig" rid="fig1"/>
-      <fig id="fig1">
-        <label>Figure 1.</label>
+      <fig id="fig2">
+        <label>Figure 2.</label>
         <caption>
           <title>Title.</title>
           <p>Reproduced from Smith et al., 19992</p>
         </caption>
       </fig>
-      <fig id="fig2">
-        <label>Figure 2.</label>
+      <xref ref-type="fig" rid="fig1"/>
+      <fig id="fig1">
+        <label>Figure 1.</label>
         <caption>
           <title>Title.</title>
           <p>Reproduced from Smith et al., 19992</p>

--- a/test/tests/gen/fig-specific-tests/final-fig-specific-test-2/final-fig-specific-test-2.sch
+++ b/test/tests/gen/fig-specific-tests/final-fig-specific-test-2/final-fig-specific-test-2.sch
@@ -683,17 +683,23 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="element-citation-web-tests">
-    <rule context="element-citation[@publication-type='web']" id="elem-citation-web">
-      <assert test="count(date-in-citation)=1" role="error" id="err-elem-cit-web-11-1">[err-elem-cit-web-11-1]
-        One and only one &lt;date-in-citation&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> 
-        &lt;date-in-citation&gt; elements.</assert>
+  <pattern id="further-fig-tests">
+    <rule context="article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]" id="fig-specific-tests">
+      <let name="article-type" value="ancestor::article/@article-type"/>
+      <let name="id" value="@id"/>
+      <let name="count" value="count(ancestor::article//fig[matches(label,'^Figure \d{1,4}\.$')])"/>
+      <let name="pos" value="$count - count(following::fig[matches(label,'^Figure \d{1,4}\.$')])"/>
+      <let name="no" value="substring-after($id,'fig')"/>
+      <let name="pre-sib" value="preceding-sibling::*[1]"/>
+      <let name="fol-sib" value="following-sibling::*[1]"/>
+      <let name="lab" value="replace(label,'\.','')"/>
+      <report test="if ($article-type = ('correction','retraction')) then ()          else if ($count = 0) then ()         else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()         else $no != string($pos)" role="error" id="final-fig-specific-test-2">
+        <value-of select="$lab"/> does not appear in sequence which is incorrect. Relative to the other figures it is placed in position <value-of select="$pos"/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='web']" role="error" id="elem-citation-web-xspec-assert">element-citation[@publication-type='web'] must be present.</assert>
+      <assert test="descendant::article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]" role="error" id="fig-specific-tests-xspec-assert">article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/fig-specific-tests/final-fig-specific-test-2/pass.xml
+++ b/test/tests/gen/fig-specific-tests/final-fig-specific-test-2/pass.xml
@@ -1,0 +1,25 @@
+<?oxygen SCHSchema="final-fig-specific-test-2.sch"?>
+<!--Context: article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]
+Test: report    if ($article-type = ('correction','retraction')) then () else if ($count = 0) then () else if (not(matches($id,'^fig[0-9]{1,3}$'))) then () else $no != string($pos)
+Message:  does not appear in sequence which is incorrect. Relative to the other figures it is placed in position .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article article-type="discussion">
+    <body>
+      <xref ref-type="fig" rid="fig1"/>
+      <fig id="fig1">
+        <label>Figure 1.</label>
+        <caption>
+          <title>Title.</title>
+          <p>Reproduced from Smith et al., 19992</p>
+        </caption>
+      </fig>
+      <fig id="fig2">
+        <label>Figure 2.</label>
+        <caption>
+          <title>Title.</title>
+          <p>Reproduced from Smith et al., 19992</p>
+        </caption>
+      </fig>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/fig-specific-tests/pre-fig-specific-test-2/fail.xml
+++ b/test/tests/gen/fig-specific-tests/pre-fig-specific-test-2/fail.xml
@@ -1,7 +1,7 @@
-<?oxygen SCHSchema="fig-specific-test-2.sch"?>
+<?oxygen SCHSchema="pre-fig-specific-test-2.sch"?>
 <!--Context: article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]
 Test: report    if ($article-type = ('correction','retraction')) then () else if ($count = 0) then () else if (not(matches($id,'^fig[0-9]{1,3}$'))) then () else $no != string($pos)
-Message:  does not appear in sequence which is incorrect. Relative to the other figures it is placed in position .-->
+Message:  does not appear in sequence. Relative to the other figures it is placed in position . Please query this with the author.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="discussion">
     <body>

--- a/test/tests/gen/fig-specific-tests/pre-fig-specific-test-2/pass.xml
+++ b/test/tests/gen/fig-specific-tests/pre-fig-specific-test-2/pass.xml
@@ -1,0 +1,25 @@
+<?oxygen SCHSchema="pre-fig-specific-test-2.sch"?>
+<!--Context: article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]
+Test: report    if ($article-type = ('correction','retraction')) then () else if ($count = 0) then () else if (not(matches($id,'^fig[0-9]{1,3}$'))) then () else $no != string($pos)
+Message:  does not appear in sequence. Relative to the other figures it is placed in position . Please query this with the author.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article article-type="discussion">
+    <body>
+      <xref ref-type="fig" rid="fig1"/>
+      <fig id="fig1">
+        <label>Figure 1.</label>
+        <caption>
+          <title>Title.</title>
+          <p>Reproduced from Smith et al., 19992</p>
+        </caption>
+      </fig>
+      <fig id="fig2">
+        <label>Figure 2.</label>
+        <caption>
+          <title>Title.</title>
+          <p>Reproduced from Smith et al., 19992</p>
+        </caption>
+      </fig>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/fig-specific-tests/pre-fig-specific-test-2/pre-fig-specific-test-2.sch
+++ b/test/tests/gen/fig-specific-tests/pre-fig-specific-test-2/pre-fig-specific-test-2.sch
@@ -683,15 +683,23 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
-      <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
+  <pattern id="further-fig-tests">
+    <rule context="article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]" id="fig-specific-tests">
+      <let name="article-type" value="ancestor::article/@article-type"/>
+      <let name="id" value="@id"/>
+      <let name="count" value="count(ancestor::article//fig[matches(label,'^Figure \d{1,4}\.$')])"/>
+      <let name="pos" value="$count - count(following::fig[matches(label,'^Figure \d{1,4}\.$')])"/>
+      <let name="no" value="substring-after($id,'fig')"/>
+      <let name="pre-sib" value="preceding-sibling::*[1]"/>
+      <let name="fol-sib" value="following-sibling::*[1]"/>
+      <let name="lab" value="replace(label,'\.','')"/>
+      <report test="if ($article-type = ('correction','retraction')) then ()                      else if ($count = 0) then ()                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()                     else $no != string($pos)" role="warning" id="pre-fig-specific-test-2">
+        <value-of select="$lab"/> does not appear in sequence. Relative to the other figures it is placed in position <value-of select="$pos"/>. Please query this with the author.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+      <assert test="descendant::article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]" role="error" id="fig-specific-tests-xspec-assert">article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/fig-tests/final-fig-test-4/fail.xml
+++ b/test/tests/gen/fig-tests/final-fig-test-4/fail.xml
@@ -1,0 +1,11 @@
+<?oxygen SCHSchema="final-fig-test-4.sch"?>
+<!--Context: fig[not(ancestor::sub-article[@article-type='reply'])]
+Test: report    if ($article-type = ('correction','retraction')) then () else not(caption)
+Message:  has no title or caption (caption element).-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article article-type="research-article">
+    <fig>
+      <label/>
+    </fig>
+  </article>
+</root>

--- a/test/tests/gen/fig-tests/final-fig-test-4/final-fig-test-4.sch
+++ b/test/tests/gen/fig-tests/final-fig-test-4/final-fig-test-4.sch
@@ -683,15 +683,16 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
-      <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
+  <pattern id="content-containers">
+    <rule context="fig[not(ancestor::sub-article[@article-type='reply'])]" id="fig-tests">
+      <let name="article-type" value="ancestor::article/@article-type"/>
+      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="error" id="final-fig-test-4">
+        <value-of select="label"/> has no title or caption (caption element).</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+      <assert test="descendant::fig[not(ancestor::sub-article[@article-type='reply'])]" role="error" id="fig-tests-xspec-assert">fig[not(ancestor::sub-article[@article-type='reply'])] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/fig-tests/final-fig-test-4/pass.xml
+++ b/test/tests/gen/fig-tests/final-fig-test-4/pass.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="final-fig-test-4.sch"?>
+<!--Context: fig[not(ancestor::sub-article[@article-type='reply'])]
+Test: report    if ($article-type = ('correction','retraction')) then () else not(caption)
+Message:  has no title or caption (caption element).-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article article-type="research-article">
+    <fig>
+      <label/>
+      <caption/>
+    </fig>
+  </article>
+</root>

--- a/test/tests/gen/fig-tests/pre-fig-test-4/fail.xml
+++ b/test/tests/gen/fig-tests/pre-fig-test-4/fail.xml
@@ -1,0 +1,11 @@
+<?oxygen SCHSchema="pre-fig-test-4.sch"?>
+<!--Context: fig[not(ancestor::sub-article[@article-type='reply'])]
+Test: report    if ($article-type = ('correction','retraction')) then () else not(caption)
+Message:  has no title or caption (caption element). Esnure this is queried with the author.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article article-type="research-article">
+    <fig>
+      <label/>
+    </fig>
+  </article>
+</root>

--- a/test/tests/gen/fig-tests/pre-fig-test-4/pass.xml
+++ b/test/tests/gen/fig-tests/pre-fig-test-4/pass.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="pre-fig-test-4.sch"?>
+<!--Context: fig[not(ancestor::sub-article[@article-type='reply'])]
+Test: report    if ($article-type = ('correction','retraction')) then () else not(caption)
+Message:  has no title or caption (caption element). Esnure this is queried with the author.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article article-type="research-article">
+    <fig>
+      <label/>
+      <caption/>
+    </fig>
+  </article>
+</root>

--- a/test/tests/gen/fig-tests/pre-fig-test-4/pre-fig-test-4.sch
+++ b/test/tests/gen/fig-tests/pre-fig-test-4/pre-fig-test-4.sch
@@ -683,15 +683,16 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
-      <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
+  <pattern id="content-containers">
+    <rule context="fig[not(ancestor::sub-article[@article-type='reply'])]" id="fig-tests">
+      <let name="article-type" value="ancestor::article/@article-type"/>
+      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="warning" id="pre-fig-test-4">
+        <value-of select="label"/> has no title or caption (caption element). Esnure this is queried with the author.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+      <assert test="descendant::fig[not(ancestor::sub-article[@article-type='reply'])]" role="error" id="fig-tests-xspec-assert">fig[not(ancestor::sub-article[@article-type='reply'])] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/software-ref-tests/R-test-4/fail.xml
+++ b/test/tests/gen/software-ref-tests/R-test-4/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="R-test-4.sch"?>
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))
-Message: software ref '' has a datatitle    but does not have a 'http://www.[Rr]project.org' link.-->
+Message: software ref '' has a datatitle    but does not have a 'http://www.rproject.org' type link.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <ref id="bib33"><element-citation publication-type="software">

--- a/test/tests/gen/software-ref-tests/R-test-4/pass.xml
+++ b/test/tests/gen/software-ref-tests/R-test-4/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="R-test-4.sch"?>
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))
-Message: software ref '' has a datatitle    but does not have a 'http://www.[Rr]project.org' link.-->
+Message: software ref '' has a datatitle    but does not have a 'http://www.rproject.org' type link.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <ref id="bib33"><element-citation publication-type="software">

--- a/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-5/fail.xml
+++ b/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-5/fail.xml
@@ -1,7 +1,7 @@
-<?oxygen SCHSchema="supplementary-material-test-2.sch"?>
+<?oxygen SCHSchema="final-supplementary-material-test-5.sch"?>
 <!--Context: supplementary-material
-Test: report    if (contains(label,'Transparent reporting form')) then () else not(caption)
-Message:  is missing a title/caption  is this correct?  (supplementarymaterial should have a child caption.)-->
+Test: assert    media
+Message:  is missing a file (supplementarymaterial must have a media).-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <supplementary-material>

--- a/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-5/final-supplementary-material-test-5.sch
+++ b/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-5/final-supplementary-material-test-5.sch
@@ -683,15 +683,18 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
-      <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
+  <pattern id="content-containers">
+    <rule context="supplementary-material" id="supplementary-material-tests">
+      <let name="link" value="media[1]/@xlink:href"/>
+      <let name="file" value="if (contains($link,'.')) then lower-case(tokenize($link,'\.')[last()]) else ()"/>
+      <let name="code-files" value="('m','py','lib','jl','c','sh','for','cpproj','ipynb','mph','cc','rmd','nlogo','stan','wrl','pl','r','fas','ijm','llb','ipf','mdl','h')"/>
+      <assert test="media" role="error" id="final-supplementary-material-test-5">
+        <value-of select="label"/> is missing a file (supplementary-material must have a media).</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+      <assert test="descendant::supplementary-material" role="error" id="supplementary-material-tests-xspec-assert">supplementary-material must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-5/pass.xml
+++ b/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-5/pass.xml
@@ -1,7 +1,7 @@
-<?oxygen SCHSchema="supplementary-material-test-2.sch"?>
+<?oxygen SCHSchema="final-supplementary-material-test-5.sch"?>
 <!--Context: supplementary-material
-Test: report    if (contains(label,'Transparent reporting form')) then () else not(caption)
-Message:  is missing a title/caption  is this correct?  (supplementarymaterial should have a child caption.)-->
+Test: assert    media
+Message:  is missing a file (supplementarymaterial must have a media).-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <supplementary-material>
@@ -9,6 +9,7 @@ Message:  is missing a title/caption  is this correct?  (supplementarymaterial s
       <caption>
         <title>Title.</title>
       </caption>
+      <media/>
     </supplementary-material>
   </article>
 </root>

--- a/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/fail.xml
+++ b/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/fail.xml
@@ -1,7 +1,7 @@
-<?oxygen SCHSchema="supplementary-material-test-5.sch"?>
+<?oxygen SCHSchema="pre-supplementary-material-test-5.sch"?>
 <!--Context: supplementary-material
 Test: assert    media
-Message:   supplementarymaterial must have a media.-->
+Message:  is missing a file (supplementarymaterial missing a media element)  please ensure that this is queried with the author.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <supplementary-material>
@@ -9,7 +9,6 @@ Message:   supplementarymaterial must have a media.-->
       <caption>
         <title>Title.</title>
       </caption>
-      <media/>
     </supplementary-material>
   </article>
 </root>

--- a/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/pass.xml
+++ b/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/pass.xml
@@ -1,7 +1,7 @@
-<?oxygen SCHSchema="supplementary-material-test-5.sch"?>
+<?oxygen SCHSchema="pre-supplementary-material-test-5.sch"?>
 <!--Context: supplementary-material
 Test: assert    media
-Message:   supplementarymaterial must have a media.-->
+Message:  is missing a file (supplementarymaterial missing a media element)  please ensure that this is queried with the author.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <supplementary-material>
@@ -9,6 +9,7 @@ Message:   supplementarymaterial must have a media.-->
       <caption>
         <title>Title.</title>
       </caption>
+      <media/>
     </supplementary-material>
   </article>
 </root>

--- a/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/pre-supplementary-material-test-5.sch
+++ b/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/pre-supplementary-material-test-5.sch
@@ -683,15 +683,18 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
-      <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
+  <pattern id="content-containers">
+    <rule context="supplementary-material" id="supplementary-material-tests">
+      <let name="link" value="media[1]/@xlink:href"/>
+      <let name="file" value="if (contains($link,'.')) then lower-case(tokenize($link,'\.')[last()]) else ()"/>
+      <let name="code-files" value="('m','py','lib','jl','c','sh','for','cpproj','ipynb','mph','cc','rmd','nlogo','stan','wrl','pl','r','fas','ijm','llb','ipf','mdl','h')"/>
+      <assert test="media" role="warning" id="pre-supplementary-material-test-5">
+        <value-of select="label"/> is missing a file (supplementary-material missing a media element) - please ensure that this is queried with the author.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+      <assert test="descendant::supplementary-material" role="error" id="supplementary-material-tests-xspec-assert">supplementary-material must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-2/fail.xml
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="supplementary-material-test-2.sch"?>
 <!--Context: supplementary-material
 Test: report    if (contains(label,'Transparent reporting form')) then () else not(caption)
-Message:  is missing a title/caption  is this correct?  (supplementarymaterial have a child caption.)-->
+Message:  is missing a title/caption  is this correct?  (supplementarymaterial should have a child caption.)-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <supplementary-material>

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-2/supplementary-material-test-2.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-2/supplementary-material-test-2.sch
@@ -689,7 +689,7 @@
       <let name="file" value="if (contains($link,'.')) then lower-case(tokenize($link,'\.')[last()]) else ()"/>
       <let name="code-files" value="('m','py','lib','jl','c','sh','for','cpproj','ipynb','mph','cc','rmd','nlogo','stan','wrl','pl','r','fas','ijm','llb','ipf','mdl','h')"/>
       <report test="if (contains(label,'Transparent reporting form')) then ()                      else not(caption)" role="warning" id="supplementary-material-test-2">
-        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material have a child caption.)</report>
+        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material should have a child caption.)</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/table-wrap-tests/kr-table-not-tagged-2/fail.xml
+++ b/test/tests/gen/table-wrap-tests/kr-table-not-tagged-2/fail.xml
@@ -1,0 +1,26 @@
+<?oxygen SCHSchema="kr-table-not-tagged-2.sch"?>
+<!--Context: table-wrap
+Test: report    matches(caption/title[1],'^[Kk]ey [Rr]esource')
+Message:  has the title  but it is not tagged as a ke resources table. Is this correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article article-type="research-article">
+    <table-wrap id="table3" position="anchor">
+      <label>Table 3.</label>
+      <caption>
+        <title>Key resources.</title>
+      </caption>
+      <table frame="hsides" rules="groups">
+        <thead>
+          <tr>
+            <th>Reagent type <break/>(species) or resource</th>
+            <th>Designation</th>
+            <th>Source or reference</th>
+            <th>Identifiers</th>
+            <th>Additional <break/>information</th>
+          </tr>
+        </thead>
+        <tbody>...</tbody>
+      </table>
+    </table-wrap>
+  </article>
+</root>

--- a/test/tests/gen/table-wrap-tests/kr-table-not-tagged-2/kr-table-not-tagged-2.sch
+++ b/test/tests/gen/table-wrap-tests/kr-table-not-tagged-2/kr-table-not-tagged-2.sch
@@ -683,15 +683,18 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
-      <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
+  <pattern id="content-containers">
+    <rule context="table-wrap" id="table-wrap-tests">
+      <let name="id" value="@id"/>
+      <let name="lab" value="label"/>
+      <let name="article-type" value="ancestor::article/@article-type"/>
+      <report test="matches(caption/title[1],'^[Kk]ey [Rr]esource')" role="warning" id="kr-table-not-tagged-2">
+        <value-of select="$lab"/> has the title <value-of select="caption/title[1]"/> but it is not tagged as a ke resources table. Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+      <assert test="descendant::table-wrap" role="error" id="table-wrap-tests-xspec-assert">table-wrap must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/table-wrap-tests/kr-table-not-tagged-2/pass.xml
+++ b/test/tests/gen/table-wrap-tests/kr-table-not-tagged-2/pass.xml
@@ -1,0 +1,23 @@
+<?oxygen SCHSchema="kr-table-not-tagged-2.sch"?>
+<!--Context: table-wrap
+Test: report    matches(caption/title[1],'^[Kk]ey [Rr]esource')
+Message:  has the title  but it is not tagged as a ke resources table. Is this correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article article-type="research-article">
+    <table-wrap id="keyresource" position="anchor">
+      <label>Key resources table</label>
+      <table frame="hsides" rules="groups">
+        <thead>
+          <tr>
+            <th>Reagent type <break/>(species) or resource</th>
+            <th>Designation</th>
+            <th>Source or reference</th>
+            <th>Identifiers</th>
+            <th>Additional <break/>information</th>
+          </tr>
+        </thead>
+        <tbody>...</tbody>
+      </table>
+    </table-wrap>
+  </article>
+</root>

--- a/test/tests/gen/vid-xref-conformance/vid-xref-conformity-2/fail.xml
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-conformity-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="vid-xref-conformity-2.sch"?>
 <!--Context: xref[@ref-type='video']
 Test: assert    contains(.,$target-no)
-Message: video citation does not matches the video that it links to (target video label number is , but that number is not in the citation).-->
+Message: video citation does not matches the video that it links to. Target video label number is , but that number is not in the citation text  .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <p>See <xref ref-type="video" rid="video1">Video 2</xref>.</p>

--- a/test/tests/gen/vid-xref-conformance/vid-xref-conformity-2/pass.xml
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-conformity-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="vid-xref-conformity-2.sch"?>
 <!--Context: xref[@ref-type='video']
 Test: assert    contains(.,$target-no)
-Message: video citation does not matches the video that it links to (target video label number is , but that number is not in the citation).-->
+Message: video citation does not matches the video that it links to. Target video label number is , but that number is not in the citation text  .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <p>See <xref ref-type="video" rid="video1">Video 1</xref>.</p>

--- a/test/tests/gen/vid-xref-conformance/vid-xref-conformity-2/vid-xref-conformity-2.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-conformity-2/vid-xref-conformity-2.sch
@@ -689,7 +689,7 @@
       <let name="target-no" value="substring-after($rid,'video')"/>
       <let name="pre-text" value="preceding-sibling::text()[1]"/>
       <let name="post-text" value="following-sibling::text()[1]"/>
-      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to (target video label number is <value-of select="$target-no"/>, but that number is not in the citation).</assert>
+      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to. Target video label number is <value-of select="$target-no"/>, but that number is not in the citation text - <value-of select="."/>.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1646,7 +1646,11 @@
       
       <report test="($article-type = $features-article-types) and not(label)" role="warning" id="feat-fig-test-3">fig doesn't have a label. Is this correct?</report>
       
-      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="error" id="fig-test-4">fig must have a caption.</report>
+      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="warning" id="pre-fig-test-4">
+        <value-of select="label"/> has no title or caption (caption element). Esnure this is queried with the author.</report>
+      
+      <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption)" role="error" id="final-fig-test-4">
+        <value-of select="label"/> has no title or caption (caption element).</report>
       
       <report test="if ($article-type = ('correction','retraction')) then ()          else not(caption/title)" role="warning" id="pre-fig-test-5">
         <value-of select="label"/> does not have a title. Please alert eLife staff.</report>
@@ -1750,7 +1754,7 @@
       <assert test="label" role="error" id="supplementary-material-test-1">supplementary-material must have a label.</assert>
       
       <report test="if (contains(label,'Transparent reporting form')) then ()                      else not(caption)" role="warning" id="supplementary-material-test-2">
-        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material have a child caption.)</report>
+        <value-of select="label"/> is missing a title/caption - is this correct?  (supplementary-material should have a child caption.)</report>
       
       <report test="if (caption) then not(caption/title)                     else ()" role="warning" id="pre-supplementary-material-test-3">
         <value-of select="label"/> does not have a title. Please alert eLife staff.</report>
@@ -1764,8 +1768,11 @@
         role="warning"
         id="supplementary-material-test-4">supplementary-material caption does not have a p. Is this correct?</report>-->
       
-      <assert test="media" role="error" id="supplementary-material-test-5">
-        <value-of select="label"/> - supplementary-material must have a media.</assert>		
+      <assert test="media" role="warning" id="pre-supplementary-material-test-5">
+        <value-of select="label"/> is missing a file (supplementary-material missing a media element) - please ensure that this is queried with the author.</assert>		
+      
+      <assert test="media" role="error" id="final-supplementary-material-test-5">
+        <value-of select="label"/> is missing a file (supplementary-material must have a media).</assert>
       
       <assert test="matches(label,'^Transparent reporting form$|^Figure \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Table \d{1,4}—source data \d{1,4}\.$|^Video \d{1,4}—source data \d{1,4}\.$|^Figure \d{1,4}—source code \d{1,4}\.$|^Figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Table \d{1,4}—source code \d{1,4}\.$|^Video \d{1,4}—source code \d{1,4}\.$|^Supplementary file \d{1,4}\.$|^Source data \d{1,4}\.$|^Source code \d{1,4}\.$|^Reporting standard \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source data \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—figure \d{1,4}—figure supplement \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—table \d{1,4}—source code \d{1,4}\.$|^Appendix \d{1,3}—video \d{1,4}—source code \d{1,4}\.$')" role="error" id="supplementary-material-test-6">supplementary-material label (<value-of select="label"/>) does not conform to eLife's usual label format.</assert>
       
@@ -1888,6 +1895,9 @@
       
       <report test="($id != 'keyresource') and matches(normalize-space(descendant::thead[1]),'[Rr]eagent\s?type\s?\(species\)\s?or resource\s?[Dd]esignation\s?[Ss]ource\s?or\s?reference\s?[Ii]dentifiers\s?[Aa]dditional\s?information')" role="error" id="kr-table-not-tagged">
         <value-of select="$lab"/> has headings that are for the Key reources table, but it does not have an @id='keyresource'.</report>
+      
+      <report test="matches(caption/title[1],'^[Kk]ey [Rr]esource')" role="warning" id="kr-table-not-tagged-2">
+        <value-of select="$lab"/> has the title <value-of select="caption/title[1]"/> but it is not tagged as a ke resources table. Is this correct?</report>
       
     </rule>
   </pattern>
@@ -2166,7 +2176,10 @@
       
       <report test="label[contains(lower-case(.),'supplement')]" role="error" id="fig-specific-test-1">fig label contains 'supplement', but it does not have a @specific-use='child-fig'. If it is a figure supplement it needs the attribute, if it isn't then it cannot contain 'supplement' in the label.</report>
       
-      <report test="if ($article-type = ('correction','retraction')) then ()                      else if ($count = 0) then ()                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()                     else $no != string($pos)" role="error" id="fig-specific-test-2">
+      <report test="if ($article-type = ('correction','retraction')) then ()                      else if ($count = 0) then ()                     else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()                     else $no != string($pos)" role="warning" id="pre-fig-specific-test-2">
+        <value-of select="$lab"/> does not appear in sequence. Relative to the other figures it is placed in position <value-of select="$pos"/>. Please query this with the author.</report>
+      
+      <report test="if ($article-type = ('correction','retraction')) then ()          else if ($count = 0) then ()         else if (not(matches($id,'^fig[0-9]{1,3}$'))) then ()         else $no != string($pos)" role="error" id="final-fig-specific-test-2">
         <value-of select="$lab"/> does not appear in sequence which is incorrect. Relative to the other figures it is placed in position <value-of select="$pos"/>.</report>
       
       <report test="if ($article-type = ('correction','retraction')) then ()          else not((preceding::p[1]//xref[@rid = $id]) or (preceding::p[parent::sec][1]//xref[@rid = $id]))" role="warning" id="fig-specific-test-3">
@@ -3789,10 +3802,13 @@
         Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(ext-link)"/> 
         &lt;ext-link&gt; elements.</assert>
       
-      <assert test="count(date-in-citation)=1" role="error" id="err-elem-cit-web-11-1">[err-elem-cit-web-11-1]
-        One and only one &lt;date-in-citation&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> 
-        &lt;date-in-citation&gt; elements.</assert>
+      <report test="count(date-in-citation) lt 1" role="warning" id="pre-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element), which is required. Please ensure this is queried with the author.</report>
+      
+      <report test="count(date-in-citation) lt 1" role="error" id="final-err-elem-cit-web-11-1">
+        Web Reference '<value-of select="ancestor::ref/@id"/>' has no accessed date (&lt;date-in-citation&gt; element) which is required.</report>
+      
+      <report test="count(date-in-citation) gt 1" role="error" id="err-elem-cit-web-11-1-1">Web Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> &lt;date-in-citation&gt; elements. One and only one &lt;date-in-citation&gt; element is required.</report>
       
       <assert test="count(*) = count(person-group|article-title|source|year|ext-link|date-in-citation)" role="error" id="err-elem-cit-web-12">[err-elem-cit-web-12]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="web" are:
@@ -4749,7 +4765,7 @@
       <assert test="matches(.,'\p{N}')" role="error" id="vid-xref-conformity-1">
         <value-of select="."/> - video citation does not contain any numbers which must be incorrect.</assert>
       
-      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to (target video label number is <value-of select="$target-no"/>, but that number is not in the citation).</assert>
+      <assert test="contains(.,$target-no)" role="error" id="vid-xref-conformity-2">video citation does not matches the video that it links to. Target video label number is <value-of select="$target-no"/>, but that number is not in the citation text - <value-of select="."/>.</assert>
       
       <report test="matches($pre-text,'[\p{L}\p{N}\p{M}\p{Pe},;]$')" role="warning" id="vid-xref-test-2">There is no space between citation and the preceding text - <value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/> - Is this correct?</report>
       
@@ -5733,7 +5749,7 @@
       
       <report test="matches($lc,'r: a language and environment for statistical computing') and (count((publisher-loc[text() = 'Vienna, Austria'])) != 1)" role="error" id="R-test-3">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a &lt;publisher-loc&gt;Vienna, Austria&lt;/publisher-loc&gt; element.</report>
       
-      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.[Rr]-project.org' link.</report>
+      <report test="matches($lc,'r: a language and environment for statistical computing') and not(matches(ext-link[1]/@xlink:href,'^http[s]?://www.[Rr]-project.org'))" role="error" id="R-test-4">software ref '<value-of select="ancestor::ref/@id"/>' has a data-title - <value-of select="data-title[1]"/> - but does not have a 'http://www.r-project.org' type link.</report>
       
       <report test="matches(lower-case(source),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -2621,14 +2621,24 @@
         <x:expect-report id="feat-fig-test-3" role="warning"/>
         <x:expect-not-assert id="fig-tests-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="fig-test-4-pass">
-        <x:context href="../tests/gen/fig-tests/fig-test-4/pass.xml"/>
-        <x:expect-not-report id="fig-test-4" role="error"/>
+      <x:scenario label="pre-fig-test-4-pass">
+        <x:context href="../tests/gen/fig-tests/pre-fig-test-4/pass.xml"/>
+        <x:expect-not-report id="pre-fig-test-4" role="warning"/>
         <x:expect-not-assert id="fig-tests-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="fig-test-4-fail">
-        <x:context href="../tests/gen/fig-tests/fig-test-4/fail.xml"/>
-        <x:expect-report id="fig-test-4" role="error"/>
+      <x:scenario label="pre-fig-test-4-fail">
+        <x:context href="../tests/gen/fig-tests/pre-fig-test-4/fail.xml"/>
+        <x:expect-report id="pre-fig-test-4" role="warning"/>
+        <x:expect-not-assert id="fig-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-fig-test-4-pass">
+        <x:context href="../tests/gen/fig-tests/final-fig-test-4/pass.xml"/>
+        <x:expect-not-report id="final-fig-test-4" role="error"/>
+        <x:expect-not-assert id="fig-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-fig-test-4-fail">
+        <x:context href="../tests/gen/fig-tests/final-fig-test-4/fail.xml"/>
+        <x:expect-report id="final-fig-test-4" role="error"/>
         <x:expect-not-assert id="fig-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="pre-fig-test-5-pass">
@@ -2961,14 +2971,24 @@
         <x:expect-report id="final-supplementary-material-test-3" role="warning"/>
         <x:expect-not-assert id="supplementary-material-tests-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="supplementary-material-test-5-pass">
-        <x:context href="../tests/gen/supplementary-material-tests/supplementary-material-test-5/pass.xml"/>
-        <x:expect-not-assert id="supplementary-material-test-5" role="error"/>
+      <x:scenario label="pre-supplementary-material-test-5-pass">
+        <x:context href="../tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/pass.xml"/>
+        <x:expect-not-assert id="pre-supplementary-material-test-5" role="warning"/>
         <x:expect-not-assert id="supplementary-material-tests-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="supplementary-material-test-5-fail">
-        <x:context href="../tests/gen/supplementary-material-tests/supplementary-material-test-5/fail.xml"/>
-        <x:expect-assert id="supplementary-material-test-5" role="error"/>
+      <x:scenario label="pre-supplementary-material-test-5-fail">
+        <x:context href="../tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/fail.xml"/>
+        <x:expect-assert id="pre-supplementary-material-test-5" role="warning"/>
+        <x:expect-not-assert id="supplementary-material-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-supplementary-material-test-5-pass">
+        <x:context href="../tests/gen/supplementary-material-tests/final-supplementary-material-test-5/pass.xml"/>
+        <x:expect-not-assert id="final-supplementary-material-test-5" role="error"/>
+        <x:expect-not-assert id="supplementary-material-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-supplementary-material-test-5-fail">
+        <x:context href="../tests/gen/supplementary-material-tests/final-supplementary-material-test-5/fail.xml"/>
+        <x:expect-assert id="final-supplementary-material-test-5" role="error"/>
         <x:expect-not-assert id="supplementary-material-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="supplementary-material-test-6-pass">
@@ -3381,6 +3401,16 @@
       <x:scenario label="kr-table-not-tagged-fail">
         <x:context href="../tests/gen/table-wrap-tests/kr-table-not-tagged/fail.xml"/>
         <x:expect-report id="kr-table-not-tagged" role="error"/>
+        <x:expect-not-assert id="table-wrap-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="kr-table-not-tagged-2-pass">
+        <x:context href="../tests/gen/table-wrap-tests/kr-table-not-tagged-2/pass.xml"/>
+        <x:expect-not-report id="kr-table-not-tagged-2" role="warning"/>
+        <x:expect-not-assert id="table-wrap-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="kr-table-not-tagged-2-fail">
+        <x:context href="../tests/gen/table-wrap-tests/kr-table-not-tagged-2/fail.xml"/>
+        <x:expect-report id="kr-table-not-tagged-2" role="warning"/>
         <x:expect-not-assert id="table-wrap-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
@@ -3935,14 +3965,24 @@
         <x:expect-report id="fig-specific-test-1" role="error"/>
         <x:expect-not-assert id="fig-specific-tests-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="fig-specific-test-2-pass">
-        <x:context href="../tests/gen/fig-specific-tests/fig-specific-test-2/pass.xml"/>
-        <x:expect-not-report id="fig-specific-test-2" role="error"/>
+      <x:scenario label="pre-fig-specific-test-2-pass">
+        <x:context href="../tests/gen/fig-specific-tests/pre-fig-specific-test-2/pass.xml"/>
+        <x:expect-not-report id="pre-fig-specific-test-2" role="warning"/>
         <x:expect-not-assert id="fig-specific-tests-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="fig-specific-test-2-fail">
-        <x:context href="../tests/gen/fig-specific-tests/fig-specific-test-2/fail.xml"/>
-        <x:expect-report id="fig-specific-test-2" role="error"/>
+      <x:scenario label="pre-fig-specific-test-2-fail">
+        <x:context href="../tests/gen/fig-specific-tests/pre-fig-specific-test-2/fail.xml"/>
+        <x:expect-report id="pre-fig-specific-test-2" role="warning"/>
+        <x:expect-not-assert id="fig-specific-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-fig-specific-test-2-pass">
+        <x:context href="../tests/gen/fig-specific-tests/final-fig-specific-test-2/pass.xml"/>
+        <x:expect-not-report id="final-fig-specific-test-2" role="error"/>
+        <x:expect-not-assert id="fig-specific-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-fig-specific-test-2-fail">
+        <x:context href="../tests/gen/fig-specific-tests/final-fig-specific-test-2/fail.xml"/>
+        <x:expect-report id="final-fig-specific-test-2" role="error"/>
         <x:expect-not-assert id="fig-specific-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="fig-specific-test-3-pass">
@@ -6957,14 +6997,34 @@
         <x:expect-assert id="err-elem-cit-web-10-1" role="error"/>
         <x:expect-not-assert id="elem-citation-web-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="err-elem-cit-web-11-1-pass">
-        <x:context href="../tests/gen/elem-citation-web/err-elem-cit-web-11-1/pass.xml"/>
-        <x:expect-not-assert id="err-elem-cit-web-11-1" role="error"/>
+      <x:scenario label="pre-err-elem-cit-web-11-1-pass">
+        <x:context href="../tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/pass.xml"/>
+        <x:expect-not-report id="pre-err-elem-cit-web-11-1" role="warning"/>
         <x:expect-not-assert id="elem-citation-web-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="err-elem-cit-web-11-1-fail">
-        <x:context href="../tests/gen/elem-citation-web/err-elem-cit-web-11-1/fail.xml"/>
-        <x:expect-assert id="err-elem-cit-web-11-1" role="error"/>
+      <x:scenario label="pre-err-elem-cit-web-11-1-fail">
+        <x:context href="../tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/fail.xml"/>
+        <x:expect-report id="pre-err-elem-cit-web-11-1" role="warning"/>
+        <x:expect-not-assert id="elem-citation-web-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-err-elem-cit-web-11-1-pass">
+        <x:context href="../tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/pass.xml"/>
+        <x:expect-not-report id="final-err-elem-cit-web-11-1" role="error"/>
+        <x:expect-not-assert id="elem-citation-web-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-err-elem-cit-web-11-1-fail">
+        <x:context href="../tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/fail.xml"/>
+        <x:expect-report id="final-err-elem-cit-web-11-1" role="error"/>
+        <x:expect-not-assert id="elem-citation-web-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="err-elem-cit-web-11-1-1-pass">
+        <x:context href="../tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/pass.xml"/>
+        <x:expect-not-report id="err-elem-cit-web-11-1-1" role="error"/>
+        <x:expect-not-assert id="elem-citation-web-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="err-elem-cit-web-11-1-1-fail">
+        <x:context href="../tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/fail.xml"/>
+        <x:expect-report id="err-elem-cit-web-11-1-1" role="error"/>
         <x:expect-not-assert id="elem-citation-web-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="err-elem-cit-web-12-pass">


### PR DESCRIPTION
- Split `fig-test-4` into pre and final versions
- Correct message for `supplementary-material-test-2`
- Split `supplementary-material-test-5` into pre and final versions
- Add `kr-table-not-tagged-2`
- Split `fig-specific-test-2` into pre and final versions
- Split `err-elem-cit-web-11-1` into various versions
- Better message for `vid-xref-conformity-2`
- Edits to `R-test-4` to stop confusion