### PR TITLE
Re-add missing pattern

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -4728,6 +4728,20 @@
     </rule>
   </pattern>
   
+  <pattern id="unlinked-ref-cite-pattern">
+    <rule context="ref-list/ref/element-citation" id="unlinked-ref-cite">
+      <let name="id" value="parent::ref/@id"/>
+      <let name="cite1" value="e:citation-format1(descendant::year[1])"/>
+      <let name="cite1.5" value="e:citation-format2(descendant::year[1])"/>
+      <let name="cite2" value="concat(substring-before($cite1.5,'('),'\(',descendant::year[1],'\)')"/>
+      <let name="regex" value="concat($cite1,'|',$cite2)"/>
+      <let name="article-text" value="string-join(for $x in ancestor::article/*[local-name() = 'body' or local-name() = 'back']//*         return          if ($x/ancestor::sec[@sec-type='data-availability']) then ()         else if ($x/ancestor::sec[@sec-type='additional-information']) then ()         else if ($x/ancestor::ref-list) then ()         else if ($x/local-name() = 'xref') then ()         else $x/text(),'')"/>
+      
+      <report test="matches($article-text,$regex)" role="error" id="text-v-cite-test">ref with id <value-of select="$id"/> has unlinked citations in the text - search <value-of select="$cite1"/> or <value-of select="$cite1.5"/>.</report>
+      
+    </rule>
+  </pattern>
+  
   <pattern id="missing-ref-cited-pattern">
     <rule context="p[ancestor::app or ancestor::body[parent::article]]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -4734,6 +4734,20 @@
     </rule>
   </pattern>
   
+  <pattern id="unlinked-ref-cite-pattern">
+    <rule context="ref-list/ref/element-citation" id="unlinked-ref-cite">
+      <let name="id" value="parent::ref/@id"/>
+      <let name="cite1" value="e:citation-format1(descendant::year[1])"/>
+      <let name="cite1.5" value="e:citation-format2(descendant::year[1])"/>
+      <let name="cite2" value="concat(substring-before($cite1.5,'('),'\(',descendant::year[1],'\)')"/>
+      <let name="regex" value="concat($cite1,'|',$cite2)"/>
+      <let name="article-text" value="string-join(for $x in ancestor::article/*[local-name() = 'body' or local-name() = 'back']//*         return          if ($x/ancestor::sec[@sec-type='data-availability']) then ()         else if ($x/ancestor::sec[@sec-type='additional-information']) then ()         else if ($x/ancestor::ref-list) then ()         else if ($x/local-name() = 'xref') then ()         else $x/text(),'')"/>
+      
+      <report test="matches($article-text,$regex)" role="error" id="text-v-cite-test">ref with id <value-of select="$id"/> has unlinked citations in the text - search <value-of select="$cite1"/> or <value-of select="$cite1.5"/>.</report>
+      
+    </rule>
+  </pattern>
+  
   <pattern id="missing-ref-cited-pattern">
     <rule context="p[ancestor::app or ancestor::body[parent::article]]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -4729,6 +4729,20 @@
     </rule>
   </pattern>
   
+  <pattern id="unlinked-ref-cite-pattern">
+    <rule context="ref-list/ref/element-citation" id="unlinked-ref-cite">
+      <let name="id" value="parent::ref/@id"/>
+      <let name="cite1" value="e:citation-format1(descendant::year[1])"/>
+      <let name="cite1.5" value="e:citation-format2(descendant::year[1])"/>
+      <let name="cite2" value="concat(substring-before($cite1.5,'('),'\(',descendant::year[1],'\)')"/>
+      <let name="regex" value="concat($cite1,'|',$cite2)"/>
+      <let name="article-text" value="string-join(for $x in ancestor::article/*[local-name() = 'body' or local-name() = 'back']//*         return          if ($x/ancestor::sec[@sec-type='data-availability']) then ()         else if ($x/ancestor::sec[@sec-type='additional-information']) then ()         else if ($x/ancestor::ref-list) then ()         else if ($x/local-name() = 'xref') then ()         else $x/text(),'')"/>
+      
+      <report test="matches($article-text,$regex)" role="error" id="text-v-cite-test">ref with id <value-of select="$id"/> has unlinked citations in the text - search <value-of select="$cite1"/> or <value-of select="$cite1.5"/>.</report>
+      
+    </rule>
+  </pattern>
+  
   <pattern id="missing-ref-cited-pattern">
     <rule context="p[ancestor::app or ancestor::body[parent::article]]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -6193,6 +6193,20 @@
   </pattern>
   
   <pattern id="unlinked-ref-cite-pattern">
+    <rule context="ref-list/ref/element-citation" id="unlinked-ref-cite">
+      <let name="id" value="parent::ref/@id"/>
+      <let name="cite1" value="e:citation-format1(descendant::year[1])"/>
+      <let name="cite1.5" value="e:citation-format2(descendant::year[1])"/>
+      <let name="cite2" value="concat(substring-before($cite1.5,'('),'\(',descendant::year[1],'\)')"/>
+      <let name="regex" value="concat($cite1,'|',$cite2)"/>
+      <let name="article-text" value="string-join(for $x in ancestor::article/*[local-name() = 'body' or local-name() = 'back']//*         return          if ($x/ancestor::sec[@sec-type='data-availability']) then ()         else if ($x/ancestor::sec[@sec-type='additional-information']) then ()         else if ($x/ancestor::ref-list) then ()         else if ($x/local-name() = 'xref') then ()         else $x/text(),'')"/>
+      
+      <report test="matches($article-text,$regex)" role="error" id="text-v-cite-test">ref with id <value-of select="$id"/> has unlinked citations in the text - search <value-of select="$cite1"/> or <value-of select="$cite1.5"/>.</report>
+      
+    </rule>
+  </pattern>
+  
+  <pattern id="missing-ref-cited-pattern">
     
     <rule context="p[ancestor::app or ancestor::body[parent::article]]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]"
       id="missing-ref-cited">

--- a/test/tests/gen/missing-ref-cited/missing-ref-in-text-test/missing-ref-in-text-test.sch
+++ b/test/tests/gen/missing-ref-cited/missing-ref-in-text-test/missing-ref-in-text-test.sch
@@ -683,7 +683,7 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="unlinked-ref-cite-pattern">
+  <pattern id="missing-ref-cited-pattern">
     <rule context="p[ancestor::app or ancestor::body[parent::article]]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
       <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -4740,6 +4740,20 @@
     </rule>
   </pattern>
   
+  <pattern id="unlinked-ref-cite-pattern">
+    <rule context="ref-list/ref/element-citation" id="unlinked-ref-cite">
+      <let name="id" value="parent::ref/@id"/>
+      <let name="cite1" value="e:citation-format1(descendant::year[1])"/>
+      <let name="cite1.5" value="e:citation-format2(descendant::year[1])"/>
+      <let name="cite2" value="concat(substring-before($cite1.5,'('),'\(',descendant::year[1],'\)')"/>
+      <let name="regex" value="concat($cite1,'|',$cite2)"/>
+      <let name="article-text" value="string-join(for $x in ancestor::article/*[local-name() = 'body' or local-name() = 'back']//*         return          if ($x/ancestor::sec[@sec-type='data-availability']) then ()         else if ($x/ancestor::sec[@sec-type='additional-information']) then ()         else if ($x/ancestor::ref-list) then ()         else if ($x/local-name() = 'xref') then ()         else $x/text(),'')"/>
+      
+      <report test="matches($article-text,$regex)" role="error" id="text-v-cite-test">ref with id <value-of select="$id"/> has unlinked citations in the text - search <value-of select="$cite1"/> or <value-of select="$cite1.5"/>.</report>
+      
+    </rule>
+  </pattern>
+  
   
   
   <pattern id="vid-xref-conformance-pattern">
@@ -6569,6 +6583,7 @@
       <assert test="descendant::p or descendant::td or descendant::th" role="error" id="rrid-org-code-xspec-assert">p|td|th must be present.</assert>
       <assert test="descendant::ref-list//ref" role="error" id="duplicate-ref-xspec-assert">ref-list//ref must be present.</assert>
       <assert test="descendant::xref[@ref-type='bibr']" role="error" id="ref-xref-conformance-xspec-assert">xref[@ref-type='bibr'] must be present.</assert>
+      <assert test="descendant::ref-list/ref/element-citation" role="error" id="unlinked-ref-cite-xspec-assert">ref-list/ref/element-citation must be present.</assert>
       <assert test="descendant::xref[@ref-type='video']" role="error" id="vid-xref-conformance-xspec-assert">xref[@ref-type='video'] must be present.</assert>
       <assert test="descendant::xref[@ref-type='fig']" role="error" id="fig-xref-conformance-xspec-assert">xref[@ref-type='fig'] must be present.</assert>
       <assert test="descendant::xref[@ref-type='table']" role="error" id="table-xref-conformance-xspec-assert">xref[@ref-type='table'] must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -8712,6 +8712,18 @@
         <x:expect-not-assert id="ref-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="unlinked-ref-cite">
+      <x:scenario label="text-v-cite-test-pass">
+        <x:context href="../tests/gen/unlinked-ref-cite/text-v-cite-test/pass.xml"/>
+        <x:expect-not-report id="text-v-cite-test" role="error"/>
+        <x:expect-not-assert id="unlinked-ref-cite-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="text-v-cite-test-fail">
+        <x:context href="../tests/gen/unlinked-ref-cite/text-v-cite-test/fail.xml"/>
+        <x:expect-report id="text-v-cite-test" role="error"/>
+        <x:expect-not-assert id="unlinked-ref-cite-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
     <x:scenario label="vid-xref-conformance">
       <x:scenario label="vid-xref-conformity-1-pass">
         <x:context href="../tests/gen/vid-xref-conformance/vid-xref-conformity-1/pass.xml"/>


### PR DESCRIPTION
- Add mistakenly removed `unlinked-ref-cite-pattern`