### PR TITLE
feat: add more tests

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -2287,9 +2287,12 @@
   </pattern>
   <pattern id="disp-quote-tests-pattern">
     <rule context="disp-quote" id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       
       <report test="ancestor::sub-article[@article-type='decision-letter']" role="warning" id="disp-quote-test-1">Content is tagged as a display quote, which is almost definitely incorrect, since it's in a decision letter - <value-of select="."/>
       </report>
+      
+      <report test="not(ancestor::sub-article) and ($subj=$research-subj)" role="error" id="disp-quote-test-2">Display quote in a <value-of select="$subj"/> is not allowed. Please capture as paragraph instead - '<value-of select="."/>'</report>
     </rule>
   </pattern>
   
@@ -5079,7 +5082,7 @@
   </pattern>
   
   <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
+    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
       <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
       
@@ -5933,7 +5936,7 @@
       
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
-      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5944,6 +5947,8 @@
       
       <report test="matches(.,'�')" role="error" id="institution-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="institution-street-presence">institution likely contains a street or building name, which is likely to be incorrect - <value-of select="."/>.</report>
       
     </rule>
   </pattern>
@@ -6612,6 +6617,26 @@
       <report test="matches(@xlink:href,'^http[s]?://www.ncbi.nlm.nih.gov/pmc/articles/PMC[\d]*')" role="warning" id="pmc-presence">
         <value-of select="parent::*/local-name()"/> element contains what looks like a link to a PMC article - <value-of select="."/> - should this be added a reference instead?</report>
       
+    </rule>
+  </pattern>
+  <pattern id="pubmed-link-2-pattern">
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="warning" id="final-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+    </rule>
+  </pattern>
+  <pattern id="rrid-link-pattern">
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="warning" id="final-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="ref-link-mandate-pattern">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -2293,9 +2293,12 @@
   </pattern>
   <pattern id="disp-quote-tests-pattern">
     <rule context="disp-quote" id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       
       <report test="ancestor::sub-article[@article-type='decision-letter']" role="warning" id="disp-quote-test-1">Content is tagged as a display quote, which is almost definitely incorrect, since it's in a decision letter - <value-of select="."/>
       </report>
+      
+      <report test="not(ancestor::sub-article) and ($subj=$research-subj)" role="error" id="disp-quote-test-2">Display quote in a <value-of select="$subj"/> is not allowed. Please capture as paragraph instead - '<value-of select="."/>'</report>
     </rule>
   </pattern>
   
@@ -5085,7 +5088,7 @@
   </pattern>
   
   <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
+    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
       <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
       
@@ -5939,7 +5942,7 @@
       
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
-      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5950,6 +5953,8 @@
       
       <report test="matches(.,'�')" role="error" id="institution-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="institution-street-presence">institution likely contains a street or building name, which is likely to be incorrect - <value-of select="."/>.</report>
       
     </rule>
   </pattern>
@@ -6618,6 +6623,26 @@
       <report test="matches(@xlink:href,'^http[s]?://www.ncbi.nlm.nih.gov/pmc/articles/PMC[\d]*')" role="warning" id="pmc-presence">
         <value-of select="parent::*/local-name()"/> element contains what looks like a link to a PMC article - <value-of select="."/> - should this be added a reference instead?</report>
       
+    </rule>
+  </pattern>
+  <pattern id="pubmed-link-2-pattern">
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="warning" id="final-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+    </rule>
+  </pattern>
+  <pattern id="rrid-link-pattern">
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="warning" id="final-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="ref-link-mandate-pattern">

--- a/src/journals.xml
+++ b/src/journals.xml
@@ -28,6 +28,7 @@
   <journal title="journal of experimental biology" year="2001"/>
   <journal title="journal of immunology" year="2000"/>
   <journal title="journal of lipid research" year="2001"/>
+  <journal title="journal of machine learning research" year="9999"/>
   <journal title="journal of neurophysiology" year="2002"/>
   <journal title="journal of neuroscience" year="2004"/>
   <journal title="journal of pharmacology and experimental therapeutics" year="2002"/>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -2285,9 +2285,12 @@
   </pattern>
   <pattern id="disp-quote-tests-pattern">
     <rule context="disp-quote" id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       
       <report test="ancestor::sub-article[@article-type='decision-letter']" role="warning" id="disp-quote-test-1">Content is tagged as a display quote, which is almost definitely incorrect, since it's in a decision letter - <value-of select="."/>
       </report>
+      
+      <report test="not(ancestor::sub-article) and ($subj=$research-subj)" role="error" id="disp-quote-test-2">Display quote in a <value-of select="$subj"/> is not allowed. Please capture as paragraph instead - '<value-of select="."/>'</report>
     </rule>
   </pattern>
   
@@ -5077,7 +5080,7 @@
   </pattern>
   
   <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
+    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
       <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
       
@@ -5931,7 +5934,7 @@
       
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
-      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5942,6 +5945,8 @@
       
       <report test="matches(.,'�')" role="error" id="institution-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="institution-street-presence">institution likely contains a street or building name, which is likely to be incorrect - <value-of select="."/>.</report>
       
     </rule>
   </pattern>
@@ -6609,6 +6614,26 @@
       
       <report test="matches(@xlink:href,'^http[s]?://www.ncbi.nlm.nih.gov/pmc/articles/PMC[\d]*')" role="warning" id="pmc-presence">
         <value-of select="parent::*/local-name()"/> element contains what looks like a link to a PMC article - <value-of select="."/> - should this be added a reference instead?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="pubmed-link-2-pattern">
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="error" id="pre-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+      
+      
+    </rule>
+  </pattern>
+  <pattern id="rrid-link-pattern">
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="error" id="pre-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+      
       
     </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -3075,10 +3075,15 @@
     
     <rule context="disp-quote"
       id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       
       <report test="ancestor::sub-article[@article-type='decision-letter']"
         role="warning"
         id="disp-quote-test-1">Content is tagged as a display quote, which is almost definitely incorrect, since it's in a decision letter - <value-of select="."/></report>
+      
+      <report test="not(ancestor::sub-article) and ($subj=$research-subj)"
+        role="error"
+        id="disp-quote-test-2">Display quote in a <value-of select="$subj"/> is not allowed. Please capture as paragraph instead - '<value-of select="."/>'</report>
     </rule>
     
   </pattern>
@@ -6686,7 +6691,7 @@
   
   <pattern id="missing-ref-cited-pattern">
     
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]"
+    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]"
       id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())
         return if ($x/local-name()='xref') then ()
@@ -7953,7 +7958,7 @@
         role="warning"
         id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
-      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')"
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')"
         role="warning"
         id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
@@ -7968,6 +7973,10 @@
       <report test="matches(.,'�')"
         role="error"
         id="institution-replacement-character-presence"><name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')"
+        role="warning"
+        id="institution-street-presence">institution likely contains a street or building name, which is likely to be incorrect - <value-of select="."/>.</report>
       
     </rule>
     
@@ -9036,6 +9045,34 @@
         role="warning" 
         id="pmc-presence"><value-of select="parent::*/local-name()"/> element contains what looks like a link to a PMC article - <value-of select="."/> - should this be added a reference instead?</report>
       
+    </rule>
+    
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" 
+      id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')"
+        role="error" 
+        id="pre-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')"
+        role="warning" 
+        id="final-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+    </rule>
+    
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" 
+      id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')"
+        role="error" 
+        id="pre-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')"
+        role="warning" 
+        id="final-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
     </rule>
     
     <rule context="ref-list/ref" 

--- a/test/tests/gen/city-tests/city-street-presence/city-street-presence.sch
+++ b/test/tests/gen/city-tests/city-street-presence/city-street-presence.sch
@@ -726,7 +726,7 @@
     <rule context="front//aff//named-content[@content-type='city']" id="city-tests">
       <let name="lc" value="normalize-space(lower-case(.))"/>
       <let name="states-regex" value="'^alabama$|^al$|^alaska$|^ak$|^arizona$|^az$|^arkansas$|^ar$|^california$|^ca$|^colorado$|^co$|^connecticut$|^ct$|^delaware$|^de$|^florida$|^fl$|^georgia$|^ga$|^hawaii$|^hi$|^idaho$|^id$|^illinois$|^il$|^indiana$|^in$|^iowa$|^ia$|^kansas$|^ks$|^kentucky$|^ky$|^louisiana$|^la$|^maine$|^me$|^maryland$|^md$|^massachusetts$|^ma$|^michigan$|^mi$|^minnesota$|^mn$|^mississippi$|^ms$|^missouri$|^mo$|^montana$|^mt$|^nebraska$|^ne$|^nevada$|^nv$|^new hampshire$|^nh$|^new jersey$|^nj$|^new mexico$|^nm$|^ny$|^north carolina$|^nc$|^north dakota$|^nd$|^ohio$|^oh$|^oklahoma$|^ok$|^oregon$|^or$|^pennsylvania$|^pa$|^rhode island$|^ri$|^south carolina$|^sc$|^south dakota$|^sd$|^tennessee$|^tn$|^texas$|^tx$|^utah$|^ut$|^vermont$|^vt$|^virginia$|^va$|^wa$|^west virginia$|^wv$|^wisconsin$|^wi$|^wyoming$|^wy$'"/>
-      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/city-tests/city-street-presence/pass.xml
+++ b/test/tests/gen/city-tests/city-street-presence/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="city-street-presence.sch"?>
 <!--Context: front//aff//named-content[@content-type='city']
-Test: report    matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')
+Test: report    matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')
 Message: city likely contains a street or building name, which is almost certainly incorrect  .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/disp-quote-tests/disp-quote-test-1/disp-quote-test-1.sch
+++ b/test/tests/gen/disp-quote-tests/disp-quote-test-1/disp-quote-test-1.sch
@@ -724,6 +724,7 @@
   </xsl:function>
   <pattern id="content-containers">
     <rule context="disp-quote" id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <report test="ancestor::sub-article[@article-type='decision-letter']" role="warning" id="disp-quote-test-1">Content is tagged as a display quote, which is almost definitely incorrect, since it's in a decision letter - <value-of select="."/>
       </report>
     </rule>

--- a/test/tests/gen/disp-quote-tests/disp-quote-test-2/disp-quote-test-2.sch
+++ b/test/tests/gen/disp-quote-tests/disp-quote-test-2/disp-quote-test-2.sch
@@ -722,18 +722,15 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
-      <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
-      <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
-      <report test="matches($text,$missing-ref-regex)" role="warning" id="missing-ref-in-text-test">
-        <name/> element contains possible citation which is unlinked or a missing reference - search - <value-of select="concat(           tokenize(substring-before($text,' et al'),' ')[last()],           ' et al ',           tokenize(substring-after($text,' et al'),' ')[2]           )"/>
-      </report>
+  <pattern id="content-containers">
+    <rule context="disp-quote" id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
+      <report test="not(ancestor::sub-article) and ($subj=$research-subj)" role="error" id="disp-quote-test-2">Display quote in a <value-of select="$subj"/> is not allowed. Please capture as paragraph instead - '<value-of select="."/>'</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)] or descendant::td[ancestor::app or ancestor::body[parent::article]] or descendant::th[ancestor::app or ancestor::body[parent::article]]" role="error" id="missing-ref-cited-xspec-assert">p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]] must be present.</assert>
+      <assert test="descendant::disp-quote" role="error" id="disp-quote-tests-xspec-assert">disp-quote must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/disp-quote-tests/disp-quote-test-2/fail.xml
+++ b/test/tests/gen/disp-quote-tests/disp-quote-test-2/fail.xml
@@ -1,0 +1,24 @@
+<?oxygen SCHSchema="disp-quote-test-2.sch"?>
+<!--Context: disp-quote
+Test: report    not(ancestor::sub-article) and ($subj=$research-subj)
+Message: Display quote in a  is not allowed. Please capture as paragraph instead  ''-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <article-meta>
+        <article-categories>
+          <subj-group subj-group-type="display-channel">
+            <subject>Research Article</subject>
+          </subj-group>
+          <subj-group subj-group-type="heading">
+            <subject>Neuroscience</subject>
+          </subj-group>
+        </article-categories>
+      </article-meta>
+    </front>
+    <disp-quote/>
+    <sub-article>
+      <disp-quote/>
+    </sub-article>
+  </article>
+</root>

--- a/test/tests/gen/disp-quote-tests/disp-quote-test-2/pass.xml
+++ b/test/tests/gen/disp-quote-tests/disp-quote-test-2/pass.xml
@@ -1,0 +1,21 @@
+<?oxygen SCHSchema="disp-quote-test-2.sch"?>
+<!--Context: disp-quote
+Test: report    not(ancestor::sub-article) and ($subj=$research-subj)
+Message: Display quote in a  is not allowed. Please capture as paragraph instead  ''-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <article-meta>
+        <article-categories>
+          <subj-group subj-group-type="display-channel">
+            <subject>Feature Article</subject>
+          </subj-group>
+          <subj-group subj-group-type="heading">
+            <subject>Neuroscience</subject>
+          </subj-group>
+        </article-categories>
+      </article-meta>
+    </front>
+    <disp-quote/>
+  </article>
+</root>

--- a/test/tests/gen/institution-tests/institution-street-presence/fail.xml
+++ b/test/tests/gen/institution-tests/institution-street-presence/fail.xml
@@ -1,13 +1,11 @@
-<?oxygen SCHSchema="city-street-presence.sch"?>
-<!--Context: front//aff//named-content[@content-type='city']
+<?oxygen SCHSchema="institution-street-presence.sch"?>
+<!--Context: aff/institution[not(@*)]
 Test: report    matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')
-Message: city likely contains a street or building name, which is almost certainly incorrect  .-->
+Message: institution likely contains a street or building name, which is likely to be incorrect  .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <front>
-      <aff>
-        <named-content content-type="city">Rue xml Bengaluru</named-content>
-      </aff>
-    </front>
+    <aff>
+      <institution>14 rue de mer</institution>
+    </aff>
   </article>
 </root>

--- a/test/tests/gen/institution-tests/institution-street-presence/institution-street-presence.sch
+++ b/test/tests/gen/institution-tests/institution-street-presence/institution-street-presence.sch
@@ -722,18 +722,14 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
-      <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
-      <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
-      <report test="matches($text,$missing-ref-regex)" role="warning" id="missing-ref-in-text-test">
-        <name/> element contains possible citation which is unlinked or a missing reference - search - <value-of select="concat(           tokenize(substring-before($text,' et al'),' ')[last()],           ' et al ',           tokenize(substring-after($text,' et al'),' ')[2]           )"/>
-      </report>
+  <pattern id="house-style">
+    <rule context="aff/institution[not(@*)]" id="institution-tests">
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="institution-street-presence">institution likely contains a street or building name, which is likely to be incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)] or descendant::td[ancestor::app or ancestor::body[parent::article]] or descendant::th[ancestor::app or ancestor::body[parent::article]]" role="error" id="missing-ref-cited-xspec-assert">p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]] must be present.</assert>
+      <assert test="descendant::aff/institution[not(@*)]" role="error" id="institution-tests-xspec-assert">aff/institution[not(@*)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/institution-tests/institution-street-presence/pass.xml
+++ b/test/tests/gen/institution-tests/institution-street-presence/pass.xml
@@ -1,13 +1,11 @@
-<?oxygen SCHSchema="city-street-presence.sch"?>
-<!--Context: front//aff//named-content[@content-type='city']
+<?oxygen SCHSchema="institution-street-presence.sch"?>
+<!--Context: aff/institution[not(@*)]
 Test: report    matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')
-Message: city likely contains a street or building name, which is almost certainly incorrect  .-->
+Message: institution likely contains a street or building name, which is likely to be incorrect  .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <front>
-      <aff>
-        <named-content content-type="city">Rue xml Bengaluru</named-content>
-      </aff>
-    </front>
+    <aff>
+      <institution/>
+    </aff>
   </article>
 </root>

--- a/test/tests/gen/missing-ref-cited/missing-ref-in-text-test/fail.xml
+++ b/test/tests/gen/missing-ref-cited/missing-ref-in-text-test/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="missing-ref-in-text-test.sch"?>
-<!--Context: p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]
+<!--Context: p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]
 Test: report    matches($text,$missing-ref-regex)
 Message:  element contains possible citation which is unlinked or a missing reference  search  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/missing-ref-cited/missing-ref-in-text-test/pass.xml
+++ b/test/tests/gen/missing-ref-cited/missing-ref-in-text-test/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="missing-ref-in-text-test.sch"?>
-<!--Context: p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]
+<!--Context: p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]
 Test: report    matches($text,$missing-ref-regex)
 Message:  element contains possible citation which is unlinked or a missing reference  search  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/pubmed-link-2/final-pmid-spacing-table/fail.xml
+++ b/test/tests/gen/pubmed-link-2/final-pmid-spacing-table/fail.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="final-pmid-spacing-table.sch"?>
+<!--Context: table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]
+Test: report    ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')
+Message: PMID link should be preceding by 'PMID:' with no space but instead it is preceded by ''.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <table-wrap>
+      <td>PMID: <ext-link ext-link-type="uri" xlink:href="https://www.ncbi.nlm.nih.gov/pubmed/27991487">27991487</ext-link>
+      </td>
+    </table-wrap>
+  </article>
+</root>

--- a/test/tests/gen/pubmed-link-2/final-pmid-spacing-table/final-pmid-spacing-table.sch
+++ b/test/tests/gen/pubmed-link-2/final-pmid-spacing-table/final-pmid-spacing-table.sch
@@ -722,18 +722,16 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
-      <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
-      <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
-      <report test="matches($text,$missing-ref-regex)" role="warning" id="missing-ref-in-text-test">
-        <name/> element contains possible citation which is unlinked or a missing reference - search - <value-of select="concat(           tokenize(substring-before($text,' et al'),' ')[last()],           ' et al ',           tokenize(substring-after($text,' et al'),' ')[2]           )"/>
-      </report>
+  <pattern id="house-style">
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="warning" id="final-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)] or descendant::td[ancestor::app or ancestor::body[parent::article]] or descendant::th[ancestor::app or ancestor::body[parent::article]]" role="error" id="missing-ref-cited-xspec-assert">p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]] must be present.</assert>
+      <assert test="descendant::table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" role="error" id="pubmed-link-2-xspec-assert">table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/pubmed-link-2/final-pmid-spacing-table/pass.xml
+++ b/test/tests/gen/pubmed-link-2/final-pmid-spacing-table/pass.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="final-pmid-spacing-table.sch"?>
+<!--Context: table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]
+Test: report    ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')
+Message: PMID link should be preceding by 'PMID:' with no space but instead it is preceded by ''.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <table-wrap>
+      <td>PMID:<ext-link ext-link-type="uri" xlink:href="https://www.ncbi.nlm.nih.gov/pubmed/27991487">27991487</ext-link>
+      </td>
+    </table-wrap>
+  </article>
+</root>

--- a/test/tests/gen/pubmed-link-2/pre-pmid-spacing-table/fail.xml
+++ b/test/tests/gen/pubmed-link-2/pre-pmid-spacing-table/fail.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="pre-pmid-spacing-table.sch"?>
+<!--Context: table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]
+Test: report    ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')
+Message: PMID link should be preceding by 'PMID:' with no space but instead it is preceded by ''.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <table-wrap>
+      <td>PMID: <ext-link ext-link-type="uri" xlink:href="https://www.ncbi.nlm.nih.gov/pubmed/27991487">27991487</ext-link>
+      </td>
+    </table-wrap>
+  </article>
+</root>

--- a/test/tests/gen/pubmed-link-2/pre-pmid-spacing-table/pass.xml
+++ b/test/tests/gen/pubmed-link-2/pre-pmid-spacing-table/pass.xml
@@ -1,0 +1,12 @@
+<?oxygen SCHSchema="pre-pmid-spacing-table.sch"?>
+<!--Context: table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]
+Test: report    ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')
+Message: PMID link should be preceding by 'PMID:' with no space but instead it is preceded by ''.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <table-wrap>
+      <td>PMID:<ext-link ext-link-type="uri" xlink:href="https://www.ncbi.nlm.nih.gov/pubmed/27991487">27991487</ext-link>
+      </td>
+    </table-wrap>
+  </article>
+</root>

--- a/test/tests/gen/pubmed-link-2/pre-pmid-spacing-table/pre-pmid-spacing-table.sch
+++ b/test/tests/gen/pubmed-link-2/pre-pmid-spacing-table/pre-pmid-spacing-table.sch
@@ -722,18 +722,16 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
-      <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
-      <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
-      <report test="matches($text,$missing-ref-regex)" role="warning" id="missing-ref-in-text-test">
-        <name/> element contains possible citation which is unlinked or a missing reference - search - <value-of select="concat(           tokenize(substring-before($text,' et al'),' ')[last()],           ' et al ',           tokenize(substring-after($text,' et al'),' ')[2]           )"/>
-      </report>
+  <pattern id="house-style">
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="error" id="pre-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)] or descendant::td[ancestor::app or ancestor::body[parent::article]] or descendant::th[ancestor::app or ancestor::body[parent::article]]" role="error" id="missing-ref-cited-xspec-assert">p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]] must be present.</assert>
+      <assert test="descendant::table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" role="error" id="pubmed-link-2-xspec-assert">table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/rrid-link/final-rrid-spacing/fail.xml
+++ b/test/tests/gen/rrid-link/final-rrid-spacing/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="final-rrid-spacing.sch"?>
+<!--Context: ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]
+Test: report    ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')
+Message: RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by ''.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <td valign="top">RRID: <ext-link ext-link-type="uri" xlink:href="https://scicrunch.org/resolver/IMSR_JAX:006410">IMSR_JAX:006410</ext-link></td>
+  </article>
+</root>

--- a/test/tests/gen/rrid-link/final-rrid-spacing/final-rrid-spacing.sch
+++ b/test/tests/gen/rrid-link/final-rrid-spacing/final-rrid-spacing.sch
@@ -722,18 +722,16 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
-      <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
-      <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
-      <report test="matches($text,$missing-ref-regex)" role="warning" id="missing-ref-in-text-test">
-        <name/> element contains possible citation which is unlinked or a missing reference - search - <value-of select="concat(           tokenize(substring-before($text,' et al'),' ')[last()],           ' et al ',           tokenize(substring-after($text,' et al'),' ')[2]           )"/>
-      </report>
+  <pattern id="house-style">
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="warning" id="final-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)] or descendant::td[ancestor::app or ancestor::body[parent::article]] or descendant::th[ancestor::app or ancestor::body[parent::article]]" role="error" id="missing-ref-cited-xspec-assert">p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]] must be present.</assert>
+      <assert test="descendant::ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" role="error" id="rrid-link-xspec-assert">ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/rrid-link/final-rrid-spacing/pass.xml
+++ b/test/tests/gen/rrid-link/final-rrid-spacing/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="final-rrid-spacing.sch"?>
+<!--Context: ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]
+Test: report    ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')
+Message: RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by ''.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <td valign="top">RRID:<ext-link ext-link-type="uri" xlink:href="https://scicrunch.org/resolver/IMSR_JAX:006410">IMSR_JAX:006410</ext-link></td>
+  </article>
+</root>

--- a/test/tests/gen/rrid-link/pre-rrid-spacing/fail.xml
+++ b/test/tests/gen/rrid-link/pre-rrid-spacing/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="pre-rrid-spacing.sch"?>
+<!--Context: ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]
+Test: report    ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')
+Message: RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by ''.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <td valign="top">RRID: <ext-link ext-link-type="uri" xlink:href="https://scicrunch.org/resolver/IMSR_JAX:006410">IMSR_JAX:006410</ext-link></td>
+  </article>
+</root>

--- a/test/tests/gen/rrid-link/pre-rrid-spacing/pass.xml
+++ b/test/tests/gen/rrid-link/pre-rrid-spacing/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="pre-rrid-spacing.sch"?>
+<!--Context: ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]
+Test: report    ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')
+Message: RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by ''.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <td valign="top">RRID:<ext-link ext-link-type="uri" xlink:href="https://scicrunch.org/resolver/IMSR_JAX:006410">IMSR_JAX:006410</ext-link></td>
+  </article>
+</root>

--- a/test/tests/gen/rrid-link/pre-rrid-spacing/pre-rrid-spacing.sch
+++ b/test/tests/gen/rrid-link/pre-rrid-spacing/pre-rrid-spacing.sch
@@ -722,18 +722,16 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
-      <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
-      <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
-      <report test="matches($text,$missing-ref-regex)" role="warning" id="missing-ref-in-text-test">
-        <name/> element contains possible citation which is unlinked or a missing reference - search - <value-of select="concat(           tokenize(substring-before($text,' et al'),' ')[last()],           ' et al ',           tokenize(substring-after($text,' et al'),' ')[2]           )"/>
-      </report>
+  <pattern id="house-style">
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="error" id="pre-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)] or descendant::td[ancestor::app or ancestor::body[parent::article]] or descendant::th[ancestor::app or ancestor::body[parent::article]]" role="error" id="missing-ref-cited-xspec-assert">p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]] must be present.</assert>
+      <assert test="descendant::ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" role="error" id="rrid-link-xspec-assert">ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/xspec/journals.xml
+++ b/test/xspec/journals.xml
@@ -28,6 +28,7 @@
   <journal title="journal of experimental biology" year="2001"/>
   <journal title="journal of immunology" year="2000"/>
   <journal title="journal of lipid research" year="2001"/>
+  <journal title="journal of machine learning research" year="9999"/>
   <journal title="journal of neurophysiology" year="2002"/>
   <journal title="journal of neuroscience" year="2004"/>
   <journal title="journal of pharmacology and experimental therapeutics" year="2002"/>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -2293,9 +2293,12 @@
   </pattern>
   <pattern id="disp-quote-tests-pattern">
     <rule context="disp-quote" id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       
       <report test="ancestor::sub-article[@article-type='decision-letter']" role="warning" id="disp-quote-test-1">Content is tagged as a display quote, which is almost definitely incorrect, since it's in a decision letter - <value-of select="."/>
       </report>
+      
+      <report test="not(ancestor::sub-article) and ($subj=$research-subj)" role="error" id="disp-quote-test-2">Display quote in a <value-of select="$subj"/> is not allowed. Please capture as paragraph instead - '<value-of select="."/>'</report>
     </rule>
   </pattern>
   
@@ -5936,7 +5939,7 @@
       
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
-      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5947,6 +5950,8 @@
       
       <report test="matches(.,'�')" role="error" id="institution-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="institution-street-presence">institution likely contains a street or building name, which is likely to be incorrect - <value-of select="."/>.</report>
       
     </rule>
   </pattern>
@@ -6634,6 +6639,26 @@
       
     </rule>
   </pattern>
+  <pattern id="pubmed-link-2-pattern">
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="error" id="pre-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="warning" id="final-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+    </rule>
+  </pattern>
+  <pattern id="rrid-link-pattern">
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="error" id="pre-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="warning" id="final-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+    </rule>
+  </pattern>
   <pattern id="ref-link-mandate-pattern">
     <rule context="ref-list/ref" id="ref-link-mandate">
       <let name="id" value="@id"/>
@@ -7121,6 +7146,8 @@
       <assert test="descendant::article/body//p[not(parent::list-item)]" role="error" id="p-punctuation-xspec-assert">article/body//p[not(parent::list-item)] must be present.</assert>
       <assert test="descendant::italic[not(ancestor::ref)]" role="error" id="italic-house-style-xspec-assert">italic[not(ancestor::ref)] must be present.</assert>
       <assert test="descendant::p//ext-link[not(ancestor::table-wrap) and not(ancestor::sub-article)]" role="error" id="pubmed-link-xspec-assert">p//ext-link[not(ancestor::table-wrap) and not(ancestor::sub-article)] must be present.</assert>
+      <assert test="descendant::table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" role="error" id="pubmed-link-2-xspec-assert">table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)] must be present.</assert>
+      <assert test="descendant::ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" role="error" id="rrid-link-xspec-assert">ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)] must be present.</assert>
       <assert test="descendant::ref-list/ref" role="error" id="ref-link-mandate-xspec-assert">ref-list/ref must be present.</assert>
       <assert test="descendant::fig or descendant::media[@mimetype='video']" role="error" id="fig-permissions-check-xspec-assert">fig|media[@mimetype='video'] must be present.</assert>
       <assert test="descendant::xref[not(@ref-type='bibr')]" role="error" id="xref-formatting-xspec-assert">xref[not(@ref-type='bibr')] must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -4165,6 +4165,16 @@
         <x:expect-report id="disp-quote-test-1" role="warning"/>
         <x:expect-not-assert id="disp-quote-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="disp-quote-test-2-pass">
+        <x:context href="../tests/gen/disp-quote-tests/disp-quote-test-2/pass.xml"/>
+        <x:expect-not-report id="disp-quote-test-2" role="error"/>
+        <x:expect-not-assert id="disp-quote-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="disp-quote-test-2-fail">
+        <x:context href="../tests/gen/disp-quote-tests/disp-quote-test-2/fail.xml"/>
+        <x:expect-report id="disp-quote-test-2" role="error"/>
+        <x:expect-not-assert id="disp-quote-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="body-video-specific">
       <x:scenario label="pre-body-video-position-test-1-pass">
@@ -12351,6 +12361,16 @@
         <x:expect-report id="institution-replacement-character-presence" role="error"/>
         <x:expect-not-assert id="institution-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="institution-street-presence-pass">
+        <x:context href="../tests/gen/institution-tests/institution-street-presence/pass.xml"/>
+        <x:expect-not-report id="institution-street-presence" role="warning"/>
+        <x:expect-not-assert id="institution-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="institution-street-presence-fail">
+        <x:context href="../tests/gen/institution-tests/institution-street-presence/fail.xml"/>
+        <x:expect-report id="institution-street-presence" role="warning"/>
+        <x:expect-not-assert id="institution-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="department-tests">
       <x:scenario label="plural-test-1-pass">
@@ -14676,6 +14696,50 @@
         <x:context href="../tests/gen/pubmed-link/pmc-presence/fail.xml"/>
         <x:expect-report id="pmc-presence" role="warning"/>
         <x:expect-not-assert id="pubmed-link-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="pubmed-link-2">
+      <x:scenario label="pre-pmid-spacing-table-pass">
+        <x:context href="../tests/gen/pubmed-link-2/pre-pmid-spacing-table/pass.xml"/>
+        <x:expect-not-report id="pre-pmid-spacing-table" role="error"/>
+        <x:expect-not-assert id="pubmed-link-2-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="pre-pmid-spacing-table-fail">
+        <x:context href="../tests/gen/pubmed-link-2/pre-pmid-spacing-table/fail.xml"/>
+        <x:expect-report id="pre-pmid-spacing-table" role="error"/>
+        <x:expect-not-assert id="pubmed-link-2-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-pmid-spacing-table-pass">
+        <x:context href="../tests/gen/pubmed-link-2/final-pmid-spacing-table/pass.xml"/>
+        <x:expect-not-report id="final-pmid-spacing-table" role="warning"/>
+        <x:expect-not-assert id="pubmed-link-2-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-pmid-spacing-table-fail">
+        <x:context href="../tests/gen/pubmed-link-2/final-pmid-spacing-table/fail.xml"/>
+        <x:expect-report id="final-pmid-spacing-table" role="warning"/>
+        <x:expect-not-assert id="pubmed-link-2-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="rrid-link">
+      <x:scenario label="pre-rrid-spacing-pass">
+        <x:context href="../tests/gen/rrid-link/pre-rrid-spacing/pass.xml"/>
+        <x:expect-not-report id="pre-rrid-spacing" role="error"/>
+        <x:expect-not-assert id="rrid-link-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="pre-rrid-spacing-fail">
+        <x:context href="../tests/gen/rrid-link/pre-rrid-spacing/fail.xml"/>
+        <x:expect-report id="pre-rrid-spacing" role="error"/>
+        <x:expect-not-assert id="rrid-link-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-rrid-spacing-pass">
+        <x:context href="../tests/gen/rrid-link/final-rrid-spacing/pass.xml"/>
+        <x:expect-not-report id="final-rrid-spacing" role="warning"/>
+        <x:expect-not-assert id="rrid-link-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-rrid-spacing-fail">
+        <x:context href="../tests/gen/rrid-link/final-rrid-spacing/fail.xml"/>
+        <x:expect-report id="final-rrid-spacing" role="warning"/>
+        <x:expect-not-assert id="rrid-link-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
     <x:scenario label="ref-link-mandate">

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -2287,9 +2287,12 @@
   </pattern>
   <pattern id="disp-quote-tests-pattern">
     <rule context="disp-quote" id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       
       <report test="ancestor::sub-article[@article-type='decision-letter']" role="warning" id="disp-quote-test-1">Content is tagged as a display quote, which is almost definitely incorrect, since it's in a decision letter - <value-of select="."/>
       </report>
+      
+      <report test="not(ancestor::sub-article) and ($subj=$research-subj)" role="error" id="disp-quote-test-2">Display quote in a <value-of select="$subj"/> is not allowed. Please capture as paragraph instead - '<value-of select="."/>'</report>
     </rule>
   </pattern>
   
@@ -5079,7 +5082,7 @@
   </pattern>
   
   <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
+    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
       <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
       
@@ -5933,7 +5936,7 @@
       
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
-      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5944,6 +5947,8 @@
       
       <report test="matches(.,'�')" role="error" id="institution-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="institution-street-presence">institution likely contains a street or building name, which is likely to be incorrect - <value-of select="."/>.</report>
       
     </rule>
   </pattern>
@@ -6612,6 +6617,26 @@
       <report test="matches(@xlink:href,'^http[s]?://www.ncbi.nlm.nih.gov/pmc/articles/PMC[\d]*')" role="warning" id="pmc-presence">
         <value-of select="parent::*/local-name()"/> element contains what looks like a link to a PMC article - <value-of select="."/> - should this be added a reference instead?</report>
       
+    </rule>
+  </pattern>
+  <pattern id="pubmed-link-2-pattern">
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="warning" id="final-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+    </rule>
+  </pattern>
+  <pattern id="rrid-link-pattern">
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="warning" id="final-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
     </rule>
   </pattern>
   <pattern id="ref-link-mandate-pattern">

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -2285,9 +2285,12 @@
   </pattern>
   <pattern id="disp-quote-tests-pattern">
     <rule context="disp-quote" id="disp-quote-tests">
+      <let name="subj" value="ancestor::article//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       
       <report test="ancestor::sub-article[@article-type='decision-letter']" role="warning" id="disp-quote-test-1">Content is tagged as a display quote, which is almost definitely incorrect, since it's in a decision letter - <value-of select="."/>
       </report>
+      
+      <report test="not(ancestor::sub-article) and ($subj=$research-subj)" role="error" id="disp-quote-test-2">Display quote in a <value-of select="$subj"/> is not allowed. Please capture as paragraph instead - '<value-of select="."/>'</report>
     </rule>
   </pattern>
   
@@ -5077,7 +5080,7 @@
   </pattern>
   
   <pattern id="missing-ref-cited-pattern">
-    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
+    <rule context="p[(ancestor::app or ancestor::body[parent::article]) and not(child::table-wrap) and not(child::supplementary-material)]|td[ancestor::app or ancestor::body[parent::article]]|th[ancestor::app or ancestor::body[parent::article]]" id="missing-ref-cited">
       <let name="text" value="string-join(for $x in self::*/(*|text())         return if ($x/local-name()='xref') then ()         else string($x),'')"/>
       <let name="missing-ref-regex" value="'[A-Z][A-Za-z]+ et al\.?, [1][7-9][0-9][0-9]|[A-Z][A-Za-z]+ et al\.?, [2][0-2][0-9][0-9]|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?|[A-Z][A-Za-z]+ et al\.? [\(]?[1][7-9][0-9][0-9][\)]?'"/>
       
@@ -5931,7 +5934,7 @@
       
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
-      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">
@@ -5942,6 +5945,8 @@
       
       <report test="matches(.,'�')" role="error" id="institution-replacement-character-presence">
         <name/> element contains the replacement character '�' which is unallowed.</report>
+      
+      <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="institution-street-presence">institution likely contains a street or building name, which is likely to be incorrect - <value-of select="."/>.</report>
       
     </rule>
   </pattern>
@@ -6609,6 +6614,26 @@
       
       <report test="matches(@xlink:href,'^http[s]?://www.ncbi.nlm.nih.gov/pmc/articles/PMC[\d]*')" role="warning" id="pmc-presence">
         <value-of select="parent::*/local-name()"/> element contains what looks like a link to a PMC article - <value-of select="."/> - should this be added a reference instead?</report>
+      
+    </rule>
+  </pattern>
+  <pattern id="pubmed-link-2-pattern">
+    <rule context="table-wrap//ext-link[contains(@xlink:href,'ncbi.nlm.nih.gov/pubmed') and not(ancestor::sub-article)]" id="pubmed-link-2">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      <report test="ends-with($lc,'pmid: ') or ends-with($lc,'pmid ')" role="error" id="pre-pmid-spacing-table">PMID link should be preceding by 'PMID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+      
+      
+    </rule>
+  </pattern>
+  <pattern id="rrid-link-pattern">
+    <rule context="ext-link[contains(@xlink:href,'scicrunch.org/resolver') and not(ancestor::sub-article)]" id="rrid-link">
+      <let name="pre-text" value="preceding-sibling::text()[1]"/>
+      <let name="lc" value="lower-case($pre-text)"/>
+      
+      <report test="ends-with($lc,'rrid: ') or ends-with($lc,'rrid ')" role="error" id="pre-rrid-spacing">RRID (scicrunch) link should be preceding by 'RRID:' with no space but instead it is preceded by '<value-of select="concat(substring($pre-text,string-length($pre-text)-15),.)"/>'.</report>
+      
       
     </rule>
   </pattern>


### PR DESCRIPTION
- Add display quote error.
- Refinement for `missing-ref-cited`.
- Add cedex to `city-street-presence`.
- Add new test - `institution-street-presence`.
- Add PMID and RRID pre-link text conformance rules - `pre-pmid-spacing-table`, `final-pmid-spacing-table`, `pre-rrid-spacing`, `final-rrid-spacing`.