### PR TITLE
Reference and title tests

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -4787,6 +4787,8 @@
       
       <report test="not(ancestor::sub-article) and not($url-text = '')" role="warning" id="unlinked-url">'<name/>' element contains possible unlinked urls. Check - <value-of select="$url-text"/>
       </report>
+      
+      <report test="matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)" role="warning" id="year-style-test">'<name/>' element contains the following string(s) - <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,' s'),'; ')"/>. If this refers to years, then the space should be removed after the number, i.e <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,'s'),'; ')"/>. If the text is referring to a unit then this is fine.</report>
     </rule>
   </pattern>
   
@@ -5881,11 +5883,25 @@
       
     </rule>
   </pattern>
+  <pattern id="ref-chapter-title-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/chapter-title" id="ref-chapter-title-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-chapter-title-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the chapter title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ref-book-source-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/source" id="ref-book-source-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-book-source-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the book title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
   <pattern id="preprint-title-tests-pattern">
     <rule context="element-citation[@publication-type='preprint']/source" id="preprint-title-tests">
       <let name="lc" value="lower-case(.)"/>
       
-      <report test="not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</report>
+      <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'.</report>
       
@@ -6220,6 +6236,7 @@
   <pattern id="sec-title-conformity-pattern">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       
       <report test="matches(.,'^[A-Za-z]{1,3}\)|^\([A-Za-z]{1,3}')" role="warning" id="sec-title-list-check">Section title might start with a list indicator - '<value-of select="."/>'. Is this correct?</report>
       
@@ -6239,6 +6256,15 @@
       </report>
       
       <report test="(count(*) = 1) and child::italic and ($free-text='')" role="warning" id="sec-title-italic">All section title content is captured in italics. This is very likely to be incorrect - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))" role="warning" id="sec-title-dna">Section title contains the phrase DNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))" role="warning" id="sec-title-rna">Section title contains the phrase RNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')" role="warning" id="sec-title-dimension">Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D' - <value-of select="."/>
       </report>
       
     </rule>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -4793,6 +4793,8 @@
       
       <report test="not(ancestor::sub-article) and not($url-text = '')" role="warning" id="unlinked-url">'<name/>' element contains possible unlinked urls. Check - <value-of select="$url-text"/>
       </report>
+      
+      <report test="matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)" role="warning" id="year-style-test">'<name/>' element contains the following string(s) - <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,' s'),'; ')"/>. If this refers to years, then the space should be removed after the number, i.e <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,'s'),'; ')"/>. If the text is referring to a unit then this is fine.</report>
     </rule>
   </pattern>
   
@@ -5887,11 +5889,25 @@
       
     </rule>
   </pattern>
+  <pattern id="ref-chapter-title-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/chapter-title" id="ref-chapter-title-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-chapter-title-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the chapter title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ref-book-source-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/source" id="ref-book-source-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-book-source-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the book title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
   <pattern id="preprint-title-tests-pattern">
     <rule context="element-citation[@publication-type='preprint']/source" id="preprint-title-tests">
       <let name="lc" value="lower-case(.)"/>
       
-      <report test="not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</report>
+      <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'.</report>
       
@@ -6226,6 +6242,7 @@
   <pattern id="sec-title-conformity-pattern">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       
       <report test="matches(.,'^[A-Za-z]{1,3}\)|^\([A-Za-z]{1,3}')" role="warning" id="sec-title-list-check">Section title might start with a list indicator - '<value-of select="."/>'. Is this correct?</report>
       
@@ -6245,6 +6262,15 @@
       </report>
       
       <report test="(count(*) = 1) and child::italic and ($free-text='')" role="warning" id="sec-title-italic">All section title content is captured in italics. This is very likely to be incorrect - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))" role="warning" id="sec-title-dna">Section title contains the phrase DNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))" role="warning" id="sec-title-rna">Section title contains the phrase RNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')" role="warning" id="sec-title-dimension">Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D' - <value-of select="."/>
       </report>
       
     </rule>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -4786,6 +4786,8 @@
       
       <report test="not(ancestor::sub-article) and not($url-text = '')" role="warning" id="unlinked-url">'<name/>' element contains possible unlinked urls. Check - <value-of select="$url-text"/>
       </report>
+      
+      <report test="matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)" role="warning" id="year-style-test">'<name/>' element contains the following string(s) - <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,' s'),'; ')"/>. If this refers to years, then the space should be removed after the number, i.e <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,'s'),'; ')"/>. If the text is referring to a unit then this is fine.</report>
     </rule>
   </pattern>
   
@@ -5880,11 +5882,25 @@
       
     </rule>
   </pattern>
+  <pattern id="ref-chapter-title-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/chapter-title" id="ref-chapter-title-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-chapter-title-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the chapter title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ref-book-source-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/source" id="ref-book-source-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-book-source-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the book title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
   <pattern id="preprint-title-tests-pattern">
     <rule context="element-citation[@publication-type='preprint']/source" id="preprint-title-tests">
       <let name="lc" value="lower-case(.)"/>
       
-      <report test="not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</report>
+      <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'.</report>
       
@@ -6219,6 +6235,7 @@
   <pattern id="sec-title-conformity-pattern">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       
       <report test="matches(.,'^[A-Za-z]{1,3}\)|^\([A-Za-z]{1,3}')" role="warning" id="sec-title-list-check">Section title might start with a list indicator - '<value-of select="."/>'. Is this correct?</report>
       
@@ -6238,6 +6255,15 @@
       </report>
       
       <report test="(count(*) = 1) and child::italic and ($free-text='')" role="warning" id="sec-title-italic">All section title content is captured in italics. This is very likely to be incorrect - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))" role="warning" id="sec-title-dna">Section title contains the phrase DNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))" role="warning" id="sec-title-rna">Section title contains the phrase RNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')" role="warning" id="sec-title-dimension">Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D' - <value-of select="."/>
       </report>
       
     </rule>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -6286,6 +6286,10 @@
       <report test="not(ancestor::sub-article) and not($url-text = '')"
         role="warning"
         id="unlinked-url">'<name/>' element contains possible unlinked urls. Check - <value-of select="$url-text"/></report>
+      
+      <report test="matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)"
+        role="warning"
+        id="year-style-test">'<name/>' element contains the following string(s) - <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,' s'),'; ')"/>. If this refers to years, then the space should be removed after the number, i.e <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,'s'),'; ')"/>. If the text is referring to a unit then this is fine.</report>
     </rule>
     
   </pattern>
@@ -7915,13 +7919,31 @@
       
     </rule>
     
+    <rule context="element-citation[@publication-type='book']/chapter-title" 
+      id="ref-chapter-title-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')"
+        role="warning" 
+        id="report-chapter-title-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the chapter title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+    
+    <rule context="element-citation[@publication-type='book']/source" 
+      id="ref-book-source-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')"
+        role="warning" 
+        id="report-book-source-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the book title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+    
     <rule context="element-citation[@publication-type='preprint']/source" 
       id="preprint-title-tests">
       <let name="lc" value="lower-case(.)"/>
       
-      <report test="not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))"
+      <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')"
         role="warning" 
-        id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</report>
+        id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')"
         role="error" 
@@ -8507,6 +8529,9 @@
       <let name="free-text" value="replace(
         normalize-space(string-join(for $x in self::*/text() return $x,''))
         ,'&#x00A0;','')"/>
+      <let name="no-link-text" value="translate(
+        normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))
+        ,'&#x00A0;?.',' ')"/>
       
       <report test="matches(.,'^[A-Za-z]{1,3}\)|^\([A-Za-z]{1,3}')"
         role="warning" 
@@ -8539,6 +8564,18 @@
       <report test="(count(*) = 1) and child::italic and ($free-text='')"
         role="warning" 
         id="sec-title-italic">All section title content is captured in italics. This is very likely to be incorrect - <value-of select="."/></report>
+      
+      <report test="matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))"
+        role="warning" 
+        id="sec-title-dna">Section title contains the phrase DNA, but it is not in all caps - <value-of select="."/></report>
+      
+      <report test="matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))"
+        role="warning" 
+        id="sec-title-rna">Section title contains the phrase RNA, but it is not in all caps - <value-of select="."/></report>
+      
+      <report test="matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')"
+        role="warning" 
+        id="sec-title-dimension">Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D' - <value-of select="."/></report>
       
     </rule>
     

--- a/test/tests/gen/preprint-title-tests/not-rxiv-test/fail.xml
+++ b/test/tests/gen/preprint-title-tests/not-rxiv-test/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="not-rxiv-test.sch"?>
 <!--Context: element-citation[@publication-type='preprint']/source
-Test: report    not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))
+Test: assert    matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')
 Message: ref '' is tagged as a preprint, but has a source , which doesn't look like a preprint. Is it correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/preprint-title-tests/not-rxiv-test/not-rxiv-test.sch
+++ b/test/tests/gen/preprint-title-tests/not-rxiv-test/not-rxiv-test.sch
@@ -686,7 +686,7 @@
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='preprint']/source" id="preprint-title-tests">
       <let name="lc" value="lower-case(.)"/>
-      <report test="not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</report>
+      <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/preprint-title-tests/not-rxiv-test/pass.xml
+++ b/test/tests/gen/preprint-title-tests/not-rxiv-test/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="not-rxiv-test.sch"?>
 <!--Context: element-citation[@publication-type='preprint']/source
-Test: report    not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))
+Test: assert    matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')
 Message: ref '' is tagged as a preprint, but has a source , which doesn't look like a preprint. Is it correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/ref-book-source-tests/report-book-source-test/fail.xml
+++ b/test/tests/gen/ref-book-source-tests/report-book-source-test/fail.xml
@@ -1,0 +1,22 @@
+<?oxygen SCHSchema="report-book-source-test.sch"?>
+<!--Context: element-citation[@publication-type='book']/source
+Test: report    matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')
+Message: ref '' is tagged as a book reference, but the book title is . Should it be captured as a report type reference instead?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref id="bib81">
+      <element-citation publication-type="book">
+        <person-group person-group-type="author">
+          <collab>National Institute of Health, National Cancer Institute</collab>
+        </person-group>
+        <year iso-8601-date="1996">1996</year>
+        <source>The FTC Cigarette Test Method for Determining Tar, Nicotine, and Carbon Monoxide
+          Yields of U.S. Cigarettes: Report of the NCI Expert Committee</source>
+        <publisher-loc>Bethesda, MD</publisher-loc>
+        <publisher-name>U.S. Department of Health and Human Services, Public Health Service,
+          National Institutes of Health</publisher-name>
+      </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/ref-book-source-tests/report-book-source-test/pass.xml
+++ b/test/tests/gen/ref-book-source-tests/report-book-source-test/pass.xml
@@ -1,0 +1,22 @@
+<?oxygen SCHSchema="report-book-source-test.sch"?>
+<!--Context: element-citation[@publication-type='book']/source
+Test: report    matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')
+Message: ref '' is tagged as a book reference, but the book title is . Should it be captured as a report type reference instead?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref id="bib81">
+      <element-citation publication-type="book">
+        <person-group person-group-type="author">
+          <collab>National Institute of Health, National Cancer Institute</collab>
+        </person-group>
+        <year iso-8601-date="1996">1996</year>
+        <source>The FTC Cigarette Test Method for Determining Tar, Nicotine, and Carbon Monoxide
+          Yields of U.S. Cigarettes</source>
+        <publisher-loc>Bethesda, MD</publisher-loc>
+        <publisher-name>U.S. Department of Health and Human Services, Public Health Service,
+          National Institutes of Health</publisher-name>
+      </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/ref-book-source-tests/report-book-source-test/report-book-source-test.sch
+++ b/test/tests/gen/ref-book-source-tests/report-book-source-test/report-book-source-test.sch
@@ -684,16 +684,13 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="house-style">
-    <rule context="sec/title" id="sec-title-conformity">
-      <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
-      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
-      <report test="(count(*) = 1) and child::underline and ($free-text='')" role="error" id="sec-title-underline">All section title content is captured in underline. This is incorrect - <value-of select="."/>
-      </report>
+    <rule context="element-citation[@publication-type='book']/source" id="ref-book-source-tests">
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-book-source-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the book title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::sec/title" role="error" id="sec-title-conformity-xspec-assert">sec/title must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='book']/source" role="error" id="ref-book-source-tests-xspec-assert">element-citation[@publication-type='book']/source must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/ref-chapter-title-tests/report-chapter-title-test/fail.xml
+++ b/test/tests/gen/ref-chapter-title-tests/report-chapter-title-test/fail.xml
@@ -1,0 +1,23 @@
+<?oxygen SCHSchema="report-chapter-title-test.sch"?>
+<!--Context: element-citation[@publication-type='book']/chapter-title
+Test: report    matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')
+Message: ref '' is tagged as a book reference, but the chapter title is . Should it be captured as a report type reference instead?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref id="bib81">
+      <element-citation publication-type="book">
+        <person-group person-group-type="author">
+          <collab>National Institute of Health, National Cancer Institute</collab>
+        </person-group>
+        <year iso-8601-date="1996">1996</year>
+        <chapter-title>Report of the NCI Expert Committee</chapter-title>
+        <source>The FTC Cigarette Test Method for Determining Tar, Nicotine, and Carbon Monoxide
+          Yields of U.S. Cigarettes</source>
+        <publisher-loc>Bethesda, MD</publisher-loc>
+        <publisher-name>U.S. Department of Health and Human Services, Public Health Service,
+          National Institutes of Health</publisher-name>
+      </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/ref-chapter-title-tests/report-chapter-title-test/pass.xml
+++ b/test/tests/gen/ref-chapter-title-tests/report-chapter-title-test/pass.xml
@@ -1,0 +1,22 @@
+<?oxygen SCHSchema="report-chapter-title-test.sch"?>
+<!--Context: element-citation[@publication-type='book']/chapter-title
+Test: report    matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')
+Message: ref '' is tagged as a book reference, but the chapter title is . Should it be captured as a report type reference instead?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref id="bib81">
+      <element-citation publication-type="book">
+        <person-group person-group-type="author">
+          <collab>National Institute of Health, National Cancer Institute</collab>
+        </person-group>
+        <year iso-8601-date="1996">1996</year>
+        <chapter-title>The FTC Cigarette Test Method for Determining Tar</chapter-title>
+        <source>Carbon Monoxide Yields of U.S. Cigarettes</source>
+        <publisher-loc>Bethesda, MD</publisher-loc>
+        <publisher-name>U.S. Department of Health and Human Services, Public Health Service,
+          National Institutes of Health</publisher-name>
+      </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/ref-chapter-title-tests/report-chapter-title-test/report-chapter-title-test.sch
+++ b/test/tests/gen/ref-chapter-title-tests/report-chapter-title-test/report-chapter-title-test.sch
@@ -684,16 +684,13 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="house-style">
-    <rule context="sec/title" id="sec-title-conformity">
-      <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
-      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
-      <report test="(count(*) = 1) and child::underline and ($free-text='')" role="error" id="sec-title-underline">All section title content is captured in underline. This is incorrect - <value-of select="."/>
-      </report>
+    <rule context="element-citation[@publication-type='book']/chapter-title" id="ref-chapter-title-tests">
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-chapter-title-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the chapter title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::sec/title" role="error" id="sec-title-conformity-xspec-assert">sec/title must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='book']/chapter-title" role="error" id="ref-chapter-title-tests-xspec-assert">element-citation[@publication-type='book']/chapter-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/rrid-org-code/year-style-test/fail.xml
+++ b/test/tests/gen/rrid-org-code/year-style-test/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="year-style-test.sch"?>
+<!--Context: p|td|th
+Test: report    matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)
+Message: '' element contains the following string(s)  . If this refers to years, then the space should be removed after the number, i.e . If the text is referring to a unit then this is fine.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>test 1960 s. test test test 2000s. 1970 s test test.</p>
+  </article>
+</root>

--- a/test/tests/gen/rrid-org-code/year-style-test/pass.xml
+++ b/test/tests/gen/rrid-org-code/year-style-test/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="year-style-test.sch"?>
+<!--Context: p|td|th
+Test: report    matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)
+Message: '' element contains the following string(s)  . If this refers to years, then the space should be removed after the number, i.e . If the text is referring to a unit then this is fine.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>test 1960s. test test test 2000s. 1970s test test.</p>
+  </article>
+</root>

--- a/test/tests/gen/rrid-org-code/year-style-test/year-style-test.sch
+++ b/test/tests/gen/rrid-org-code/year-style-test/year-style-test.sch
@@ -683,17 +683,22 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="sec/title" id="sec-title-conformity">
-      <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
-      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
-      <report test="(count(*) = 1) and child::underline and ($free-text='')" role="error" id="sec-title-underline">All section title content is captured in underline. This is incorrect - <value-of select="."/>
-      </report>
+  <pattern id="rrid-org-pattern">
+    <rule context="p|td|th" id="rrid-org-code">
+      <let name="count" value="count(descendant::ext-link[matches(@xlink:href,'scicrunch\.org.*')])"/>
+      <let name="lc" value="lower-case(.)"/>
+      <let name="text-count" value="number(count(         for $x in tokenize(.,'RRID:|RRID AB_[\d]+|RRID CVCL_[\d]+|RRID SCR_[\d]+|RRID ISMR_JAX')          return $x)) -1"/>
+      <let name="t" value="replace($lc,'drosophila genetic resource center|bloomington drosophila stock center|drosophila genomics resource center','')"/>
+      <let name="code-text" value="string-join(for $x in tokenize(.,' ') return if (matches($x,'^--[a-z]+')) then $x else (),'; ')"/>
+      <let name="unequal-equal-text" value="string-join(for $x in tokenize(.,' | ') return if (matches($x,'=$|^=') and not(matches($x,'^=$'))) then $x else (),'; ')"/>
+      <let name="link-strip-text" value="string-join(for $x in (*[not(matches(local-name(),'^ext-link$|^contrib-id$|^license_ref$|^institution-id$|^email$|^xref$|^monospace$'))]|text()) return $x,'')"/>
+      <let name="url-text" value="string-join(for $x in tokenize($link-strip-text,' ')          return   if (matches($x,'^https?:..(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%_\+.~#?&amp;//=]*)|^ftp://.|^git://.|^tel:.|^mailto:.|\.org[\s]?|\.com[\s]?|\.co.uk[\s]?|\.us[\s]?|\.net[\s]?|\.edu[\s]?|\.gov[\s]?|\.io[\s]?')) then $x         else (),'; ')"/>
+      <report test="matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)" role="warning" id="year-style-test">'<name/>' element contains the following string(s) - <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,' s'),'; ')"/>. If this refers to years, then the space should be removed after the number, i.e <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,'s'),'; ')"/>. If the text is referring to a unit then this is fine.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::sec/title" role="error" id="sec-title-conformity-xspec-assert">sec/title must be present.</assert>
+      <assert test="descendant::p or descendant::td or descendant::th" role="error" id="rrid-org-code-xspec-assert">p|td|th must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/sec-title-conformity/sec-title-abbr-check/sec-title-abbr-check.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-abbr-check/sec-title-abbr-check.sch
@@ -686,6 +686,7 @@
   <pattern id="house-style">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       <report test="matches(.,'^[Aa]bbreviation[s]?')" role="warning" id="sec-title-abbr-check">Section title contains the word abbreviation - '<value-of select="."/>'. Is it an abbreviation section? eLife house style is to define abbreviations in the text when they are first mentioned.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/sec-title-conformity/sec-title-appendix-check/sec-title-appendix-check.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-appendix-check/sec-title-appendix-check.sch
@@ -686,6 +686,7 @@
   <pattern id="house-style">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       <report test="matches(.,'^[Aa]ppendix')" role="warning" id="sec-title-appendix-check">Section title contains the word appendix - '<value-of select="."/>'. Should it be captured as an appendix?</report>
     </rule>
   </pattern>

--- a/test/tests/gen/sec-title-conformity/sec-title-bold/sec-title-bold.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-bold/sec-title-bold.sch
@@ -686,6 +686,7 @@
   <pattern id="house-style">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       <report test="(count(*) = 1) and child::bold and ($free-text='')" role="error" id="sec-title-bold">All section title content is captured in bold. This is incorrect - <value-of select="."/>
       </report>
     </rule>

--- a/test/tests/gen/sec-title-conformity/sec-title-content-mandate/sec-title-content-mandate.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-content-mandate/sec-title-content-mandate.sch
@@ -686,6 +686,7 @@
   <pattern id="house-style">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       <report test="not(*) and (normalize-space(.)='')" role="error" id="sec-title-content-mandate">Section title must not be empty.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/sec-title-conformity/sec-title-dimension/fail.xml
+++ b/test/tests/gen/sec-title-conformity/sec-title-dimension/fail.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="sec-title-dimension.sch"?>
+<!--Context: sec/title
+Test: report    matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')
+Message: Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D'  -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <body>
+      <sec>
+        <title>This is in 3d</title>
+      </sec>
+      <sec>
+        <title>This is in 4d</title>
+      </sec>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/sec-title-conformity/sec-title-dimension/pass.xml
+++ b/test/tests/gen/sec-title-conformity/sec-title-dimension/pass.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="sec-title-dimension.sch"?>
+<!--Context: sec/title
+Test: report    matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')
+Message: Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D'  -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <body>
+      <sec>
+        <title>This is in <xref ref-type="fig" rid="fig3">Figure 3d</xref></title>
+      </sec>
+      <sec>
+        <title>This is in 4D</title>
+      </sec>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/sec-title-conformity/sec-title-dimension/sec-title-dimension.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-dimension/sec-title-dimension.sch
@@ -687,7 +687,7 @@
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
       <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
-      <report test="(count(*) = 1) and child::underline and ($free-text='')" role="error" id="sec-title-underline">All section title content is captured in underline. This is incorrect - <value-of select="."/>
+      <report test="matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')" role="warning" id="sec-title-dimension">Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D' - <value-of select="."/>
       </report>
     </rule>
   </pattern>

--- a/test/tests/gen/sec-title-conformity/sec-title-dna/fail.xml
+++ b/test/tests/gen/sec-title-conformity/sec-title-dna/fail.xml
@@ -1,0 +1,13 @@
+<?oxygen SCHSchema="sec-title-dna.sch"?>
+<!--Context: sec/title
+Test: report    matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))
+Message: Section title contains the phrase DNA, but it is not in all caps  -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <body>
+      <sec>
+        <title>My Dna is exceptional</title>
+      </sec>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/sec-title-conformity/sec-title-dna/pass.xml
+++ b/test/tests/gen/sec-title-conformity/sec-title-dna/pass.xml
@@ -1,0 +1,13 @@
+<?oxygen SCHSchema="sec-title-dna.sch"?>
+<!--Context: sec/title
+Test: report    matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))
+Message: Section title contains the phrase DNA, but it is not in all caps  -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <body>
+      <sec>
+        <title>My DNA is exceptional</title>
+      </sec>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/sec-title-conformity/sec-title-dna/sec-title-dna.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-dna/sec-title-dna.sch
@@ -687,7 +687,7 @@
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
       <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
-      <report test="(count(*) = 1) and child::underline and ($free-text='')" role="error" id="sec-title-underline">All section title content is captured in underline. This is incorrect - <value-of select="."/>
+      <report test="matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))" role="warning" id="sec-title-dna">Section title contains the phrase DNA, but it is not in all caps - <value-of select="."/>
       </report>
     </rule>
   </pattern>

--- a/test/tests/gen/sec-title-conformity/sec-title-full-stop/sec-title-full-stop.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-full-stop/sec-title-full-stop.sch
@@ -686,6 +686,7 @@
   <pattern id="house-style">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       <report test="matches(replace(.,' ',' '),'\.[\s]*$')" role="warning" id="sec-title-full-stop">Section title ends with full stop, which is very likely to be incorrect - <value-of select="."/>
       </report>
     </rule>

--- a/test/tests/gen/sec-title-conformity/sec-title-italic/sec-title-italic.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-italic/sec-title-italic.sch
@@ -686,6 +686,7 @@
   <pattern id="house-style">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       <report test="(count(*) = 1) and child::italic and ($free-text='')" role="warning" id="sec-title-italic">All section title content is captured in italics. This is very likely to be incorrect - <value-of select="."/>
       </report>
     </rule>

--- a/test/tests/gen/sec-title-conformity/sec-title-list-check/sec-title-list-check.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-list-check/sec-title-list-check.sch
@@ -686,6 +686,7 @@
   <pattern id="house-style">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       <report test="matches(.,'^[A-Za-z]{1,3}\)|^\([A-Za-z]{1,3}')" role="warning" id="sec-title-list-check">Section title might start with a list indicator - '<value-of select="."/>'. Is this correct?</report>
     </rule>
   </pattern>

--- a/test/tests/gen/sec-title-conformity/sec-title-rna/fail.xml
+++ b/test/tests/gen/sec-title-conformity/sec-title-rna/fail.xml
@@ -1,0 +1,11 @@
+<?oxygen SCHSchema="sec-title-rna.sch"?>
+<!--Context: sec/title
+Test: report    matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))
+Message: Section title contains the phrase RNA, but it is not in all caps  -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec>
+      <title>What even is Rna?</title>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/sec-title-conformity/sec-title-rna/pass.xml
+++ b/test/tests/gen/sec-title-conformity/sec-title-rna/pass.xml
@@ -1,0 +1,11 @@
+<?oxygen SCHSchema="sec-title-rna.sch"?>
+<!--Context: sec/title
+Test: report    matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))
+Message: Section title contains the phrase RNA, but it is not in all caps  -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec>
+      <title>What even is RNA?</title>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/sec-title-conformity/sec-title-rna/sec-title-rna.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-rna/sec-title-rna.sch
@@ -687,7 +687,7 @@
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
       <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
-      <report test="(count(*) = 1) and child::underline and ($free-text='')" role="error" id="sec-title-underline">All section title content is captured in underline. This is incorrect - <value-of select="."/>
+      <report test="matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))" role="warning" id="sec-title-rna">Section title contains the phrase RNA, but it is not in all caps - <value-of select="."/>
       </report>
     </rule>
   </pattern>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -4800,6 +4800,8 @@
       
       <report test="not(ancestor::sub-article) and not($url-text = '')" role="warning" id="unlinked-url">'<name/>' element contains possible unlinked urls. Check - <value-of select="$url-text"/>
       </report>
+      
+      <report test="matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)" role="warning" id="year-style-test">'<name/>' element contains the following string(s) - <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,' s'),'; ')"/>. If this refers to years, then the space should be removed after the number, i.e <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,'s'),'; ')"/>. If the text is referring to a unit then this is fine.</report>
     </rule>
   </pattern>
   
@@ -5884,11 +5886,25 @@
       
     </rule>
   </pattern>
+  <pattern id="ref-chapter-title-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/chapter-title" id="ref-chapter-title-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-chapter-title-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the chapter title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ref-book-source-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/source" id="ref-book-source-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-book-source-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the book title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
   <pattern id="preprint-title-tests-pattern">
     <rule context="element-citation[@publication-type='preprint']/source" id="preprint-title-tests">
       <let name="lc" value="lower-case(.)"/>
       
-      <report test="not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</report>
+      <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'.</report>
       
@@ -6223,6 +6239,7 @@
   <pattern id="sec-title-conformity-pattern">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       
       <report test="matches(.,'^[A-Za-z]{1,3}\)|^\([A-Za-z]{1,3}')" role="warning" id="sec-title-list-check">Section title might start with a list indicator - '<value-of select="."/>'. Is this correct?</report>
       
@@ -6242,6 +6259,15 @@
       </report>
       
       <report test="(count(*) = 1) and child::italic and ($free-text='')" role="warning" id="sec-title-italic">All section title content is captured in italics. This is very likely to be incorrect - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))" role="warning" id="sec-title-dna">Section title contains the phrase DNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))" role="warning" id="sec-title-rna">Section title contains the phrase RNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')" role="warning" id="sec-title-dimension">Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D' - <value-of select="."/>
       </report>
       
     </rule>
@@ -6870,6 +6896,8 @@
       <assert test="descendant::element-citation[@publication-type='journal']/source" role="error" id="journal-title-tests-xspec-assert">element-citation[@publication-type='journal']/source must be present.</assert>
       <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="ref-article-title-tests-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
       <assert test="descendant::element-citation[@publication-type='journal']" role="error" id="journal-tests-xspec-assert">element-citation[@publication-type='journal'] must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='book']/chapter-title" role="error" id="ref-chapter-title-tests-xspec-assert">element-citation[@publication-type='book']/chapter-title must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='book']/source" role="error" id="ref-book-source-tests-xspec-assert">element-citation[@publication-type='book']/source must be present.</assert>
       <assert test="descendant::element-citation[@publication-type='preprint']/source" role="error" id="preprint-title-tests-xspec-assert">element-citation[@publication-type='preprint']/source must be present.</assert>
       <assert test="descendant::element-citation[@publication-type='web']" role="error" id="website-tests-xspec-assert">element-citation[@publication-type='web'] must be present.</assert>
       <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -8903,6 +8903,16 @@
         <x:expect-report id="unlinked-url" role="warning"/>
         <x:expect-not-assert id="rrid-org-code-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="year-style-test-pass">
+        <x:context href="../tests/gen/rrid-org-code/year-style-test/pass.xml"/>
+        <x:expect-not-report id="year-style-test" role="warning"/>
+        <x:expect-not-assert id="rrid-org-code-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="year-style-test-fail">
+        <x:context href="../tests/gen/rrid-org-code/year-style-test/fail.xml"/>
+        <x:expect-report id="year-style-test" role="warning"/>
+        <x:expect-not-assert id="rrid-org-code-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="duplicate-ref">
       <x:scenario label="duplicate-ref-test-1-pass">
@@ -12432,15 +12442,39 @@
         <x:expect-not-assert id="journal-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="ref-chapter-title-tests">
+      <x:scenario label="report-chapter-title-test-pass">
+        <x:context href="../tests/gen/ref-chapter-title-tests/report-chapter-title-test/pass.xml"/>
+        <x:expect-not-report id="report-chapter-title-test" role="warning"/>
+        <x:expect-not-assert id="ref-chapter-title-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="report-chapter-title-test-fail">
+        <x:context href="../tests/gen/ref-chapter-title-tests/report-chapter-title-test/fail.xml"/>
+        <x:expect-report id="report-chapter-title-test" role="warning"/>
+        <x:expect-not-assert id="ref-chapter-title-tests-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="ref-book-source-tests">
+      <x:scenario label="report-book-source-test-pass">
+        <x:context href="../tests/gen/ref-book-source-tests/report-book-source-test/pass.xml"/>
+        <x:expect-not-report id="report-book-source-test" role="warning"/>
+        <x:expect-not-assert id="ref-book-source-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="report-book-source-test-fail">
+        <x:context href="../tests/gen/ref-book-source-tests/report-book-source-test/fail.xml"/>
+        <x:expect-report id="report-book-source-test" role="warning"/>
+        <x:expect-not-assert id="ref-book-source-tests-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
     <x:scenario label="preprint-title-tests">
       <x:scenario label="not-rxiv-test-pass">
         <x:context href="../tests/gen/preprint-title-tests/not-rxiv-test/pass.xml"/>
-        <x:expect-not-report id="not-rxiv-test" role="warning"/>
+        <x:expect-not-assert id="not-rxiv-test" role="warning"/>
         <x:expect-not-assert id="preprint-title-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="not-rxiv-test-fail">
         <x:context href="../tests/gen/preprint-title-tests/not-rxiv-test/fail.xml"/>
-        <x:expect-report id="not-rxiv-test" role="warning"/>
+        <x:expect-assert id="not-rxiv-test" role="warning"/>
         <x:expect-not-assert id="preprint-title-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="biorxiv-test-pass">
@@ -13853,6 +13887,36 @@
       <x:scenario label="sec-title-italic-fail">
         <x:context href="../tests/gen/sec-title-conformity/sec-title-italic/fail.xml"/>
         <x:expect-report id="sec-title-italic" role="warning"/>
+        <x:expect-not-assert id="sec-title-conformity-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="sec-title-dna-pass">
+        <x:context href="../tests/gen/sec-title-conformity/sec-title-dna/pass.xml"/>
+        <x:expect-not-report id="sec-title-dna" role="warning"/>
+        <x:expect-not-assert id="sec-title-conformity-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="sec-title-dna-fail">
+        <x:context href="../tests/gen/sec-title-conformity/sec-title-dna/fail.xml"/>
+        <x:expect-report id="sec-title-dna" role="warning"/>
+        <x:expect-not-assert id="sec-title-conformity-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="sec-title-rna-pass">
+        <x:context href="../tests/gen/sec-title-conformity/sec-title-rna/pass.xml"/>
+        <x:expect-not-report id="sec-title-rna" role="warning"/>
+        <x:expect-not-assert id="sec-title-conformity-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="sec-title-rna-fail">
+        <x:context href="../tests/gen/sec-title-conformity/sec-title-rna/fail.xml"/>
+        <x:expect-report id="sec-title-rna" role="warning"/>
+        <x:expect-not-assert id="sec-title-conformity-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="sec-title-dimension-pass">
+        <x:context href="../tests/gen/sec-title-conformity/sec-title-dimension/pass.xml"/>
+        <x:expect-not-report id="sec-title-dimension" role="warning"/>
+        <x:expect-not-assert id="sec-title-conformity-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="sec-title-dimension-fail">
+        <x:context href="../tests/gen/sec-title-conformity/sec-title-dimension/fail.xml"/>
+        <x:expect-report id="sec-title-dimension" role="warning"/>
         <x:expect-not-assert id="sec-title-conformity-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -4787,6 +4787,8 @@
       
       <report test="not(ancestor::sub-article) and not($url-text = '')" role="warning" id="unlinked-url">'<name/>' element contains possible unlinked urls. Check - <value-of select="$url-text"/>
       </report>
+      
+      <report test="matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)" role="warning" id="year-style-test">'<name/>' element contains the following string(s) - <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,' s'),'; ')"/>. If this refers to years, then the space should be removed after the number, i.e <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,'s'),'; ')"/>. If the text is referring to a unit then this is fine.</report>
     </rule>
   </pattern>
   
@@ -5881,11 +5883,25 @@
       
     </rule>
   </pattern>
+  <pattern id="ref-chapter-title-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/chapter-title" id="ref-chapter-title-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-chapter-title-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the chapter title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ref-book-source-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/source" id="ref-book-source-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-book-source-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the book title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
   <pattern id="preprint-title-tests-pattern">
     <rule context="element-citation[@publication-type='preprint']/source" id="preprint-title-tests">
       <let name="lc" value="lower-case(.)"/>
       
-      <report test="not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</report>
+      <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'.</report>
       
@@ -6220,6 +6236,7 @@
   <pattern id="sec-title-conformity-pattern">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       
       <report test="matches(.,'^[A-Za-z]{1,3}\)|^\([A-Za-z]{1,3}')" role="warning" id="sec-title-list-check">Section title might start with a list indicator - '<value-of select="."/>'. Is this correct?</report>
       
@@ -6239,6 +6256,15 @@
       </report>
       
       <report test="(count(*) = 1) and child::italic and ($free-text='')" role="warning" id="sec-title-italic">All section title content is captured in italics. This is very likely to be incorrect - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))" role="warning" id="sec-title-dna">Section title contains the phrase DNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))" role="warning" id="sec-title-rna">Section title contains the phrase RNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')" role="warning" id="sec-title-dimension">Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D' - <value-of select="."/>
       </report>
       
     </rule>

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -4786,6 +4786,8 @@
       
       <report test="not(ancestor::sub-article) and not($url-text = '')" role="warning" id="unlinked-url">'<name/>' element contains possible unlinked urls. Check - <value-of select="$url-text"/>
       </report>
+      
+      <report test="matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]') and not(descendant::p[matches(.,'\s[1-2][0-9][0-9]0\ss[\s\.]')]) and not(descendant::td) and not(descendant::th)" role="warning" id="year-style-test">'<name/>' element contains the following string(s) - <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,' s'),'; ')"/>. If this refers to years, then the space should be removed after the number, i.e <value-of select="string-join(for $x in tokenize(.,' ')[matches(.,'^[1-2][0-9][0-9]0$')] return concat($x,'s'),'; ')"/>. If the text is referring to a unit then this is fine.</report>
     </rule>
   </pattern>
   
@@ -5880,11 +5882,25 @@
       
     </rule>
   </pattern>
+  <pattern id="ref-chapter-title-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/chapter-title" id="ref-chapter-title-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-chapter-title-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the chapter title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ref-book-source-tests-pattern">
+    <rule context="element-citation[@publication-type='book']/source" id="ref-book-source-tests">
+      
+      <report test="matches(.,' [Rr]eport |^[Rr]eport | [Rr]eport[\s\p{P}]?$')" role="warning" id="report-book-source-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a book reference, but the book title is <value-of select="."/>. Should it be captured as a report type reference instead?</report>
+      
+    </rule>
+  </pattern>
   <pattern id="preprint-title-tests-pattern">
     <rule context="element-citation[@publication-type='preprint']/source" id="preprint-title-tests">
       <let name="lc" value="lower-case(.)"/>
       
-      <report test="not(matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints'))" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</report>
+      <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct?</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'.</report>
       
@@ -6219,6 +6235,7 @@
   <pattern id="sec-title-conformity-pattern">
     <rule context="sec/title" id="sec-title-conformity">
       <let name="free-text" value="replace(         normalize-space(string-join(for $x in self::*/text() return $x,''))         ,' ','')"/>
+      <let name="no-link-text" value="translate(         normalize-space(string-join(for $x in self::*/(*[not(name()='xref')]|text()) return $x,''))         ,' ?.',' ')"/>
       
       <report test="matches(.,'^[A-Za-z]{1,3}\)|^\([A-Za-z]{1,3}')" role="warning" id="sec-title-list-check">Section title might start with a list indicator - '<value-of select="."/>'. Is this correct?</report>
       
@@ -6238,6 +6255,15 @@
       </report>
       
       <report test="(count(*) = 1) and child::italic and ($free-text='')" role="warning" id="sec-title-italic">All section title content is captured in italics. This is very likely to be incorrect - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^DNA | DNA | DNA$') and not(matches($no-link-text,'^DNA | DNA | DNA$'))" role="warning" id="sec-title-dna">Section title contains the phrase DNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches(upper-case($no-link-text),'^RNA | RNA | RNA$') and not(matches($no-link-text,'^RNA | RNA | RNA$'))" role="warning" id="sec-title-rna">Section title contains the phrase RNA, but it is not in all caps - <value-of select="."/>
+      </report>
+      
+      <report test="matches($no-link-text,'^[1-4]d | [1-4]d | [1-4]d$')" role="warning" id="sec-title-dimension">Section title contains lowercase abbreviation for dimension, when this should always be uppercase 'D' - <value-of select="."/>
       </report>
       
     </rule>


### PR DESCRIPTION
- Test for `3d` and similar in section titles - `sec-title-dimension`.
- Tests for `Dna`, `Rna` and similar in section titles - `sec-title-dna`, `sec-title-rna`.
- Test for erroneous spaces in decades notation - e.g. `1960 s` - `year-style-test`.
- Tests for reports erroneously tagged as books - `report-chapter-title-test`, `report-book-source-test`.
- Simplify logic in `not-rxiv-test`.