### PR TITLE
feat: add more tests

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1711,6 +1711,8 @@
       <report test="contains(.,'copy archived')" role="error" id="ext-link-child-test-3">ext-link - <value-of select="."/> - contains the phrase 'copy archived', which is incorrect.</report>
       
       <report test="matches(.,'^[Dd][Oo][Ii]:|^[Dd][Oo][Ii]\s')" role="warning" id="ext-link-child-test-4">ext-link text - <value-of select="."/> - appears to start with the string 'Doi:' or 'Doi ' (or similar), which is unncessary.</report>
+      
+      <report test="contains(@xlink:href,'datadryad.org/review?')" role="warning" id="ext-link-child-test-5">ext-link looks like it points to a review dryad dataset - <value-of select="."/>. Should it be updated?</report>
     </rule>
   </pattern>
   <pattern id="fig-group-tests-pattern">
@@ -2135,6 +2137,13 @@
       <assert test="self::*/local-name() = ($allowed-blocks,'bold')" role="error" id="th-child-test-1">th cannot contain <value-of select="self::*/local-name()"/>. Only the following elements are allowed - 'italic','sup','sub','sc','ext-link', 'break', 'named-content', 'monospace' and 'xref'.</assert>
       
       <report test="self::*/local-name() = 'bold'" role="warning" id="th-child-test-2">th contains bold. Is this correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="table-fn-label-tests-pattern">
+    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
+      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+      
+      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -5890,6 +5899,10 @@
       
       <report test="matches(.,'�')" role="error" id="city-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5994,7 +6007,7 @@
       
       <report test="matches(normalize-space(lower-case(source[1])),'^biorxiv$|^arxiv$|^chemrxiv$|^peerj preprints$|^psyarxiv$|^paleorxiv$|^preprints$')" role="error" id="journal-preprint-check">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="source[1]"/>, but it is captured as a journal not a preprint.</report>
       
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
       
       <report test="matches(lower-case(source[1]),'conference|symposium|symposia|neural information processing|nips|computer vision and pattern recognition|scipy|workshop|meeting|spie|congress|[\d]st|[\d]nd|[\d]rd|[\d]th')" role="warning" id="journal-conference-ref-check-1">Journal ref '<value-of select="ancestor::ref/@id"/>' has the journal title <value-of select="source[1]"/>. Should it be a conference type reference instead?</report>
       
@@ -6594,7 +6607,7 @@
     <rule context="xref[not(@ref-type='bibr')]" id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       
       <report test="$parent = $formatting-elems" role="error" id="xref-parent-test">xref - <value-of select="."/> - has a formatting parent element - <value-of select="$parent"/> - which is not correct.</report>
       
@@ -6631,6 +6644,26 @@
       <report test="not(matches(.,'RNA|[Cc]ryoEM|[34]D')) and (. != $lower) and not(contains($t,.))" role="warning" id="auth-kwd-check">Keyword - '<value-of select="."/>' - does not appear in the article text with this capitalisation. Should it be <value-of select="$lower"/> instead?</report>
       
       <report test="matches(.,'&amp;#x\d')" role="warning" id="auth-kwd-check-2">Keyword contains what looks like a broken unicode - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="ref-given-names-pattern">
+    <rule context="ref-list//element-citation/person-group[@person-group-type='author']//given-names" id="ref-given-names">
+      
+      <report test="string-length(.) gt 4" role="warning" id="ref-given-names-test-1">Given names should always be initialised. Ref '<value-of select="ancestor::ref[1]/@id"/>' contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+    </rule>
+  </pattern>
+  <pattern id="data-ref-given-names-pattern">
+    <rule context="sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" id="data-ref-given-names">      
+      
+      <report test="string-length(.) gt 4" role="warning" id="data-ref-given-names-test-1">Given names should always be initialised. Ref contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ar-fig-title-tests-pattern">
+    <rule context="fig[ancestor::sub-article]/caption/title" id="ar-fig-title-tests">     
+      
+      <report test="lower-case(normalize-space(.))=('title','title.')" role="warning" id="ar-fig-title-test-1">Please query author for a <value-of select="ancestor::fig/label"/> title, and/or remove placeholder title text - <value-of select="."/>.</report>
+      
     </rule>
   </pattern>
   

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1717,6 +1717,8 @@
       <report test="contains(.,'copy archived')" role="error" id="ext-link-child-test-3">ext-link - <value-of select="."/> - contains the phrase 'copy archived', which is incorrect.</report>
       
       <report test="matches(.,'^[Dd][Oo][Ii]:|^[Dd][Oo][Ii]\s')" role="warning" id="ext-link-child-test-4">ext-link text - <value-of select="."/> - appears to start with the string 'Doi:' or 'Doi ' (or similar), which is unncessary.</report>
+      
+      <report test="contains(@xlink:href,'datadryad.org/review?')" role="warning" id="ext-link-child-test-5">ext-link looks like it points to a review dryad dataset - <value-of select="."/>. Should it be updated?</report>
     </rule>
   </pattern>
   <pattern id="fig-group-tests-pattern">
@@ -2141,6 +2143,13 @@
       <assert test="self::*/local-name() = ($allowed-blocks,'bold')" role="error" id="th-child-test-1">th cannot contain <value-of select="self::*/local-name()"/>. Only the following elements are allowed - 'italic','sup','sub','sc','ext-link', 'break', 'named-content', 'monospace' and 'xref'.</assert>
       
       <report test="self::*/local-name() = 'bold'" role="warning" id="th-child-test-2">th contains bold. Is this correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="table-fn-label-tests-pattern">
+    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
+      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+      
+      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -5896,6 +5905,10 @@
       
       <report test="matches(.,'�')" role="error" id="city-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -6000,7 +6013,7 @@
       
       <report test="matches(normalize-space(lower-case(source[1])),'^biorxiv$|^arxiv$|^chemrxiv$|^peerj preprints$|^psyarxiv$|^paleorxiv$|^preprints$')" role="error" id="journal-preprint-check">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="source[1]"/>, but it is captured as a journal not a preprint.</report>
       
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
       
       <report test="matches(lower-case(source[1]),'conference|symposium|symposia|neural information processing|nips|computer vision and pattern recognition|scipy|workshop|meeting|spie|congress|[\d]st|[\d]nd|[\d]rd|[\d]th')" role="warning" id="journal-conference-ref-check-1">Journal ref '<value-of select="ancestor::ref/@id"/>' has the journal title <value-of select="source[1]"/>. Should it be a conference type reference instead?</report>
       
@@ -6600,7 +6613,7 @@
     <rule context="xref[not(@ref-type='bibr')]" id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       
       <report test="$parent = $formatting-elems" role="error" id="xref-parent-test">xref - <value-of select="."/> - has a formatting parent element - <value-of select="$parent"/> - which is not correct.</report>
       
@@ -6637,6 +6650,26 @@
       <report test="not(matches(.,'RNA|[Cc]ryoEM|[34]D')) and (. != $lower) and not(contains($t,.))" role="warning" id="auth-kwd-check">Keyword - '<value-of select="."/>' - does not appear in the article text with this capitalisation. Should it be <value-of select="$lower"/> instead?</report>
       
       <report test="matches(.,'&amp;#x\d')" role="warning" id="auth-kwd-check-2">Keyword contains what looks like a broken unicode - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="ref-given-names-pattern">
+    <rule context="ref-list//element-citation/person-group[@person-group-type='author']//given-names" id="ref-given-names">
+      
+      <report test="string-length(.) gt 4" role="warning" id="ref-given-names-test-1">Given names should always be initialised. Ref '<value-of select="ancestor::ref[1]/@id"/>' contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+    </rule>
+  </pattern>
+  <pattern id="data-ref-given-names-pattern">
+    <rule context="sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" id="data-ref-given-names">      
+      
+      <report test="string-length(.) gt 4" role="warning" id="data-ref-given-names-test-1">Given names should always be initialised. Ref contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ar-fig-title-tests-pattern">
+    <rule context="fig[ancestor::sub-article]/caption/title" id="ar-fig-title-tests">     
+      
+      <report test="lower-case(normalize-space(.))=('title','title.')" role="warning" id="ar-fig-title-test-1">Please query author for a <value-of select="ancestor::fig/label"/> title, and/or remove placeholder title text - <value-of select="."/>.</report>
+      
     </rule>
   </pattern>
   

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1708,6 +1708,8 @@
       <report test="contains(.,'copy archived')" role="error" id="ext-link-child-test-3">ext-link - <value-of select="."/> - contains the phrase 'copy archived', which is incorrect.</report>
       
       <report test="matches(.,'^[Dd][Oo][Ii]:|^[Dd][Oo][Ii]\s')" role="warning" id="ext-link-child-test-4">ext-link text - <value-of select="."/> - appears to start with the string 'Doi:' or 'Doi ' (or similar), which is unncessary.</report>
+      
+      <report test="contains(@xlink:href,'datadryad.org/review?')" role="warning" id="ext-link-child-test-5">ext-link looks like it points to a review dryad dataset - <value-of select="."/>. Should it be updated?</report>
     </rule>
   </pattern>
   <pattern id="fig-group-tests-pattern">
@@ -2133,6 +2135,13 @@
       <assert test="self::*/local-name() = ($allowed-blocks,'bold')" role="error" id="th-child-test-1">th cannot contain <value-of select="self::*/local-name()"/>. Only the following elements are allowed - 'italic','sup','sub','sc','ext-link', 'break', 'named-content', 'monospace' and 'xref'.</assert>
       
       <report test="self::*/local-name() = 'bold'" role="warning" id="th-child-test-2">th contains bold. Is this correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="table-fn-label-tests-pattern">
+    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
+      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+      
+      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -5888,6 +5897,10 @@
       
       <report test="matches(.,'�')" role="error" id="city-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5992,7 +6005,7 @@
       
       <report test="matches(normalize-space(lower-case(source[1])),'^biorxiv$|^arxiv$|^chemrxiv$|^peerj preprints$|^psyarxiv$|^paleorxiv$|^preprints$')" role="error" id="journal-preprint-check">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="source[1]"/>, but it is captured as a journal not a preprint.</report>
       
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
       
       <report test="matches(lower-case(source[1]),'conference|symposium|symposia|neural information processing|nips|computer vision and pattern recognition|scipy|workshop|meeting|spie|congress|[\d]st|[\d]nd|[\d]rd|[\d]th')" role="warning" id="journal-conference-ref-check-1">Journal ref '<value-of select="ancestor::ref/@id"/>' has the journal title <value-of select="source[1]"/>. Should it be a conference type reference instead?</report>
       
@@ -6592,7 +6605,7 @@
     <rule context="xref[not(@ref-type='bibr')]" id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       
       <report test="$parent = $formatting-elems" role="error" id="xref-parent-test">xref - <value-of select="."/> - has a formatting parent element - <value-of select="$parent"/> - which is not correct.</report>
       
@@ -6629,6 +6642,26 @@
       <report test="not(matches(.,'RNA|[Cc]ryoEM|[34]D')) and (. != $lower) and not(contains($t,.))" role="warning" id="auth-kwd-check">Keyword - '<value-of select="."/>' - does not appear in the article text with this capitalisation. Should it be <value-of select="$lower"/> instead?</report>
       
       <report test="matches(.,'&amp;#x\d')" role="warning" id="auth-kwd-check-2">Keyword contains what looks like a broken unicode - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="ref-given-names-pattern">
+    <rule context="ref-list//element-citation/person-group[@person-group-type='author']//given-names" id="ref-given-names">
+      
+      <report test="string-length(.) gt 4" role="warning" id="ref-given-names-test-1">Given names should always be initialised. Ref '<value-of select="ancestor::ref[1]/@id"/>' contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+    </rule>
+  </pattern>
+  <pattern id="data-ref-given-names-pattern">
+    <rule context="sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" id="data-ref-given-names">      
+      
+      <report test="string-length(.) gt 4" role="warning" id="data-ref-given-names-test-1">Given names should always be initialised. Ref contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ar-fig-title-tests-pattern">
+    <rule context="fig[ancestor::sub-article]/caption/title" id="ar-fig-title-tests">     
+      
+      <report test="lower-case(normalize-space(.))=('title','title.')" role="warning" id="ar-fig-title-test-1">Please query author for a <value-of select="ancestor::fig/label"/> title, and/or remove placeholder title text - <value-of select="."/>.</report>
+      
     </rule>
   </pattern>
   

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2240,6 +2240,10 @@
       <report test="matches(.,'^[Dd][Oo][Ii]:|^[Dd][Oo][Ii]\s')"
         role="warning" 
         id="ext-link-child-test-4">ext-link text - <value-of select="."/> - appears to start with the string 'Doi:' or 'Doi ' (or similar), which is unncessary.</report>
+      
+      <report test="contains(@xlink:href,'datadryad.org/review?')"
+        role="warning" 
+        id="ext-link-child-test-5">ext-link looks like it points to a review dryad dataset - <value-of select="."/>. Should it be updated?</report>
     </rule>
     
     <rule context="fig-group" 
@@ -2881,6 +2885,15 @@
       <report test="self::*/local-name() = 'bold'"
         role="warning"
         id="th-child-test-2">th contains bold. Is this correct?</report>
+    </rule>
+    
+    <rule context="table-wrap-foot//fn/p/*[1]" 
+      id="table-fn-label-tests"> 
+      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+      
+      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)"
+        role="warning"
+        id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.</report>
     </rule>
     
     <rule context="fn[@id][not(@fn-type='other')]" 
@@ -7897,6 +7910,14 @@
       <report test="matches(.,'�')"
         role="error"
         id="city-replacement-character-presence"><name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(.,'\d')"
+        role="warning"
+        id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')"
+        role="warning"
+        id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
     
     <rule context="aff/institution[not(@*)]" 
@@ -8041,7 +8062,7 @@
         role="error" 
         id="journal-preprint-check">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="source[1]"/>, but it is captured as a journal not a preprint.</report>
       
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))"
+      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))"
         role="error" 
         id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
       
@@ -9013,7 +9034,7 @@
       id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       
       <report test="$parent = $formatting-elems"
         role="error" 
@@ -9072,6 +9093,32 @@
       <report test="matches(.,'&amp;#x\d')"
         role="warning"
         id="auth-kwd-check-2">Keyword contains what looks like a broken unicode - <value-of select="."/>.</report>
+    </rule>
+    
+    <rule context="ref-list//element-citation/person-group[@person-group-type='author']//given-names" 
+      id="ref-given-names">
+      
+      <report test="string-length(.) gt 4"
+        role="warning"
+        id="ref-given-names-test-1">Given names should always be initialised. Ref '<value-of select="ancestor::ref[1]/@id"/>' contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+    </rule>
+    
+    <rule context="sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" 
+      id="data-ref-given-names">      
+      
+      <report test="string-length(.) gt 4"
+        role="warning"
+        id="data-ref-given-names-test-1">Given names should always be initialised. Ref contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+      
+    </rule>
+    
+    <rule context="fig[ancestor::sub-article]/caption/title" 
+      id="ar-fig-title-tests">     
+      
+      <report test="lower-case(normalize-space(.))=('title','title.')"
+        role="warning"
+        id="ar-fig-title-test-1">Please query author for a <value-of select="ancestor::fig/label"/> title, and/or remove placeholder title text - <value-of select="."/>.</report>
+      
     </rule>
   </pattern>
   

--- a/test/tests/gen/ar-fig-title-tests/ar-fig-title-test-1/ar-fig-title-test-1.sch
+++ b/test/tests/gen/ar-fig-title-tests/ar-fig-title-test-1/ar-fig-title-test-1.sch
@@ -712,13 +712,13 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="house-style">
-    <rule context="element-citation[@publication-type='journal']" id="journal-tests">
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+    <rule context="fig[ancestor::sub-article]/caption/title" id="ar-fig-title-tests">
+      <report test="lower-case(normalize-space(.))=('title','title.')" role="warning" id="ar-fig-title-test-1">Please query author for a <value-of select="ancestor::fig/label"/> title, and/or remove placeholder title text - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']" role="error" id="journal-tests-xspec-assert">element-citation[@publication-type='journal'] must be present.</assert>
+      <assert test="descendant::fig[ancestor::sub-article]/caption/title" role="error" id="ar-fig-title-tests-xspec-assert">fig[ancestor::sub-article]/caption/title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/ar-fig-title-tests/ar-fig-title-test-1/fail.xml
+++ b/test/tests/gen/ar-fig-title-tests/ar-fig-title-test-1/fail.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="ar-fig-title-test-1.sch"?>
+<!--Context: fig[ancestor::sub-article]/caption/title
+Test: report    lower-case(normalize-space(.))=('title','title.')
+Message: Please query author for a  title, and/or remove placeholder title text  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sub-article article-type="reply">
+      <fig id="sa2fig1"><label>Author response image 1.</label>
+        <caption><title>Title</title></caption><graphic xlink:href="{.}..resources/elife2/ecs/article/172702/resources/elife-53638-sa2-fig1.jpg" mimetype="image" mime-subtype="jpeg"/></fig>
+    </sub-article>
+  </article>
+</root>

--- a/test/tests/gen/ar-fig-title-tests/ar-fig-title-test-1/pass.xml
+++ b/test/tests/gen/ar-fig-title-tests/ar-fig-title-test-1/pass.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="ar-fig-title-test-1.sch"?>
+<!--Context: fig[ancestor::sub-article]/caption/title
+Test: report    lower-case(normalize-space(.))=('title','title.')
+Message: Please query author for a  title, and/or remove placeholder title text  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sub-article article-type="reply">
+      <fig id="sa2fig1"><label>Author response image 1.</label>
+        <caption><title>Placeholder text</title></caption><graphic xlink:href="{.}..resources/elife2/ecs/article/172702/resources/elife-53638-sa2-fig1.jpg" mimetype="image" mime-subtype="jpeg"/></fig>
+    </sub-article>
+  </article>
+</root>

--- a/test/tests/gen/city-tests/city-number-presence/city-number-presence.sch
+++ b/test/tests/gen/city-tests/city-number-presence/city-number-presence.sch
@@ -712,13 +712,15 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="house-style">
-    <rule context="element-citation[@publication-type='journal']" id="journal-tests">
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+    <rule context="front//aff//named-content[@content-type='city']" id="city-tests">
+      <let name="lc" value="normalize-space(lower-case(.))"/>
+      <let name="states-regex" value="'^alabama$|^al$|^alaska$|^ak$|^arizona$|^az$|^arkansas$|^ar$|^california$|^ca$|^colorado$|^co$|^connecticut$|^ct$|^delaware$|^de$|^florida$|^fl$|^georgia$|^ga$|^hawaii$|^hi$|^idaho$|^id$|^illinois$|^il$|^indiana$|^in$|^iowa$|^ia$|^kansas$|^ks$|^kentucky$|^ky$|^louisiana$|^la$|^maine$|^me$|^maryland$|^md$|^massachusetts$|^ma$|^michigan$|^mi$|^minnesota$|^mn$|^mississippi$|^ms$|^missouri$|^mo$|^montana$|^mt$|^nebraska$|^ne$|^nevada$|^nv$|^new hampshire$|^nh$|^new jersey$|^nj$|^new mexico$|^nm$|^ny$|^north carolina$|^nc$|^north dakota$|^nd$|^ohio$|^oh$|^oklahoma$|^ok$|^oregon$|^or$|^pennsylvania$|^pa$|^rhode island$|^ri$|^south carolina$|^sc$|^south dakota$|^sd$|^tennessee$|^tn$|^texas$|^tx$|^utah$|^ut$|^vermont$|^vt$|^virginia$|^va$|^wa$|^west virginia$|^wv$|^wisconsin$|^wi$|^wyoming$|^wy$'"/>
+      <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']" role="error" id="journal-tests-xspec-assert">element-citation[@publication-type='journal'] must be present.</assert>
+      <assert test="descendant::front//aff//named-content[@content-type='city']" role="error" id="city-tests-xspec-assert">front//aff//named-content[@content-type='city'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/city-tests/city-number-presence/fail.xml
+++ b/test/tests/gen/city-tests/city-number-presence/fail.xml
@@ -1,0 +1,13 @@
+<?oxygen SCHSchema="city-number-presence.sch"?>
+<!--Context: front//aff//named-content[@content-type='city']
+Test: report    matches(.,'\d')
+Message: city contains a number, which is almost certainly incorrect  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff>
+        <named-content content-type="city">F-1905 Paris</named-content>
+      </aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/city-tests/city-number-presence/pass.xml
+++ b/test/tests/gen/city-tests/city-number-presence/pass.xml
@@ -1,0 +1,13 @@
+<?oxygen SCHSchema="city-number-presence.sch"?>
+<!--Context: front//aff//named-content[@content-type='city']
+Test: report    matches(.,'\d')
+Message: city contains a number, which is almost certainly incorrect  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff>
+        <named-content content-type="city">Bengaluru</named-content>
+      </aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/city-tests/city-street-presence/city-street-presence.sch
+++ b/test/tests/gen/city-tests/city-street-presence/city-street-presence.sch
@@ -712,13 +712,15 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="house-style">
-    <rule context="element-citation[@publication-type='journal']" id="journal-tests">
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+    <rule context="front//aff//named-content[@content-type='city']" id="city-tests">
+      <let name="lc" value="normalize-space(lower-case(.))"/>
+      <let name="states-regex" value="'^alabama$|^al$|^alaska$|^ak$|^arizona$|^az$|^arkansas$|^ar$|^california$|^ca$|^colorado$|^co$|^connecticut$|^ct$|^delaware$|^de$|^florida$|^fl$|^georgia$|^ga$|^hawaii$|^hi$|^idaho$|^id$|^illinois$|^il$|^indiana$|^in$|^iowa$|^ia$|^kansas$|^ks$|^kentucky$|^ky$|^louisiana$|^la$|^maine$|^me$|^maryland$|^md$|^massachusetts$|^ma$|^michigan$|^mi$|^minnesota$|^mn$|^mississippi$|^ms$|^missouri$|^mo$|^montana$|^mt$|^nebraska$|^ne$|^nevada$|^nv$|^new hampshire$|^nh$|^new jersey$|^nj$|^new mexico$|^nm$|^ny$|^north carolina$|^nc$|^north dakota$|^nd$|^ohio$|^oh$|^oklahoma$|^ok$|^oregon$|^or$|^pennsylvania$|^pa$|^rhode island$|^ri$|^south carolina$|^sc$|^south dakota$|^sd$|^tennessee$|^tn$|^texas$|^tx$|^utah$|^ut$|^vermont$|^vt$|^virginia$|^va$|^wa$|^west virginia$|^wv$|^wisconsin$|^wi$|^wyoming$|^wy$'"/>
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']" role="error" id="journal-tests-xspec-assert">element-citation[@publication-type='journal'] must be present.</assert>
+      <assert test="descendant::front//aff//named-content[@content-type='city']" role="error" id="city-tests-xspec-assert">front//aff//named-content[@content-type='city'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/city-tests/city-street-presence/fail.xml
+++ b/test/tests/gen/city-tests/city-street-presence/fail.xml
@@ -1,0 +1,13 @@
+<?oxygen SCHSchema="city-street-presence.sch"?>
+<!--Context: front//aff//named-content[@content-type='city']
+Test: report    matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')
+Message: city likely contains a street or building name, which is almost certainly incorrect  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff>
+        <named-content content-type="city">Rue xml Bengaluru</named-content>
+      </aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/city-tests/city-street-presence/pass.xml
+++ b/test/tests/gen/city-tests/city-street-presence/pass.xml
@@ -1,0 +1,13 @@
+<?oxygen SCHSchema="city-street-presence.sch"?>
+<!--Context: front//aff//named-content[@content-type='city']
+Test: report    matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')
+Message: city likely contains a street or building name, which is almost certainly incorrect  .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff>
+        <named-content content-type="city">Bengaluru</named-content>
+      </aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-given-names/data-ref-given-names-test-1/data-ref-given-names-test-1.sch
+++ b/test/tests/gen/data-ref-given-names/data-ref-given-names-test-1/data-ref-given-names-test-1.sch
@@ -712,13 +712,13 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="house-style">
-    <rule context="element-citation[@publication-type='journal']" id="journal-tests">
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+    <rule context="sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" id="data-ref-given-names">
+      <report test="string-length(.) gt 4" role="warning" id="data-ref-given-names-test-1">Given names should always be initialised. Ref contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']" role="error" id="journal-tests-xspec-assert">element-citation[@publication-type='journal'] must be present.</assert>
+      <assert test="descendant::sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" role="error" id="data-ref-given-names-xspec-assert">sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/data-ref-given-names/data-ref-given-names-test-1/fail.xml
+++ b/test/tests/gen/data-ref-given-names/data-ref-given-names-test-1/fail.xml
@@ -1,0 +1,56 @@
+<?oxygen SCHSchema="data-ref-given-names-test-1.sch"?>
+<!--Context: sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names
+Test: report    string-length(.) gt 4
+Message: Given names should always be initialised. Ref contains a given names with a string longer than 4 characters  '' in . Is this a surname captured as given names? Or a fully spelt out given names?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec id="s7" sec-type="data-availability">
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Sankaranarayanan</surname>
+              <given-names>SR</given-names>
+            </name>
+            <name>
+              <surname>Ianiri</surname>
+              <given-names>G</given-names>
+            </name>
+            <name>
+              <surname>Coelho</surname>
+              <given-names>MA</given-names>
+            </name>
+            <name>
+              <surname>Reza</surname>
+              <given-names>MH</given-names>
+            </name>
+            <name>
+              <surname>Thimmappa</surname>
+              <given-names>BCvfewbvfew</given-names>
+            </name>
+            <name>
+              <surname>Ganguly</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Vadnala</surname>
+              <given-names>RN</given-names>
+            </name>
+            <name>
+              <surname>Sun</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Siddharthan</surname>
+              <given-names>R</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>Genome assembly of Malassezia slooffiae</data-title>
+          <source>NCBI BioSample</source>
+          <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/biosample/10720088">SAMN10720088</pub-id>
+        </element-citation>
+      </p>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-given-names/data-ref-given-names-test-1/pass.xml
+++ b/test/tests/gen/data-ref-given-names/data-ref-given-names-test-1/pass.xml
@@ -1,0 +1,56 @@
+<?oxygen SCHSchema="data-ref-given-names-test-1.sch"?>
+<!--Context: sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names
+Test: report    string-length(.) gt 4
+Message: Given names should always be initialised. Ref contains a given names with a string longer than 4 characters  '' in . Is this a surname captured as given names? Or a fully spelt out given names?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec id="s7" sec-type="data-availability">
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Sankaranarayanan</surname>
+              <given-names>SR</given-names>
+            </name>
+            <name>
+              <surname>Ianiri</surname>
+              <given-names>G</given-names>
+            </name>
+            <name>
+              <surname>Coelho</surname>
+              <given-names>MA</given-names>
+            </name>
+            <name>
+              <surname>Reza</surname>
+              <given-names>MH</given-names>
+            </name>
+            <name>
+              <surname>Thimmappa</surname>
+              <given-names>BC</given-names>
+            </name>
+            <name>
+              <surname>Ganguly</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Vadnala</surname>
+              <given-names>RN</given-names>
+            </name>
+            <name>
+              <surname>Sun</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Siddharthan</surname>
+              <given-names>R</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>Genome assembly of Malassezia slooffiae</data-title>
+          <source>NCBI BioSample</source>
+          <pub-id assigning-authority="NCBI" pub-id-type="accession" xlink:href="https://www.ncbi.nlm.nih.gov/biosample/10720088">SAMN10720088</pub-id>
+        </element-citation>
+      </p>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/ext-link-tests/ext-link-child-test-5/ext-link-child-test-5.sch
+++ b/test/tests/gen/ext-link-tests/ext-link-child-test-5/ext-link-child-test-5.sch
@@ -711,14 +711,18 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='journal']" id="journal-tests">
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+  <pattern id="content-containers">
+    <rule context="ext-link[@ext-link-type='uri']" id="ext-link-tests">
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="parent" value="parent::*[1]/local-name()"/>
+      <let name="form-children" value="string-join(         for $x in child::* return if ($x/local-name()=$formatting-elems) then $x/local-name()         else ()         ,', ')"/>
+      <let name="non-form-children" value="string-join(         for $x in child::* return if ($x/local-name()=$formatting-elems) then ()         else ($x/local-name())         ,', ')"/>
+      <report test="contains(@xlink:href,'datadryad.org/review?')" role="warning" id="ext-link-child-test-5">ext-link looks like it points to a review dryad dataset - <value-of select="."/>. Should it be updated?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']" role="error" id="journal-tests-xspec-assert">element-citation[@publication-type='journal'] must be present.</assert>
+      <assert test="descendant::ext-link[@ext-link-type='uri']" role="error" id="ext-link-tests-xspec-assert">ext-link[@ext-link-type='uri'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/ext-link-tests/ext-link-child-test-5/fail.xml
+++ b/test/tests/gen/ext-link-tests/ext-link-child-test-5/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="ext-link-child-test-5.sch"?>
+<!--Context: ext-link[@ext-link-type='uri']
+Test: report    contains(@xlink:href,'datadryad.org/review?')
+Message: extlink looks like it points to a review dryad dataset  . Should it be updated?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ext-link ext-link-type="uri" xlink:href="https://datadryad.org/review?doi=doi:10.5061/dryad.1t61c80">https://datadryad.org/review?doi=doi:10.5061/dryad.1t61c80</ext-link>
+  </article>
+</root>

--- a/test/tests/gen/ext-link-tests/ext-link-child-test-5/pass.xml
+++ b/test/tests/gen/ext-link-tests/ext-link-child-test-5/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="ext-link-child-test-5.sch"?>
+<!--Context: ext-link[@ext-link-type='uri']
+Test: report    contains(@xlink:href,'datadryad.org/review?')
+Message: extlink looks like it points to a review dryad dataset  . Should it be updated?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ext-link ext-link-type="uri" xlink:href="https://datadryad.org/doi:10.5061/dryad.1t61c80">https://datadryad.org/review?doi=doi:10.5061/dryad.1t61c80</ext-link>
+  </article>
+</root>

--- a/test/tests/gen/journal-tests/elife-ref-check/fail.xml
+++ b/test/tests/gen/journal-tests/elife-ref-check/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="elife-ref-check.sch"?>
 <!--Context: element-citation[@publication-type='journal']
-Test: report    (lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))
+Test: report    (lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))
 Message: ref '' is an  article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/journal-tests/elife-ref-check/pass.xml
+++ b/test/tests/gen/journal-tests/elife-ref-check/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="elife-ref-check.sch"?>
 <!--Context: element-citation[@publication-type='journal']
-Test: report    (lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))
+Test: report    (lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))
 Message: ref '' is an  article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/ref-given-names/ref-given-names-test-1/fail.xml
+++ b/test/tests/gen/ref-given-names/ref-given-names-test-1/fail.xml
@@ -1,0 +1,27 @@
+<?oxygen SCHSchema="ref-given-names-test-1.sch"?>
+<!--Context: ref-list//element-citation/person-group[@person-group-type='author']//given-names
+Test: report    string-length(.) gt 4
+Message: Given names should always be initialised. Ref '' contains a given names with a string longer than 4 characters  '' in . Is this a surname captured as given names? Or a fully spelt out given names?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref-list>
+      <ref id="bib1">
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>A</surname>
+              <given-names>Amend</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2014">2014</year>
+          <article-title>From dandruff to deep-sea vents: <italic>Malassezia</italic>-like fungi are ecologically hyper-diverse</article-title>
+          <source>PLOS Pathogens</source>
+          <volume>10</volume>
+          <elocation-id>e1004277</elocation-id>
+          <pub-id pub-id-type="doi">10.1371/journal.ppat.1004277</pub-id>
+          <pub-id pub-id-type="pmid">25144294</pub-id>
+        </element-citation>
+      </ref>
+    </ref-list>
+  </article>
+</root>

--- a/test/tests/gen/ref-given-names/ref-given-names-test-1/pass.xml
+++ b/test/tests/gen/ref-given-names/ref-given-names-test-1/pass.xml
@@ -1,0 +1,27 @@
+<?oxygen SCHSchema="ref-given-names-test-1.sch"?>
+<!--Context: ref-list//element-citation/person-group[@person-group-type='author']//given-names
+Test: report    string-length(.) gt 4
+Message: Given names should always be initialised. Ref '' contains a given names with a string longer than 4 characters  '' in . Is this a surname captured as given names? Or a fully spelt out given names?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref-list>
+      <ref id="bib1">
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Amend</surname>
+              <given-names>A</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2014">2014</year>
+          <article-title>From dandruff to deep-sea vents: <italic>Malassezia</italic>-like fungi are ecologically hyper-diverse</article-title>
+          <source>PLOS Pathogens</source>
+          <volume>10</volume>
+          <elocation-id>e1004277</elocation-id>
+          <pub-id pub-id-type="doi">10.1371/journal.ppat.1004277</pub-id>
+          <pub-id pub-id-type="pmid">25144294</pub-id>
+        </element-citation>
+      </ref>
+    </ref-list>
+  </article>
+</root>

--- a/test/tests/gen/ref-given-names/ref-given-names-test-1/ref-given-names-test-1.sch
+++ b/test/tests/gen/ref-given-names/ref-given-names-test-1/ref-given-names-test-1.sch
@@ -712,13 +712,13 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="house-style">
-    <rule context="element-citation[@publication-type='journal']" id="journal-tests">
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+    <rule context="ref-list//element-citation/person-group[@person-group-type='author']//given-names" id="ref-given-names">
+      <report test="string-length(.) gt 4" role="warning" id="ref-given-names-test-1">Given names should always be initialised. Ref '<value-of select="ancestor::ref[1]/@id"/>' contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']" role="error" id="journal-tests-xspec-assert">element-citation[@publication-type='journal'] must be present.</assert>
+      <assert test="descendant::ref-list//element-citation/person-group[@person-group-type='author']//given-names" role="error" id="ref-given-names-xspec-assert">ref-list//element-citation/person-group[@person-group-type='author']//given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/fail.xml
+++ b/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/fail.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="table-fn-label-test-1.sch"?>
+<!--Context: table-wrap-foot//fn/p/*[1]
+Test: report    not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)
+Message: Footnote starts with label which is not in line with house style  . Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <table-wrap-foot>
+      <fn>
+        <p><sup>1</sup> ‘BP’ indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
+      </fn>
+      <fn>
+        <p><sup>2</sup> ‘BP’ indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
+      </fn>
+    </table-wrap-foot>
+  </article>
+</root>

--- a/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/pass.xml
+++ b/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/pass.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="table-fn-label-test-1.sch"?>
+<!--Context: table-wrap-foot//fn/p/*[1]
+Test: report    not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)
+Message: Footnote starts with label which is not in line with house style  . Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <table-wrap-foot>
+      <fn>
+        <p><sup>*</sup> ‘BP’ indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
+      </fn>
+      <fn>
+        <p><sup>†</sup> ‘BP’ indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
+      </fn>
+    </table-wrap-foot>
+  </article>
+</root>

--- a/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/table-fn-label-test-1.sch
+++ b/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/table-fn-label-test-1.sch
@@ -711,14 +711,15 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='journal']" id="journal-tests">
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+  <pattern id="content-containers">
+    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests">
+      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']" role="error" id="journal-tests-xspec-assert">element-citation[@publication-type='journal'] must be present.</assert>
+      <assert test="descendant::table-wrap-foot//fn/p/*[1]" role="error" id="table-fn-label-tests-xspec-assert">table-wrap-foot//fn/p/*[1] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/xref-formatting/xref-child-test/xref-child-test.sch
+++ b/test/tests/gen/xref-formatting/xref-child-test/xref-child-test.sch
@@ -715,7 +715,7 @@
     <rule context="xref[not(@ref-type='bibr')]" id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       <report test="$child = $formatting-elems" role="warning" id="xref-child-test">xref - <value-of select="."/> - has a formatting child element - <value-of select="$child"/> - which is likely not correct.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/xref-formatting/xref-parent-test/xref-parent-test.sch
+++ b/test/tests/gen/xref-formatting/xref-parent-test/xref-parent-test.sch
@@ -715,7 +715,7 @@
     <rule context="xref[not(@ref-type='bibr')]" id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       <report test="$parent = $formatting-elems" role="error" id="xref-parent-test">xref - <value-of select="."/> - has a formatting parent element - <value-of select="$parent"/> - which is not correct.</report>
     </rule>
   </pattern>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1711,6 +1711,8 @@
       <report test="contains(.,'copy archived')" role="error" id="ext-link-child-test-3">ext-link - <value-of select="."/> - contains the phrase 'copy archived', which is incorrect.</report>
       
       <report test="matches(.,'^[Dd][Oo][Ii]:|^[Dd][Oo][Ii]\s')" role="warning" id="ext-link-child-test-4">ext-link text - <value-of select="."/> - appears to start with the string 'Doi:' or 'Doi ' (or similar), which is unncessary.</report>
+      
+      <report test="contains(@xlink:href,'datadryad.org/review?')" role="warning" id="ext-link-child-test-5">ext-link looks like it points to a review dryad dataset - <value-of select="."/>. Should it be updated?</report>
     </rule>
   </pattern>
   <pattern id="fig-group-tests-pattern">
@@ -2141,6 +2143,13 @@
       <assert test="self::*/local-name() = ($allowed-blocks,'bold')" role="error" id="th-child-test-1">th cannot contain <value-of select="self::*/local-name()"/>. Only the following elements are allowed - 'italic','sup','sub','sc','ext-link', 'break', 'named-content', 'monospace' and 'xref'.</assert>
       
       <report test="self::*/local-name() = 'bold'" role="warning" id="th-child-test-2">th contains bold. Is this correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="table-fn-label-tests-pattern">
+    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
+      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+      
+      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -5893,6 +5902,10 @@
       
       <report test="matches(.,'�')" role="error" id="city-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5997,7 +6010,7 @@
       
       <report test="matches(normalize-space(lower-case(source[1])),'^biorxiv$|^arxiv$|^chemrxiv$|^peerj preprints$|^psyarxiv$|^paleorxiv$|^preprints$')" role="error" id="journal-preprint-check">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="source[1]"/>, but it is captured as a journal not a preprint.</report>
       
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
       
       <report test="matches(lower-case(source[1]),'conference|symposium|symposia|neural information processing|nips|computer vision and pattern recognition|scipy|workshop|meeting|spie|congress|[\d]st|[\d]nd|[\d]rd|[\d]th')" role="warning" id="journal-conference-ref-check-1">Journal ref '<value-of select="ancestor::ref/@id"/>' has the journal title <value-of select="source[1]"/>. Should it be a conference type reference instead?</report>
       
@@ -6614,7 +6627,7 @@
     <rule context="xref[not(@ref-type='bibr')]" id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       
       <report test="$parent = $formatting-elems" role="error" id="xref-parent-test">xref - <value-of select="."/> - has a formatting parent element - <value-of select="$parent"/> - which is not correct.</report>
       
@@ -6651,6 +6664,26 @@
       <report test="not(matches(.,'RNA|[Cc]ryoEM|[34]D')) and (. != $lower) and not(contains($t,.))" role="warning" id="auth-kwd-check">Keyword - '<value-of select="."/>' - does not appear in the article text with this capitalisation. Should it be <value-of select="$lower"/> instead?</report>
       
       <report test="matches(.,'&amp;#x\d')" role="warning" id="auth-kwd-check-2">Keyword contains what looks like a broken unicode - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="ref-given-names-pattern">
+    <rule context="ref-list//element-citation/person-group[@person-group-type='author']//given-names" id="ref-given-names">
+      
+      <report test="string-length(.) gt 4" role="warning" id="ref-given-names-test-1">Given names should always be initialised. Ref '<value-of select="ancestor::ref[1]/@id"/>' contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+    </rule>
+  </pattern>
+  <pattern id="data-ref-given-names-pattern">
+    <rule context="sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" id="data-ref-given-names">      
+      
+      <report test="string-length(.) gt 4" role="warning" id="data-ref-given-names-test-1">Given names should always be initialised. Ref contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ar-fig-title-tests-pattern">
+    <rule context="fig[ancestor::sub-article]/caption/title" id="ar-fig-title-tests">     
+      
+      <report test="lower-case(normalize-space(.))=('title','title.')" role="warning" id="ar-fig-title-test-1">Please query author for a <value-of select="ancestor::fig/label"/> title, and/or remove placeholder title text - <value-of select="."/>.</report>
+      
     </rule>
   </pattern>
   
@@ -6818,6 +6851,7 @@
       <assert test="descendant::tr" role="error" id="tr-tests-xspec-assert">tr must be present.</assert>
       <assert test="descendant::td/*" role="error" id="td-child-tests-xspec-assert">td/* must be present.</assert>
       <assert test="descendant::th/*" role="error" id="th-child-tests-xspec-assert">th/* must be present.</assert>
+      <assert test="descendant::table-wrap-foot//fn/p/*[1]" role="error" id="table-fn-label-tests-xspec-assert">table-wrap-foot//fn/p/*[1] must be present.</assert>
       <assert test="descendant::fn[@id][not(@fn-type='other')]" role="error" id="fn-tests-xspec-assert">fn[@id][not(@fn-type='other')] must be present.</assert>
       <assert test="descendant::list-item" role="error" id="list-item-tests-xspec-assert">list-item must be present.</assert>
       <assert test="descendant::media[@mimetype='video'][matches(@id,'^video[0-9]{1,3}$')]" role="error" id="general-video-xspec-assert">media[@mimetype='video'][matches(@id,'^video[0-9]{1,3}$')] must be present.</assert>
@@ -7052,6 +7086,9 @@
       <assert test="descendant::xref[@ref-type='bibr']" role="error" id="ref-xref-formatting-xspec-assert">xref[@ref-type='bibr'] must be present.</assert>
       <assert test="descendant::article" role="error" id="code-fork-xspec-assert">article must be present.</assert>
       <assert test="descendant::kwd-group[@kwd-group-type='author-keywords']/kwd" role="error" id="auth-kwd-style-xspec-assert">kwd-group[@kwd-group-type='author-keywords']/kwd must be present.</assert>
+      <assert test="descendant::ref-list//element-citation/person-group[@person-group-type='author']//given-names" role="error" id="ref-given-names-xspec-assert">ref-list//element-citation/person-group[@person-group-type='author']//given-names must be present.</assert>
+      <assert test="descendant::sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" role="error" id="data-ref-given-names-xspec-assert">sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names must be present.</assert>
+      <assert test="descendant::fig[ancestor::sub-article]/caption/title" role="error" id="ar-fig-title-tests-xspec-assert">fig[ancestor::sub-article]/caption/title must be present.</assert>
       <assert test="descendant::element-citation[(@publication-type='journal') and not(pub-id[@pub-id-type='doi']) and year and source]" role="error" id="doi-journal-ref-checks-xspec-assert">element-citation[(@publication-type='journal') and not(pub-id[@pub-id-type='doi']) and year and source] must be present.</assert>
       <assert test="descendant::element-citation[(@publication-type='book') and not(pub-id[@pub-id-type='doi']) and year and publisher-name]" role="error" id="doi-book-ref-checks-xspec-assert">element-citation[(@publication-type='book') and not(pub-id[@pub-id-type='doi']) and year and publisher-name] must be present.</assert>
       <assert test="descendant::element-citation[(@publication-type='software') and year and source]" role="error" id="doi-software-ref-checks-xspec-assert">element-citation[(@publication-type='software') and year and source] must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -2727,6 +2727,16 @@
         <x:expect-report id="ext-link-child-test-4" role="warning"/>
         <x:expect-not-assert id="ext-link-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="ext-link-child-test-5-pass">
+        <x:context href="../tests/gen/ext-link-tests/ext-link-child-test-5/pass.xml"/>
+        <x:expect-not-report id="ext-link-child-test-5" role="warning"/>
+        <x:expect-not-assert id="ext-link-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="ext-link-child-test-5-fail">
+        <x:context href="../tests/gen/ext-link-tests/ext-link-child-test-5/fail.xml"/>
+        <x:expect-report id="ext-link-child-test-5" role="warning"/>
+        <x:expect-not-assert id="ext-link-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="fig-group-tests">
       <x:scenario label="fig-group-test-1-pass">
@@ -3832,6 +3842,18 @@
         <x:context href="../tests/gen/th-child-tests/th-child-test-2/fail.xml"/>
         <x:expect-report id="th-child-test-2" role="warning"/>
         <x:expect-not-assert id="th-child-tests-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="table-fn-label-tests">
+      <x:scenario label="table-fn-label-test-1-pass">
+        <x:context href="../tests/gen/table-fn-label-tests/table-fn-label-test-1/pass.xml"/>
+        <x:expect-not-report id="table-fn-label-test-1" role="warning"/>
+        <x:expect-not-assert id="table-fn-label-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="table-fn-label-test-1-fail">
+        <x:context href="../tests/gen/table-fn-label-tests/table-fn-label-test-1/fail.xml"/>
+        <x:expect-report id="table-fn-label-test-1" role="warning"/>
+        <x:expect-not-assert id="table-fn-label-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
     <x:scenario label="fn-tests">
@@ -12233,6 +12255,26 @@
         <x:expect-report id="city-replacement-character-presence" role="error"/>
         <x:expect-not-assert id="city-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="city-number-presence-pass">
+        <x:context href="../tests/gen/city-tests/city-number-presence/pass.xml"/>
+        <x:expect-not-report id="city-number-presence" role="warning"/>
+        <x:expect-not-assert id="city-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="city-number-presence-fail">
+        <x:context href="../tests/gen/city-tests/city-number-presence/fail.xml"/>
+        <x:expect-report id="city-number-presence" role="warning"/>
+        <x:expect-not-assert id="city-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="city-street-presence-pass">
+        <x:context href="../tests/gen/city-tests/city-street-presence/pass.xml"/>
+        <x:expect-not-report id="city-street-presence" role="warning"/>
+        <x:expect-not-assert id="city-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="city-street-presence-fail">
+        <x:context href="../tests/gen/city-tests/city-street-presence/fail.xml"/>
+        <x:expect-report id="city-street-presence" role="warning"/>
+        <x:expect-not-assert id="city-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="institution-tests">
       <x:scenario label="UC-no-test1-pass">
@@ -14722,6 +14764,42 @@
         <x:context href="../tests/gen/auth-kwd-style/auth-kwd-check-2/fail.xml"/>
         <x:expect-report id="auth-kwd-check-2" role="warning"/>
         <x:expect-not-assert id="auth-kwd-style-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="ref-given-names">
+      <x:scenario label="ref-given-names-test-1-pass">
+        <x:context href="../tests/gen/ref-given-names/ref-given-names-test-1/pass.xml"/>
+        <x:expect-not-report id="ref-given-names-test-1" role="warning"/>
+        <x:expect-not-assert id="ref-given-names-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="ref-given-names-test-1-fail">
+        <x:context href="../tests/gen/ref-given-names/ref-given-names-test-1/fail.xml"/>
+        <x:expect-report id="ref-given-names-test-1" role="warning"/>
+        <x:expect-not-assert id="ref-given-names-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="data-ref-given-names">
+      <x:scenario label="data-ref-given-names-test-1-pass">
+        <x:context href="../tests/gen/data-ref-given-names/data-ref-given-names-test-1/pass.xml"/>
+        <x:expect-not-report id="data-ref-given-names-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-given-names-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-ref-given-names-test-1-fail">
+        <x:context href="../tests/gen/data-ref-given-names/data-ref-given-names-test-1/fail.xml"/>
+        <x:expect-report id="data-ref-given-names-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-given-names-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="ar-fig-title-tests">
+      <x:scenario label="ar-fig-title-test-1-pass">
+        <x:context href="../tests/gen/ar-fig-title-tests/ar-fig-title-test-1/pass.xml"/>
+        <x:expect-not-report id="ar-fig-title-test-1" role="warning"/>
+        <x:expect-not-assert id="ar-fig-title-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="ar-fig-title-test-1-fail">
+        <x:context href="../tests/gen/ar-fig-title-tests/ar-fig-title-test-1/fail.xml"/>
+        <x:expect-report id="ar-fig-title-test-1" role="warning"/>
+        <x:expect-not-assert id="ar-fig-title-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
     <x:scenario label="doi-journal-ref-checks">

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -1711,6 +1711,8 @@
       <report test="contains(.,'copy archived')" role="error" id="ext-link-child-test-3">ext-link - <value-of select="."/> - contains the phrase 'copy archived', which is incorrect.</report>
       
       <report test="matches(.,'^[Dd][Oo][Ii]:|^[Dd][Oo][Ii]\s')" role="warning" id="ext-link-child-test-4">ext-link text - <value-of select="."/> - appears to start with the string 'Doi:' or 'Doi ' (or similar), which is unncessary.</report>
+      
+      <report test="contains(@xlink:href,'datadryad.org/review?')" role="warning" id="ext-link-child-test-5">ext-link looks like it points to a review dryad dataset - <value-of select="."/>. Should it be updated?</report>
     </rule>
   </pattern>
   <pattern id="fig-group-tests-pattern">
@@ -2135,6 +2137,13 @@
       <assert test="self::*/local-name() = ($allowed-blocks,'bold')" role="error" id="th-child-test-1">th cannot contain <value-of select="self::*/local-name()"/>. Only the following elements are allowed - 'italic','sup','sub','sc','ext-link', 'break', 'named-content', 'monospace' and 'xref'.</assert>
       
       <report test="self::*/local-name() = 'bold'" role="warning" id="th-child-test-2">th contains bold. Is this correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="table-fn-label-tests-pattern">
+    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
+      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+      
+      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -5890,6 +5899,10 @@
       
       <report test="matches(.,'�')" role="error" id="city-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5994,7 +6007,7 @@
       
       <report test="matches(normalize-space(lower-case(source[1])),'^biorxiv$|^arxiv$|^chemrxiv$|^peerj preprints$|^psyarxiv$|^paleorxiv$|^preprints$')" role="error" id="journal-preprint-check">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="source[1]"/>, but it is captured as a journal not a preprint.</report>
       
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
       
       <report test="matches(lower-case(source[1]),'conference|symposium|symposia|neural information processing|nips|computer vision and pattern recognition|scipy|workshop|meeting|spie|congress|[\d]st|[\d]nd|[\d]rd|[\d]th')" role="warning" id="journal-conference-ref-check-1">Journal ref '<value-of select="ancestor::ref/@id"/>' has the journal title <value-of select="source[1]"/>. Should it be a conference type reference instead?</report>
       
@@ -6594,7 +6607,7 @@
     <rule context="xref[not(@ref-type='bibr')]" id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       
       <report test="$parent = $formatting-elems" role="error" id="xref-parent-test">xref - <value-of select="."/> - has a formatting parent element - <value-of select="$parent"/> - which is not correct.</report>
       
@@ -6631,6 +6644,26 @@
       <report test="not(matches(.,'RNA|[Cc]ryoEM|[34]D')) and (. != $lower) and not(contains($t,.))" role="warning" id="auth-kwd-check">Keyword - '<value-of select="."/>' - does not appear in the article text with this capitalisation. Should it be <value-of select="$lower"/> instead?</report>
       
       <report test="matches(.,'&amp;#x\d')" role="warning" id="auth-kwd-check-2">Keyword contains what looks like a broken unicode - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="ref-given-names-pattern">
+    <rule context="ref-list//element-citation/person-group[@person-group-type='author']//given-names" id="ref-given-names">
+      
+      <report test="string-length(.) gt 4" role="warning" id="ref-given-names-test-1">Given names should always be initialised. Ref '<value-of select="ancestor::ref[1]/@id"/>' contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+    </rule>
+  </pattern>
+  <pattern id="data-ref-given-names-pattern">
+    <rule context="sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" id="data-ref-given-names">      
+      
+      <report test="string-length(.) gt 4" role="warning" id="data-ref-given-names-test-1">Given names should always be initialised. Ref contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ar-fig-title-tests-pattern">
+    <rule context="fig[ancestor::sub-article]/caption/title" id="ar-fig-title-tests">     
+      
+      <report test="lower-case(normalize-space(.))=('title','title.')" role="warning" id="ar-fig-title-test-1">Please query author for a <value-of select="ancestor::fig/label"/> title, and/or remove placeholder title text - <value-of select="."/>.</report>
+      
     </rule>
   </pattern>
   

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -1708,6 +1708,8 @@
       <report test="contains(.,'copy archived')" role="error" id="ext-link-child-test-3">ext-link - <value-of select="."/> - contains the phrase 'copy archived', which is incorrect.</report>
       
       <report test="matches(.,'^[Dd][Oo][Ii]:|^[Dd][Oo][Ii]\s')" role="warning" id="ext-link-child-test-4">ext-link text - <value-of select="."/> - appears to start with the string 'Doi:' or 'Doi ' (or similar), which is unncessary.</report>
+      
+      <report test="contains(@xlink:href,'datadryad.org/review?')" role="warning" id="ext-link-child-test-5">ext-link looks like it points to a review dryad dataset - <value-of select="."/>. Should it be updated?</report>
     </rule>
   </pattern>
   <pattern id="fig-group-tests-pattern">
@@ -2133,6 +2135,13 @@
       <assert test="self::*/local-name() = ($allowed-blocks,'bold')" role="error" id="th-child-test-1">th cannot contain <value-of select="self::*/local-name()"/>. Only the following elements are allowed - 'italic','sup','sub','sc','ext-link', 'break', 'named-content', 'monospace' and 'xref'.</assert>
       
       <report test="self::*/local-name() = 'bold'" role="warning" id="th-child-test-2">th contains bold. Is this correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="table-fn-label-tests-pattern">
+    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
+      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+      
+      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc.</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -5888,6 +5897,10 @@
       
       <report test="matches(.,'�')" role="error" id="city-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5992,7 +6005,7 @@
       
       <report test="matches(normalize-space(lower-case(source[1])),'^biorxiv$|^arxiv$|^chemrxiv$|^peerj preprints$|^psyarxiv$|^paleorxiv$|^preprints$')" role="error" id="journal-preprint-check">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="source[1]"/>, but it is captured as a journal not a preprint.</report>
       
-      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife.\d{5}$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
+      <report test="(lower-case(source[1]) = 'elife') and not(matches(pub-id[@pub-id-type='doi'][1],'^10.7554/eLife\.\d{5}$|^10.7554/eLife\.\d{5}\.\d{3}$|^10.7554/eLife\.\d{5}\.sa[12]$'))" role="error" id="elife-ref-check">ref '<value-of select="ancestor::ref/@id"/>' is an <value-of select="source[1]"/> article, but it has no doi in the format 10.7554/eLife.00000, which must be incorrect.</report>
       
       <report test="matches(lower-case(source[1]),'conference|symposium|symposia|neural information processing|nips|computer vision and pattern recognition|scipy|workshop|meeting|spie|congress|[\d]st|[\d]nd|[\d]rd|[\d]th')" role="warning" id="journal-conference-ref-check-1">Journal ref '<value-of select="ancestor::ref/@id"/>' has the journal title <value-of select="source[1]"/>. Should it be a conference type reference instead?</report>
       
@@ -6592,7 +6605,7 @@
     <rule context="xref[not(@ref-type='bibr')]" id="xref-formatting">
       <let name="parent" value="parent::*/local-name()"/>
       <let name="child" value="child::*/local-name()"/>
-      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby','sub','sup')"/>
+      <let name="formatting-elems" value="('bold','fixed-case','italic','monospace','overline','overline-start','overline-end','roman','sans-serif','sc','strike','underline','underline-start','underline-end','ruby')"/>
       
       <report test="$parent = $formatting-elems" role="error" id="xref-parent-test">xref - <value-of select="."/> - has a formatting parent element - <value-of select="$parent"/> - which is not correct.</report>
       
@@ -6629,6 +6642,26 @@
       <report test="not(matches(.,'RNA|[Cc]ryoEM|[34]D')) and (. != $lower) and not(contains($t,.))" role="warning" id="auth-kwd-check">Keyword - '<value-of select="."/>' - does not appear in the article text with this capitalisation. Should it be <value-of select="$lower"/> instead?</report>
       
       <report test="matches(.,'&amp;#x\d')" role="warning" id="auth-kwd-check-2">Keyword contains what looks like a broken unicode - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="ref-given-names-pattern">
+    <rule context="ref-list//element-citation/person-group[@person-group-type='author']//given-names" id="ref-given-names">
+      
+      <report test="string-length(.) gt 4" role="warning" id="ref-given-names-test-1">Given names should always be initialised. Ref '<value-of select="ancestor::ref[1]/@id"/>' contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+    </rule>
+  </pattern>
+  <pattern id="data-ref-given-names-pattern">
+    <rule context="sec[@sec-type='data-availability']//element-citation/person-group[@person-group-type='author']//given-names" id="data-ref-given-names">      
+      
+      <report test="string-length(.) gt 4" role="warning" id="data-ref-given-names-test-1">Given names should always be initialised. Ref contains a given names with a string longer than 4 characters - '<value-of select="."/>' in <value-of select="concat(preceding-sibling::surname[1],' ',.)"/>. Is this a surname captured as given names? Or a fully spelt out given names?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="ar-fig-title-tests-pattern">
+    <rule context="fig[ancestor::sub-article]/caption/title" id="ar-fig-title-tests">     
+      
+      <report test="lower-case(normalize-space(.))=('title','title.')" role="warning" id="ar-fig-title-test-1">Please query author for a <value-of select="ancestor::fig/label"/> title, and/or remove placeholder title text - <value-of select="."/>.</report>
+      
     </rule>
   </pattern>
   


### PR DESCRIPTION
- `ext-link-child-test-5` - check for dryad review links
- Table footnote labels in conformance with house style - `table-fn-label-test-1`
- City content tests - `city-street-presence` and `city-number-presence`
- Account for eLife sub-dois - `elife-ref-check`
- Tests for given-names string-length - `ref-given-names-test-1` and `data-ref-given-names`
- Check for AR image title placeholder text in context of new DL delivery workflow - `ar-fig-title-test-1`