### PR TITLE
feat: Add more tests

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1845,6 +1845,8 @@
       <report test="count(media) gt 1" role="error" id="supplementary-material-test-9">
         <value-of select="label"/> has <value-of select="count(media)"/> media elements which is incorrect.</report>
       
+      <report test="matches(label,'^Reporting standard \d{1,4}\.$')" role="warning" id="supplementary-material-test-10">Article contains <value-of select="label"/> Please check with eLife - is this actually a reporting standard?</report>
+      
       <report test="($file = $code-files) and not(matches(label,'[Ss]ource code \d{1,4}\.$'))" role="warning" id="source-code-test-1">
         <value-of select="label"/> has a file which looks like code - <value-of select="$link"/>, but it's not labelled as code.</report>
     </rule>
@@ -3009,6 +3011,8 @@
       <assert test="@ext-link-type='doi'" role="error" id="related-articles-test-5">related-article element must contain a @ext-link-type='doi'.</assert>
       
       <assert test="matches(@xlink:href,'^10\.7554/eLife\.[\d]{5}$')" role="error" id="related-articles-test-6">related-article element must contain a @xlink:href, the value of which should be in the form 10.7554/eLife.00000.</assert>
+      
+      <report test="@xlink:href = preceding::related-article/@xlink:href" role="error" id="related-articles-test-10">related-article elements must contain a distinct @xlink:href. There is more than 1 related article link for <value-of select="@xlink:href"/>.</report>
       
     </rule>
   </pattern>
@@ -4665,6 +4669,15 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-related-article-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/related-article" id="insight-related-article-tests">
+     <let name="doi" value="@xlink:href"/>
+     <let name="text" value="replace(ancestor::article/body/boxed-text[1],' ',' ')"/>
+     <let name="citation" value="for $x in ancestor::article//ref-list//element-citation[pub-id[@pub-id-type='doi']=$doi][1]        return replace(concat(           string-join(             for $y in $x/person-group[@person-group-type='author']/*             return if ($y/name()='name') then concat($y/surname,' ', $y/given-names)             else $y           ,', '),        '. ',        $x/year,        '. ',        $x/article-title,        '. eLife ',        $x/volume,        ':',        $x/elocation-id,        '. doi: ',        $x/pub-id[@pub-id-type='doi']),' ',' ')"/>
+     
+     <assert test="contains($text,$citation)" role="warning" id="insight-box-test-1">A citation for related article <value-of select="$doi"/> is not included in the related-article box text in the body of the article. '<value-of select="$citation"/>' is not present (or is different to the relevant passage) in '<value-of select="$text"/>'</assert>
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4735,8 +4748,8 @@
       <report test="matches($t,$org-regex) and not(descendant::italic[contains(.,e:org-conform($t))])" role="warning" id="org-test">
         <name/> element contains an organism - <value-of select="e:org-conform($t)"/> - but there is no italic element with that correct capitalisation or spacing. Is this correct? <name/> element begins with <value-of select="concat(.,substring(.,1,15))"/>.</report>
       
-      <report test="not(descendant::monospace) and ($code-text != '')" role="warning" id="code-test">
-        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;preformat/&gt;?</report>
+      <report test="not(descendant::monospace) and not(descendant::code) and ($code-text != '')" role="warning" id="code-test">
+        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;code/&gt;?</report>
       
       <report test="($unequal-equal-text != '') and not(disp-formula[contains(.,'=')]) and not(inline-formula[contains(.,'=')])" role="warning" id="cell-spacing-test">
         <name/> element contains an equal sign with content directly next to one side, but a space on the other, is this correct? - <value-of select="$unequal-equal-text"/>
@@ -6479,7 +6492,7 @@
       <let name="name" value="lower-case(conf-name[1])"/>
       
       <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conference-name[1]"/>). Should it have one?</report>
+        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
       
     </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1851,6 +1851,8 @@
       <report test="count(media) gt 1" role="error" id="supplementary-material-test-9">
         <value-of select="label"/> has <value-of select="count(media)"/> media elements which is incorrect.</report>
       
+      <report test="matches(label,'^Reporting standard \d{1,4}\.$')" role="warning" id="supplementary-material-test-10">Article contains <value-of select="label"/> Please check with eLife - is this actually a reporting standard?</report>
+      
       <report test="($file = $code-files) and not(matches(label,'[Ss]ource code \d{1,4}\.$'))" role="warning" id="source-code-test-1">
         <value-of select="label"/> has a file which looks like code - <value-of select="$link"/>, but it's not labelled as code.</report>
     </rule>
@@ -3015,6 +3017,8 @@
       <assert test="@ext-link-type='doi'" role="error" id="related-articles-test-5">related-article element must contain a @ext-link-type='doi'.</assert>
       
       <assert test="matches(@xlink:href,'^10\.7554/eLife\.[\d]{5}$')" role="error" id="related-articles-test-6">related-article element must contain a @xlink:href, the value of which should be in the form 10.7554/eLife.00000.</assert>
+      
+      <report test="@xlink:href = preceding::related-article/@xlink:href" role="error" id="related-articles-test-10">related-article elements must contain a distinct @xlink:href. There is more than 1 related article link for <value-of select="@xlink:href"/>.</report>
       
     </rule>
   </pattern>
@@ -4671,6 +4675,15 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-related-article-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/related-article" id="insight-related-article-tests">
+     <let name="doi" value="@xlink:href"/>
+     <let name="text" value="replace(ancestor::article/body/boxed-text[1],' ',' ')"/>
+     <let name="citation" value="for $x in ancestor::article//ref-list//element-citation[pub-id[@pub-id-type='doi']=$doi][1]        return replace(concat(           string-join(             for $y in $x/person-group[@person-group-type='author']/*             return if ($y/name()='name') then concat($y/surname,' ', $y/given-names)             else $y           ,', '),        '. ',        $x/year,        '. ',        $x/article-title,        '. eLife ',        $x/volume,        ':',        $x/elocation-id,        '. doi: ',        $x/pub-id[@pub-id-type='doi']),' ',' ')"/>
+     
+     <assert test="contains($text,$citation)" role="warning" id="insight-box-test-1">A citation for related article <value-of select="$doi"/> is not included in the related-article box text in the body of the article. '<value-of select="$citation"/>' is not present (or is different to the relevant passage) in '<value-of select="$text"/>'</assert>
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4741,8 +4754,8 @@
       <report test="matches($t,$org-regex) and not(descendant::italic[contains(.,e:org-conform($t))])" role="warning" id="org-test">
         <name/> element contains an organism - <value-of select="e:org-conform($t)"/> - but there is no italic element with that correct capitalisation or spacing. Is this correct? <name/> element begins with <value-of select="concat(.,substring(.,1,15))"/>.</report>
       
-      <report test="not(descendant::monospace) and ($code-text != '')" role="warning" id="code-test">
-        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;preformat/&gt;?</report>
+      <report test="not(descendant::monospace) and not(descendant::code) and ($code-text != '')" role="warning" id="code-test">
+        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;code/&gt;?</report>
       
       <report test="($unequal-equal-text != '') and not(disp-formula[contains(.,'=')]) and not(inline-formula[contains(.,'=')])" role="warning" id="cell-spacing-test">
         <name/> element contains an equal sign with content directly next to one side, but a space on the other, is this correct? - <value-of select="$unequal-equal-text"/>
@@ -6485,7 +6498,7 @@
       <let name="name" value="lower-case(conf-name[1])"/>
       
       <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conference-name[1]"/>). Should it have one?</report>
+        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1844,6 +1844,8 @@
       <report test="count(media) gt 1" role="error" id="supplementary-material-test-9">
         <value-of select="label"/> has <value-of select="count(media)"/> media elements which is incorrect.</report>
       
+      <report test="matches(label,'^Reporting standard \d{1,4}\.$')" flag="pub-check" role="warning" id="supplementary-material-test-10">Article contains <value-of select="label"/> Please check with eLife - is this actually a reporting standard?</report>
+      
       <report test="($file = $code-files) and not(matches(label,'[Ss]ource code \d{1,4}\.$'))" role="warning" id="source-code-test-1">
         <value-of select="label"/> has a file which looks like code - <value-of select="$link"/>, but it's not labelled as code.</report>
     </rule>
@@ -3008,6 +3010,8 @@
       <assert test="@ext-link-type='doi'" role="error" id="related-articles-test-5">related-article element must contain a @ext-link-type='doi'.</assert>
       
       <assert test="matches(@xlink:href,'^10\.7554/eLife\.[\d]{5}$')" role="error" id="related-articles-test-6">related-article element must contain a @xlink:href, the value of which should be in the form 10.7554/eLife.00000.</assert>
+      
+      <report test="@xlink:href = preceding::related-article/@xlink:href" role="error" id="related-articles-test-10">related-article elements must contain a distinct @xlink:href. There is more than 1 related article link for <value-of select="@xlink:href"/>.</report>
       
     </rule>
   </pattern>
@@ -4664,6 +4668,15 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-related-article-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/related-article" id="insight-related-article-tests">
+     <let name="doi" value="@xlink:href"/>
+     <let name="text" value="replace(ancestor::article/body/boxed-text[1],' ',' ')"/>
+     <let name="citation" value="for $x in ancestor::article//ref-list//element-citation[pub-id[@pub-id-type='doi']=$doi][1]        return replace(concat(           string-join(             for $y in $x/person-group[@person-group-type='author']/*             return if ($y/name()='name') then concat($y/surname,' ', $y/given-names)             else $y           ,', '),        '. ',        $x/year,        '. ',        $x/article-title,        '. eLife ',        $x/volume,        ':',        $x/elocation-id,        '. doi: ',        $x/pub-id[@pub-id-type='doi']),' ',' ')"/>
+     
+     <assert test="contains($text,$citation)" role="warning" id="insight-box-test-1">A citation for related article <value-of select="$doi"/> is not included in the related-article box text in the body of the article. '<value-of select="$citation"/>' is not present (or is different to the relevant passage) in '<value-of select="$text"/>'</assert>
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4734,8 +4747,8 @@
       <report test="matches($t,$org-regex) and not(descendant::italic[contains(.,e:org-conform($t))])" role="warning" id="org-test">
         <name/> element contains an organism - <value-of select="e:org-conform($t)"/> - but there is no italic element with that correct capitalisation or spacing. Is this correct? <name/> element begins with <value-of select="concat(.,substring(.,1,15))"/>.</report>
       
-      <report test="not(descendant::monospace) and ($code-text != '')" role="warning" id="code-test">
-        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;preformat/&gt;?</report>
+      <report test="not(descendant::monospace) and not(descendant::code) and ($code-text != '')" role="warning" id="code-test">
+        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;code/&gt;?</report>
       
       <report test="($unequal-equal-text != '') and not(disp-formula[contains(.,'=')]) and not(inline-formula[contains(.,'=')])" role="warning" id="cell-spacing-test">
         <name/> element contains an equal sign with content directly next to one side, but a space on the other, is this correct? - <value-of select="$unequal-equal-text"/>
@@ -6478,7 +6491,7 @@
       <let name="name" value="lower-case(conf-name[1])"/>
       
       <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conference-name[1]"/>). Should it have one?</report>
+        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
       
     </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2477,6 +2477,11 @@
         role="error"
         id="supplementary-material-test-9"><value-of select="label"/> has <value-of select="count(media)"/> media elements which is incorrect.</report>
       
+      <report test="matches(label,'^Reporting standard \d{1,4}\.$')"
+        flag="pub-check"
+        role="warning"
+        id="supplementary-material-test-10">Article contains <value-of select="label"/> Please check with eLife - is this actually a reporting standard?</report>
+      
       <report test="($file = $code-files) and not(matches(label,'[Ss]ource code \d{1,4}\.$'))"
         role="warning"
         id="source-code-test-1"><value-of select="label"/> has a file which looks like code - <value-of select="$link"/>, but it's not labelled as code.</report>
@@ -4204,6 +4209,10 @@
       <assert test="matches(@xlink:href,'^10\.7554/eLife\.[\d]{5}$')"
         role="error"
         id="related-articles-test-6">related-article element must contain a @xlink:href, the value of which should be in the form 10.7554/eLife.00000.</assert>
+      
+      <report test="@xlink:href = preceding::related-article/@xlink:href"
+        role="error"
+        id="related-articles-test-10">related-article elements must contain a distinct @xlink:href. There is more than 1 related article link for <value-of select="@xlink:href"/>.</report>
       
     </rule>
     
@@ -6073,6 +6082,33 @@
        id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
      
    </rule>
+   
+   <rule context="article[@article-type='article-commentary']//article-meta/related-article"
+     id="insight-related-article-tests">
+     <let name="doi" value="@xlink:href"/>
+     <let name="text" value="replace(ancestor::article/body/boxed-text[1],' ',' ')"/>
+     <let name="citation" value="for $x in ancestor::article//ref-list//element-citation[pub-id[@pub-id-type='doi']=$doi][1]
+       return replace(concat(
+          string-join(
+            for $y in $x/person-group[@person-group-type='author']/*
+            return if ($y/name()='name') then concat($y/surname,' ', $y/given-names)
+            else $y
+          ,', '),
+       '. ',
+       $x/year,
+       '. ',
+       $x/article-title,
+       '. eLife ',
+       $x/volume,
+       ':',
+       $x/elocation-id,
+       '. doi: ',
+       $x/pub-id[@pub-id-type='doi']),' ',' ')"/>
+     
+     <assert test="contains($text,$citation)"
+       role="warning"
+       id="insight-box-test-1">A citation for related article <value-of select="$doi"/> is not included in the related-article box text in the body of the article. '<value-of select="$citation"/>' is not present (or is different to the relevant passage) in '<value-of select="$text"/>'</assert>
+   </rule>
   </pattern>
   
   <pattern
@@ -6196,9 +6232,9 @@
         role="warning" 
         id="org-test"><name/> element contains an organism - <value-of select="e:org-conform($t)"/> - but there is no italic element with that correct capitalisation or spacing. Is this correct? <name/> element begins with <value-of select="concat(.,substring(.,1,15))"/>.</report>
       
-      <report test="not(descendant::monospace) and ($code-text != '')"
+      <report test="not(descendant::monospace) and not(descendant::code) and ($code-text != '')"
         role="warning" 
-        id="code-test"><name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;preformat/&gt;?</report>
+        id="code-test"><name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;code/&gt;?</report>
       
       <report test="($unequal-equal-text != '') and not(disp-formula[contains(.,'=')]) and not(inline-formula[contains(.,'=')])"
         role="warning" 
@@ -8850,7 +8886,7 @@
       
       <report test="contains($name,'ieee')"
         role="warning" 
-        id="conf-doi-test-1"><value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conference-name[1]"/>). Should it have one?</report>
+        id="conf-doi-test-1"><value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
       
     </rule>
   </pattern>

--- a/test/tests/gen/insight-related-article-tests/insight-box-test-1/fail.xml
+++ b/test/tests/gen/insight-related-article-tests/insight-box-test-1/fail.xml
@@ -1,0 +1,81 @@
+<?oxygen SCHSchema="insight-box-test-1.sch"?>
+<!--Context: article[@article-type='article-commentary']//article-meta/related-article
+Test: assert    contains($text,$citation)
+Message: A citation for related article  is not included in the relatedarticle box text in the body of the article. '' is not present (or is different to the relevant passage) in ''-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="article-commentary">
+    <front>
+      <article-meta> 
+        ... 
+        <related-article ext-link-type="doi" id="ra1" related-article-type="commentary-article" xlink:href="10.7554/eLife.43079"/>
+        <related-article ext-link-type="doi" id="ra2" related-article-type="commentary-article" xlink:href="10.7554/eLife.44590"/>
+      </article-meta>
+    </front>
+    <body>
+      <boxed-text>
+        <p><bold>Related research article</bold> Frechter S, Dolan M-J, Bates AS, Dan C, Huoviala P, Roberts RJV, Schlegel P, Dhawan S, Tabano R, Dionne H, Christoforou C, Close K, Sutcliffe B, Giuliani B, Feng L , Costa M, Ihrke G, Meissner GW, Bock DD, Aso Y, Rubin GM, Jefferis GSXE. 2019. Neurogenetic dissection of the Drosophila lateral horn reveals major outputs, diverse behavioural functions, and interactions with the mushroom body. <italic>eLife</italic> <bold>8</bold>:e43079. doi: <ext-link ext-link-type="uri" xlink:href="http://doi.org/10.7554/eLife.43079">10.7554/eLife.43079</ext-link></p>
+        <p><bold>Related research article</bold> Frechter S, Bates AS, Tootoonian S, Dolan M_J, Manton JD, Jamasb A, Kohl J, Bock DD, Jefferis GSXE. 2019. Neurogenetic dissection of the <italic>Drosophila </italic>lateral horn reveals major outputs, diverse behavioural functions, and interactions with the mushroom body. <italic>eLife</italic> <bold>8</bold>:e44590. doi: <ext-link ext-link-type="uri" xlink:href="http://doi.org/10.7554/eLife.44590">10.7554/eLife.44590</ext-link></p>
+      </boxed-text>
+    </body>
+    <back>
+      <ref-list>
+        <ref id="bib3">
+          <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+              <name><surname>Dolan</surname><given-names>M-J</given-names></name>
+              <name><surname>Frechter</surname><given-names>S</given-names></name>
+              <name><surname>Bates</surname><given-names>AS</given-names></name>
+              <name><surname>Dan</surname><given-names>C</given-names></name>
+              <name><surname>Huoviala</surname><given-names>P</given-names></name>
+              <name><surname>Roberts</surname><given-names>RJV</given-names></name>
+              <name><surname>Schlegel</surname><given-names>P</given-names></name>
+              <name><surname>Dhawan</surname><given-names>S</given-names></name>
+              <name><surname>Tabano</surname><given-names>R</given-names></name>
+              <name><surname>Dionne</surname><given-names>H</given-names></name>
+              <name><surname>Christoforou</surname><given-names>C</given-names></name>
+              <name><surname>Close</surname><given-names>K</given-names></name>
+              <name><surname>Sutcliffe</surname><given-names>B</given-names></name>
+              <name><surname>Giuliani</surname><given-names>B</given-names></name>
+              <name><surname>Feng L</surname></name>
+              <name><surname>Costa</surname><given-names>M</given-names></name>
+              <name><surname>Ihrke</surname><given-names>G</given-names></name>
+              <name><surname>Meissner</surname><given-names>GW</given-names></name>
+              <name><surname>Bock</surname><given-names>DD</given-names></name>
+              <name><surname>Aso</surname><given-names>Y</given-names></name>
+              <name><surname>Rubin</surname><given-names>GM</given-names></name>
+              <name><surname>Jefferis</surname><given-names>GSXE</given-names></name>
+            </person-group>
+            <year iso-8601-date="2019">2019</year>
+            <article-title>Neurogenetic dissection of the <italic>Drosophila </italic>lateral horn reveals major outputs, diverse behavioural functions, and interactions with the mushroom body</article-title>
+            <source>eLife</source>
+            <volume>8</volume>
+            <elocation-id>e43079</elocation-id>
+            <pub-id pub-id-type="doi">10.7554/eLife.43079</pub-id>
+          </element-citation>
+        </ref>
+        <ref id="bib4">
+          <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+              <name><surname>Frechter</surname> <given-names>S</given-names></name>
+              <name><surname>Bates</surname> <given-names>AS</given-names></name>
+              <name><surname>Tootoonian</surname> <given-names>S</given-names></name>
+              <name><surname>Dolan</surname> <given-names>M_J</given-names></name>
+              <name><surname>Manton</surname> <given-names>JD</given-names></name>
+              <name><surname>Jamasb</surname> <given-names>A</given-names></name>
+              <name><surname>Kohl</surname> <given-names>J</given-names></name>
+              <name><surname>Bock</surname> <given-names>DD</given-names></name>
+              <name><surname>Jefferis</surname> <given-names>GSXE</given-names></name>
+            </person-group>
+            <year iso-8601-date="2019">2019</year>
+            <article-title>Functional and anatomical specificity in a higher olfactory centre</article-title>
+            <source>eLife</source>
+            <volume>8</volume>
+            <elocation-id>e44590</elocation-id>
+            <pub-id pub-id-type="doi">10.7554/eLife.44590</pub-id>
+          </element-citation>
+        </ref>
+      </ref-list>
+    </back>
+  </article>
+</root>

--- a/test/tests/gen/insight-related-article-tests/insight-box-test-1/insight-box-test-1.sch
+++ b/test/tests/gen/insight-related-article-tests/insight-box-test-1/insight-box-test-1.sch
@@ -683,17 +683,17 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="doi-ref-checks">
-    <rule context="element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name]" id="doi-conf-ref-checks">
-      <let name="cite" value="e:citation-format1(year[1])"/>
-      <let name="name" value="lower-case(conf-name[1])"/>
-      <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
+  <pattern id="features">
+    <rule context="article[@article-type='article-commentary']//article-meta/related-article" id="insight-related-article-tests">
+      <let name="doi" value="@xlink:href"/>
+      <let name="text" value="replace(ancestor::article/body/boxed-text[1],' ',' ')"/>
+      <let name="citation" value="for $x in ancestor::article//ref-list//element-citation[pub-id[@pub-id-type='doi']=$doi][1]        return replace(concat(           string-join(             for $y in $x/person-group[@person-group-type='author']/*             return if ($y/name()='name') then concat($y/surname,' ', $y/given-names)             else $y           ,', '),        '. ',        $x/year,        '. ',        $x/article-title,        '. eLife ',        $x/volume,        ':',        $x/elocation-id,        '. doi: ',        $x/pub-id[@pub-id-type='doi']),' ',' ')"/>
+      <assert test="contains($text,$citation)" role="warning" id="insight-box-test-1">A citation for related article <value-of select="$doi"/> is not included in the related-article box text in the body of the article. '<value-of select="$citation"/>' is not present (or is different to the relevant passage) in '<value-of select="$text"/>'</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name]" role="error" id="doi-conf-ref-checks-xspec-assert">element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name] must be present.</assert>
+      <assert test="descendant::article[@article-type='article-commentary']//article-meta/related-article" role="error" id="insight-related-article-tests-xspec-assert">article[@article-type='article-commentary']//article-meta/related-article must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/insight-related-article-tests/insight-box-test-1/pass.xml
+++ b/test/tests/gen/insight-related-article-tests/insight-box-test-1/pass.xml
@@ -1,0 +1,81 @@
+<?oxygen SCHSchema="insight-box-test-1.sch"?>
+<!--Context: article[@article-type='article-commentary']//article-meta/related-article
+Test: assert    contains($text,$citation)
+Message: A citation for related article  is not included in the relatedarticle box text in the body of the article. '' is not present (or is different to the relevant passage) in ''-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="article-commentary">
+    <front>
+      <article-meta> 
+        ... 
+        <related-article ext-link-type="doi" id="ra1" related-article-type="commentary-article" xlink:href="10.7554/eLife.43079"/>
+        <related-article ext-link-type="doi" id="ra2" related-article-type="commentary-article" xlink:href="10.7554/eLife.44590"/>
+      </article-meta>
+    </front>
+    <body>
+      <boxed-text>
+        <p><bold>Related research article</bold> Dolan M-J, Frechter S, Bates AS, Dan C, Huoviala P, Roberts RJV, Schlegel P, Dhawan S, Tabano R, Dionne H, Christoforou C, Close K, Sutcliffe B, Giuliani B, Feng L , Costa M, Ihrke G, Meissner GW, Bock DD, Aso Y, Rubin GM, Jefferis GSXE. 2019. Neurogenetic dissection of the Drosophila lateral horn reveals major outputs, diverse behavioural functions, and interactions with the mushroom body. <italic>eLife</italic> <bold>8</bold>:e43079. doi: <ext-link ext-link-type="uri" xlink:href="http://doi.org/10.7554/eLife.43079">10.7554/eLife.43079</ext-link></p>
+        <p><bold>Related research article</bold> Frechter S, Bates AS, Tootoonian S, Dolan M_J, Manton JD, Jamasb A, Kohl J, Bock DD, Jefferis GSXE. 2019. Functional and anatomical specificity in a higher olfactory centre. <italic>eLife</italic> <bold>8</bold>:e44590. doi: <ext-link ext-link-type="uri" xlink:href="http://doi.org/10.7554/eLife.44590">10.7554/eLife.44590</ext-link></p>
+      </boxed-text>
+    </body>
+    <back>
+      <ref-list>
+        <ref id="bib3">
+          <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+              <name><surname>Dolan</surname><given-names>M-J</given-names></name>
+              <name><surname>Frechter</surname><given-names>S</given-names></name>
+              <name><surname>Bates</surname><given-names>AS</given-names></name>
+              <name><surname>Dan</surname><given-names>C</given-names></name>
+              <name><surname>Huoviala</surname><given-names>P</given-names></name>
+              <name><surname>Roberts</surname><given-names>RJV</given-names></name>
+              <name><surname>Schlegel</surname><given-names>P</given-names></name>
+              <name><surname>Dhawan</surname><given-names>S</given-names></name>
+              <name><surname>Tabano</surname><given-names>R</given-names></name>
+              <name><surname>Dionne</surname><given-names>H</given-names></name>
+              <name><surname>Christoforou</surname><given-names>C</given-names></name>
+              <name><surname>Close</surname><given-names>K</given-names></name>
+              <name><surname>Sutcliffe</surname><given-names>B</given-names></name>
+              <name><surname>Giuliani</surname><given-names>B</given-names></name>
+              <name><surname>Feng L</surname></name>
+              <name><surname>Costa</surname><given-names>M</given-names></name>
+              <name><surname>Ihrke</surname><given-names>G</given-names></name>
+              <name><surname>Meissner</surname><given-names>GW</given-names></name>
+              <name><surname>Bock</surname><given-names>DD</given-names></name>
+              <name><surname>Aso</surname><given-names>Y</given-names></name>
+              <name><surname>Rubin</surname><given-names>GM</given-names></name>
+              <name><surname>Jefferis</surname><given-names>GSXE</given-names></name>
+            </person-group>
+            <year iso-8601-date="2019">2019</year>
+            <article-title>Neurogenetic dissection of the <italic>Drosophila </italic>lateral horn reveals major outputs, diverse behavioural functions, and interactions with the mushroom body</article-title>
+            <source>eLife</source>
+            <volume>8</volume>
+            <elocation-id>e43079</elocation-id>
+            <pub-id pub-id-type="doi">10.7554/eLife.43079</pub-id>
+          </element-citation>
+        </ref>
+        <ref id="bib4">
+          <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+              <name><surname>Frechter</surname> <given-names>S</given-names></name>
+              <name><surname>Bates</surname> <given-names>AS</given-names></name>
+              <name><surname>Tootoonian</surname> <given-names>S</given-names></name>
+              <name><surname>Dolan</surname> <given-names>M_J</given-names></name>
+              <name><surname>Manton</surname> <given-names>JD</given-names></name>
+              <name><surname>Jamasb</surname> <given-names>A</given-names></name>
+              <name><surname>Kohl</surname> <given-names>J</given-names></name>
+              <name><surname>Bock</surname> <given-names>DD</given-names></name>
+              <name><surname>Jefferis</surname> <given-names>GSXE</given-names></name>
+            </person-group>
+            <year iso-8601-date="2019">2019</year>
+            <article-title>Functional and anatomical specificity in a higher olfactory centre</article-title>
+            <source>eLife</source>
+            <volume>8</volume>
+            <elocation-id>e44590</elocation-id>
+            <pub-id pub-id-type="doi">10.7554/eLife.44590</pub-id>
+          </element-citation>
+        </ref>
+      </ref-list>
+    </back>
+  </article>
+</root>

--- a/test/tests/gen/related-articles-conformance/related-articles-test-10/fail.xml
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-10/fail.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="related-articles-test-10.sch"?>
+<!--Context: related-article
+Test: report    @xlink:href = preceding::related-article/@xlink:href
+Message: relatedarticle elements must contain a distinct @xlink:href. There is more than 1 related article link for .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <article-meta>
+        ...
+        <related-article ext-link-type="doi" id="ra1" related-article-type="commentary-article" xlink:href="10.7554/eLife.43079"/>
+        <related-article ext-link-type="doi" id="ra2" related-article-type="commentary-article" xlink:href="10.7554/eLife.44590"/>
+        <related-article ext-link-type="doi" id="ra3" related-article-type="commentary-article" xlink:href="10.7554/eLife.44590"/>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/related-articles-conformance/related-articles-test-10/pass.xml
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-10/pass.xml
@@ -1,0 +1,15 @@
+<?oxygen SCHSchema="related-articles-test-10.sch"?>
+<!--Context: related-article
+Test: report    @xlink:href = preceding::related-article/@xlink:href
+Message: relatedarticle elements must contain a distinct @xlink:href. There is more than 1 related article link for .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <article-meta>
+        ...
+        <related-article ext-link-type="doi" id="ra1" related-article-type="commentary-article" xlink:href="10.7554/eLife.43079"/>
+        <related-article ext-link-type="doi" id="ra2" related-article-type="commentary-article" xlink:href="10.7554/eLife.44590"/>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/related-articles-conformance/related-articles-test-10/related-articles-test-10.sch
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-10/related-articles-test-10.sch
@@ -683,17 +683,15 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="doi-ref-checks">
-    <rule context="element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name]" id="doi-conf-ref-checks">
-      <let name="cite" value="e:citation-format1(year[1])"/>
-      <let name="name" value="lower-case(conf-name[1])"/>
-      <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
+  <pattern id="related-articles">
+    <rule context="related-article" id="related-articles-conformance">
+      <let name="allowed-values" value="('article-reference', 'commentary', 'commentary-article', 'corrected-article', 'retracted-article')"/>
+      <report test="@xlink:href = preceding::related-article/@xlink:href" role="error" id="related-articles-test-10">related-article elements must contain a distinct @xlink:href. There is more than 1 related article link for <value-of select="@xlink:href"/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name]" role="error" id="doi-conf-ref-checks-xspec-assert">element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name] must be present.</assert>
+      <assert test="descendant::related-article" role="error" id="related-articles-conformance-xspec-assert">related-article must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/rrid-org-code/code-test/code-test.sch
+++ b/test/tests/gen/rrid-org-code/code-test/code-test.sch
@@ -693,8 +693,8 @@
       <let name="unequal-equal-text" value="string-join(for $x in tokenize(.,' | ') return if (matches($x,'=$|^=') and not(matches($x,'^=$'))) then $x else (),'; ')"/>
       <let name="link-strip-text" value="string-join(for $x in (*[not(matches(local-name(),'^ext-link$|^contrib-id$|^license_ref$|^institution-id$|^email$|^xref$|^monospace$'))]|text()) return $x,'')"/>
       <let name="url-text" value="string-join(for $x in tokenize($link-strip-text,' ')          return   if (matches($x,'^https?:..(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%_\+.~#?&amp;//=]*)|^ftp://.|^git://.|^tel:.|^mailto:.|\.org[\s]?|\.com[\s]?|\.co.uk[\s]?|\.us[\s]?|\.net[\s]?|\.edu[\s]?|\.gov[\s]?|\.io[\s]?')) then $x         else (),'; ')"/>
-      <report test="not(descendant::monospace) and ($code-text != '')" role="warning" id="code-test">
-        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;preformat/&gt;?</report>
+      <report test="not(descendant::monospace) and not(descendant::code) and ($code-text != '')" role="warning" id="code-test">
+        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;code/&gt;?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/rrid-org-code/code-test/fail.xml
+++ b/test/tests/gen/rrid-org-code/code-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="code-test.sch"?>
 <!--Context: p|td|th
-Test: report    not(descendant::monospace) and ($code-text != '')
-Message:  element contains what looks like unformatted code  ''  does this need tagging with <monospace/> or <preformat/>?-->
+Test: report    not(descendant::monospace) and not(descendant::code) and ($code-text != '')
+Message:  element contains what looks like unformatted code  ''  does this need tagging with <monospace/> or <code/>?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <p> --test-code </p>

--- a/test/tests/gen/rrid-org-code/code-test/pass.xml
+++ b/test/tests/gen/rrid-org-code/code-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="code-test.sch"?>
 <!--Context: p|td|th
-Test: report    not(descendant::monospace) and ($code-text != '')
-Message:  element contains what looks like unformatted code  ''  does this need tagging with <monospace/> or <preformat/>?-->
+Test: report    not(descendant::monospace) and not(descendant::code) and ($code-text != '')
+Message:  element contains what looks like unformatted code  ''  does this need tagging with <monospace/> or <code/>?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <p><monospace>--test-code</monospace></p>

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-10/fail.xml
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-10/fail.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="supplementary-material-test-10.sch"?>
+<!--Context: supplementary-material
+Test: report    matches(label,'^Reporting standard \d{1,4}\.$')
+Message: Article contains  Please check with eLife  is this actually a reporting standard?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <supplementary-material>
+      <label>Reporting standard 1.</label>
+      ...
+    </supplementary-material>
+  </article>
+</root>

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-10/pass.xml
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-10/pass.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="supplementary-material-test-10.sch"?>
+<!--Context: supplementary-material
+Test: report    matches(label,'^Reporting standard \d{1,4}\.$')
+Message: Article contains  Please check with eLife  is this actually a reporting standard?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <supplementary-material>
+      <label>Supplementary file 1.</label>
+      ...
+    </supplementary-material>
+  </article>
+</root>

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-10/supplementary-material-test-10.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-10/supplementary-material-test-10.sch
@@ -683,17 +683,17 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="doi-ref-checks">
-    <rule context="element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name]" id="doi-conf-ref-checks">
-      <let name="cite" value="e:citation-format1(year[1])"/>
-      <let name="name" value="lower-case(conf-name[1])"/>
-      <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
+  <pattern id="content-containers">
+    <rule context="supplementary-material" id="supplementary-material-tests">
+      <let name="link" value="media[1]/@xlink:href"/>
+      <let name="file" value="if (contains($link,'.')) then lower-case(tokenize($link,'\.')[last()]) else ()"/>
+      <let name="code-files" value="('m','py','lib','jl','c','sh','for','cpproj','ipynb','mph','cc','rmd','nlogo','stan','wrl','pl','r','fas','ijm','llb','ipf','mdl','h')"/>
+      <report test="matches(label,'^Reporting standard \d{1,4}\.$')" flag="pub-check" role="warning" id="supplementary-material-test-10">Article contains <value-of select="label"/> Please check with eLife - is this actually a reporting standard?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name]" role="error" id="doi-conf-ref-checks-xspec-assert">element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name] must be present.</assert>
+      <assert test="descendant::supplementary-material" role="error" id="supplementary-material-tests-xspec-assert">supplementary-material must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1851,6 +1851,8 @@
       <report test="count(media) gt 1" role="error" id="supplementary-material-test-9">
         <value-of select="label"/> has <value-of select="count(media)"/> media elements which is incorrect.</report>
       
+      <report test="matches(label,'^Reporting standard \d{1,4}\.$')" flag="pub-check" role="warning" id="supplementary-material-test-10">Article contains <value-of select="label"/> Please check with eLife - is this actually a reporting standard?</report>
+      
       <report test="($file = $code-files) and not(matches(label,'[Ss]ource code \d{1,4}\.$'))" role="warning" id="source-code-test-1">
         <value-of select="label"/> has a file which looks like code - <value-of select="$link"/>, but it's not labelled as code.</report>
     </rule>
@@ -3020,6 +3022,8 @@
       <assert test="@ext-link-type='doi'" role="error" id="related-articles-test-5">related-article element must contain a @ext-link-type='doi'.</assert>
       
       <assert test="matches(@xlink:href,'^10\.7554/eLife\.[\d]{5}$')" role="error" id="related-articles-test-6">related-article element must contain a @xlink:href, the value of which should be in the form 10.7554/eLife.00000.</assert>
+      
+      <report test="@xlink:href = preceding::related-article/@xlink:href" role="error" id="related-articles-test-10">related-article elements must contain a distinct @xlink:href. There is more than 1 related article link for <value-of select="@xlink:href"/>.</report>
       
     </rule>
   </pattern>
@@ -4677,6 +4681,15 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-related-article-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/related-article" id="insight-related-article-tests">
+     <let name="doi" value="@xlink:href"/>
+     <let name="text" value="replace(ancestor::article/body/boxed-text[1],' ',' ')"/>
+     <let name="citation" value="for $x in ancestor::article//ref-list//element-citation[pub-id[@pub-id-type='doi']=$doi][1]        return replace(concat(           string-join(             for $y in $x/person-group[@person-group-type='author']/*             return if ($y/name()='name') then concat($y/surname,' ', $y/given-names)             else $y           ,', '),        '. ',        $x/year,        '. ',        $x/article-title,        '. eLife ',        $x/volume,        ':',        $x/elocation-id,        '. doi: ',        $x/pub-id[@pub-id-type='doi']),' ',' ')"/>
+     
+     <assert test="contains($text,$citation)" role="warning" id="insight-box-test-1">A citation for related article <value-of select="$doi"/> is not included in the related-article box text in the body of the article. '<value-of select="$citation"/>' is not present (or is different to the relevant passage) in '<value-of select="$text"/>'</assert>
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4747,8 +4760,8 @@
       <report test="matches($t,$org-regex) and not(descendant::italic[contains(.,e:org-conform($t))])" role="warning" id="org-test">
         <name/> element contains an organism - <value-of select="e:org-conform($t)"/> - but there is no italic element with that correct capitalisation or spacing. Is this correct? <name/> element begins with <value-of select="concat(.,substring(.,1,15))"/>.</report>
       
-      <report test="not(descendant::monospace) and ($code-text != '')" role="warning" id="code-test">
-        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;preformat/&gt;?</report>
+      <report test="not(descendant::monospace) and not(descendant::code) and ($code-text != '')" role="warning" id="code-test">
+        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;code/&gt;?</report>
       
       <report test="($unequal-equal-text != '') and not(disp-formula[contains(.,'=')]) and not(inline-formula[contains(.,'=')])" role="warning" id="cell-spacing-test">
         <name/> element contains an equal sign with content directly next to one side, but a space on the other, is this correct? - <value-of select="$unequal-equal-text"/>
@@ -6498,7 +6511,7 @@
       <let name="name" value="lower-case(conf-name[1])"/>
       
       <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conference-name[1]"/>). Should it have one?</report>
+        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
       
     </rule>
   </pattern>
@@ -6782,6 +6795,7 @@
       <assert test="descendant::article[@article-type = $features-article-types]//article-meta//contrib[@contrib-type='author']/bio" role="error" id="feature-bio-tests-xspec-assert">article[@article-type = $features-article-types]//article-meta//contrib[@contrib-type='author']/bio must be present.</assert>
       <assert test="descendant::article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = $features-subj]" role="error" id="feature-template-tests-xspec-assert">article[descendant::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject = $features-subj] must be present.</assert>
       <assert test="descendant::article[@article-type='article-commentary']//article-meta/abstract" role="error" id="insight-asbtract-tests-xspec-assert">article[@article-type='article-commentary']//article-meta/abstract must be present.</assert>
+      <assert test="descendant::article[@article-type='article-commentary']//article-meta/related-article" role="error" id="insight-related-article-tests-xspec-assert">article[@article-type='article-commentary']//article-meta/related-article must be present.</assert>
       <assert test="descendant::article[@article-type = 'correction']" role="error" id="correction-tests-xspec-assert">article[@article-type = 'correction'] must be present.</assert>
       <assert test="descendant::article[@article-type = 'retraction']" role="error" id="retraction-tests-xspec-assert">article[@article-type = 'retraction'] must be present.</assert>
       <assert test="descendant::p" role="error" id="final-gene-primer-sequence-xspec-assert">p must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -3203,6 +3203,16 @@
         <x:expect-report id="supplementary-material-test-9" role="error"/>
         <x:expect-not-assert id="supplementary-material-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="supplementary-material-test-10-pass">
+        <x:context href="../tests/gen/supplementary-material-tests/supplementary-material-test-10/pass.xml"/>
+        <x:expect-not-report id="supplementary-material-test-10" role="warning"/>
+        <x:expect-not-assert id="supplementary-material-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="supplementary-material-test-10-fail">
+        <x:context href="../tests/gen/supplementary-material-tests/supplementary-material-test-10/fail.xml"/>
+        <x:expect-report id="supplementary-material-test-10" role="warning"/>
+        <x:expect-not-assert id="supplementary-material-tests-xspec-assert" role="error"/>
+      </x:scenario>
       <x:scenario label="source-code-test-1-pass">
         <x:context href="../tests/gen/supplementary-material-tests/source-code-test-1/pass.xml"/>
         <x:expect-not-report id="source-code-test-1" role="warning"/>
@@ -6039,6 +6049,16 @@
         <x:expect-assert id="related-articles-test-6" role="error"/>
         <x:expect-not-assert id="related-articles-conformance-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="related-articles-test-10-pass">
+        <x:context href="../tests/gen/related-articles-conformance/related-articles-test-10/pass.xml"/>
+        <x:expect-not-report id="related-articles-test-10" role="error"/>
+        <x:expect-not-assert id="related-articles-conformance-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="related-articles-test-10-fail">
+        <x:context href="../tests/gen/related-articles-conformance/related-articles-test-10/fail.xml"/>
+        <x:expect-report id="related-articles-test-10" role="error"/>
+        <x:expect-not-assert id="related-articles-conformance-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="elem-citation-general">
       <x:scenario label="err-elem-cit-gen-name-5-pass">
@@ -8568,6 +8588,18 @@
         <x:context href="../tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/fail.xml"/>
         <x:expect-assert id="insight-asbtract-impact-test-2" role="warning"/>
         <x:expect-not-assert id="insight-asbtract-tests-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="insight-related-article-tests">
+      <x:scenario label="insight-box-test-1-pass">
+        <x:context href="../tests/gen/insight-related-article-tests/insight-box-test-1/pass.xml"/>
+        <x:expect-not-assert id="insight-box-test-1" role="warning"/>
+        <x:expect-not-assert id="insight-related-article-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="insight-box-test-1-fail">
+        <x:context href="../tests/gen/insight-related-article-tests/insight-box-test-1/fail.xml"/>
+        <x:expect-assert id="insight-box-test-1" role="warning"/>
+        <x:expect-not-assert id="insight-related-article-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
     <x:scenario label="correction-tests">

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -1845,6 +1845,8 @@
       <report test="count(media) gt 1" role="error" id="supplementary-material-test-9">
         <value-of select="label"/> has <value-of select="count(media)"/> media elements which is incorrect.</report>
       
+      <report test="matches(label,'^Reporting standard \d{1,4}\.$')" role="warning" id="supplementary-material-test-10">Article contains <value-of select="label"/> Please check with eLife - is this actually a reporting standard?</report>
+      
       <report test="($file = $code-files) and not(matches(label,'[Ss]ource code \d{1,4}\.$'))" role="warning" id="source-code-test-1">
         <value-of select="label"/> has a file which looks like code - <value-of select="$link"/>, but it's not labelled as code.</report>
     </rule>
@@ -3009,6 +3011,8 @@
       <assert test="@ext-link-type='doi'" role="error" id="related-articles-test-5">related-article element must contain a @ext-link-type='doi'.</assert>
       
       <assert test="matches(@xlink:href,'^10\.7554/eLife\.[\d]{5}$')" role="error" id="related-articles-test-6">related-article element must contain a @xlink:href, the value of which should be in the form 10.7554/eLife.00000.</assert>
+      
+      <report test="@xlink:href = preceding::related-article/@xlink:href" role="error" id="related-articles-test-10">related-article elements must contain a distinct @xlink:href. There is more than 1 related article link for <value-of select="@xlink:href"/>.</report>
       
     </rule>
   </pattern>
@@ -4665,6 +4669,15 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-related-article-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/related-article" id="insight-related-article-tests">
+     <let name="doi" value="@xlink:href"/>
+     <let name="text" value="replace(ancestor::article/body/boxed-text[1],' ',' ')"/>
+     <let name="citation" value="for $x in ancestor::article//ref-list//element-citation[pub-id[@pub-id-type='doi']=$doi][1]        return replace(concat(           string-join(             for $y in $x/person-group[@person-group-type='author']/*             return if ($y/name()='name') then concat($y/surname,' ', $y/given-names)             else $y           ,', '),        '. ',        $x/year,        '. ',        $x/article-title,        '. eLife ',        $x/volume,        ':',        $x/elocation-id,        '. doi: ',        $x/pub-id[@pub-id-type='doi']),' ',' ')"/>
+     
+     <assert test="contains($text,$citation)" role="warning" id="insight-box-test-1">A citation for related article <value-of select="$doi"/> is not included in the related-article box text in the body of the article. '<value-of select="$citation"/>' is not present (or is different to the relevant passage) in '<value-of select="$text"/>'</assert>
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4735,8 +4748,8 @@
       <report test="matches($t,$org-regex) and not(descendant::italic[contains(.,e:org-conform($t))])" role="warning" id="org-test">
         <name/> element contains an organism - <value-of select="e:org-conform($t)"/> - but there is no italic element with that correct capitalisation or spacing. Is this correct? <name/> element begins with <value-of select="concat(.,substring(.,1,15))"/>.</report>
       
-      <report test="not(descendant::monospace) and ($code-text != '')" role="warning" id="code-test">
-        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;preformat/&gt;?</report>
+      <report test="not(descendant::monospace) and not(descendant::code) and ($code-text != '')" role="warning" id="code-test">
+        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;code/&gt;?</report>
       
       <report test="($unequal-equal-text != '') and not(disp-formula[contains(.,'=')]) and not(inline-formula[contains(.,'=')])" role="warning" id="cell-spacing-test">
         <name/> element contains an equal sign with content directly next to one side, but a space on the other, is this correct? - <value-of select="$unequal-equal-text"/>
@@ -6479,7 +6492,7 @@
       <let name="name" value="lower-case(conf-name[1])"/>
       
       <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conference-name[1]"/>). Should it have one?</report>
+        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
       
     </rule>
   </pattern>

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -1844,6 +1844,8 @@
       <report test="count(media) gt 1" role="error" id="supplementary-material-test-9">
         <value-of select="label"/> has <value-of select="count(media)"/> media elements which is incorrect.</report>
       
+      <report test="matches(label,'^Reporting standard \d{1,4}\.$')" flag="pub-check" role="warning" id="supplementary-material-test-10">Article contains <value-of select="label"/> Please check with eLife - is this actually a reporting standard?</report>
+      
       <report test="($file = $code-files) and not(matches(label,'[Ss]ource code \d{1,4}\.$'))" role="warning" id="source-code-test-1">
         <value-of select="label"/> has a file which looks like code - <value-of select="$link"/>, but it's not labelled as code.</report>
     </rule>
@@ -3008,6 +3010,8 @@
       <assert test="@ext-link-type='doi'" role="error" id="related-articles-test-5">related-article element must contain a @ext-link-type='doi'.</assert>
       
       <assert test="matches(@xlink:href,'^10\.7554/eLife\.[\d]{5}$')" role="error" id="related-articles-test-6">related-article element must contain a @xlink:href, the value of which should be in the form 10.7554/eLife.00000.</assert>
+      
+      <report test="@xlink:href = preceding::related-article/@xlink:href" role="error" id="related-articles-test-10">related-article elements must contain a distinct @xlink:href. There is more than 1 related article link for <value-of select="@xlink:href"/>.</report>
       
     </rule>
   </pattern>
@@ -4664,6 +4668,15 @@
      
    </rule>
   </pattern>
+  <pattern id="insight-related-article-tests-pattern">
+    <rule context="article[@article-type='article-commentary']//article-meta/related-article" id="insight-related-article-tests">
+     <let name="doi" value="@xlink:href"/>
+     <let name="text" value="replace(ancestor::article/body/boxed-text[1],' ',' ')"/>
+     <let name="citation" value="for $x in ancestor::article//ref-list//element-citation[pub-id[@pub-id-type='doi']=$doi][1]        return replace(concat(           string-join(             for $y in $x/person-group[@person-group-type='author']/*             return if ($y/name()='name') then concat($y/surname,' ', $y/given-names)             else $y           ,', '),        '. ',        $x/year,        '. ',        $x/article-title,        '. eLife ',        $x/volume,        ':',        $x/elocation-id,        '. doi: ',        $x/pub-id[@pub-id-type='doi']),' ',' ')"/>
+     
+     <assert test="contains($text,$citation)" role="warning" id="insight-box-test-1">A citation for related article <value-of select="$doi"/> is not included in the related-article box text in the body of the article. '<value-of select="$citation"/>' is not present (or is different to the relevant passage) in '<value-of select="$text"/>'</assert>
+   </rule>
+  </pattern>
   
   <pattern id="correction-tests-pattern">
     <rule context="article[@article-type = 'correction']" id="correction-tests">
@@ -4734,8 +4747,8 @@
       <report test="matches($t,$org-regex) and not(descendant::italic[contains(.,e:org-conform($t))])" role="warning" id="org-test">
         <name/> element contains an organism - <value-of select="e:org-conform($t)"/> - but there is no italic element with that correct capitalisation or spacing. Is this correct? <name/> element begins with <value-of select="concat(.,substring(.,1,15))"/>.</report>
       
-      <report test="not(descendant::monospace) and ($code-text != '')" role="warning" id="code-test">
-        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;preformat/&gt;?</report>
+      <report test="not(descendant::monospace) and not(descendant::code) and ($code-text != '')" role="warning" id="code-test">
+        <name/> element contains what looks like unformatted code - '<value-of select="$code-text"/>' - does this need tagging with &lt;monospace/&gt; or &lt;code/&gt;?</report>
       
       <report test="($unequal-equal-text != '') and not(disp-formula[contains(.,'=')]) and not(inline-formula[contains(.,'=')])" role="warning" id="cell-spacing-test">
         <name/> element contains an equal sign with content directly next to one side, but a space on the other, is this correct? - <value-of select="$unequal-equal-text"/>
@@ -6478,7 +6491,7 @@
       <let name="name" value="lower-case(conf-name[1])"/>
       
       <report test="contains($name,'ieee')" role="warning" id="conf-doi-test-1">
-        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conference-name[1]"/>). Should it have one?</report>
+        <value-of select="$cite"/> is a conference ref without a doi, but it's a conference which is know to possibly have dois - (<value-of select="conf-name[1]"/>). Should it have one?</report>
       
     </rule>
   </pattern>


### PR DESCRIPTION
- feat: Add general warning for reporting standard files (`supplementary-material-test-10`).
- feat: Add error for non-distinct related article links (`related-articles-test-10`).
- feat: Add warning for insight boxed-text citation conformance (`insight-box-test-1`).
- fix: Don't fire `code-test` when `<code>` is present as a descendant of `<p>`.
- fix: Update value supplied in `conf-doi-test-1` message.