### PR TITLE
feat: Add more tests

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1447,7 +1447,7 @@
 		
 		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1559,11 +1559,11 @@
       
       
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
       <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of letters, which must be incorrect.</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
       
       <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
       
@@ -1650,7 +1650,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4696,6 +4696,10 @@
       <assert test="@specific-use" role="error" id="das-elem-cit-1">Every reference in the data availability section must have an @specific-use. The reference in position <value-of select="$pos"/> does not.</assert>
       
       <report test="@specific-use and not(@specific-use=('isSupplementedBy','references'))" role="error" id="das-elem-cit-2">The reference in position <value-of select="$pos"/> of the data availability section has a @specific-use value of <value-of select="@specific-use"/>, which is not allowed. It must be 'isSupplementedBy' or 'references'.</report>
+      
+      <report test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
+      
+      <report test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
       
     </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1453,7 +1453,7 @@
 		
 		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1565,11 +1565,11 @@
       
       
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
       <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of letters, which must be incorrect.</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
       
       <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
       
@@ -1656,7 +1656,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4702,6 +4702,10 @@
       <assert test="@specific-use" role="error" id="das-elem-cit-1">Every reference in the data availability section must have an @specific-use. The reference in position <value-of select="$pos"/> does not.</assert>
       
       <report test="@specific-use and not(@specific-use=('isSupplementedBy','references'))" role="error" id="das-elem-cit-2">The reference in position <value-of select="$pos"/> of the data availability section has a @specific-use value of <value-of select="@specific-use"/>, which is not allowed. It must be 'isSupplementedBy' or 'references'.</report>
+      
+      <report test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
+      
+      <report test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
       
     </rule>
   </pattern>

--- a/src/journals.xml
+++ b/src/journals.xml
@@ -34,6 +34,7 @@
   <journal title="journal of pharmacology and experimental therapeutics" year="2002"/>
   <journal title="journal of physiology" year="1998"/>
   <journal title="journal of virology" year="2001"/>
+  <journal title="jmlr" year="9999"/>
   <journal title="learning &amp; memory" year="1997"/>
   <journal title="microbiological reviews" year="2000"/>
   <journal title="molecular pharmacology" year="1995"/>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1445,7 +1445,7 @@
 		
 		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1555,13 +1555,13 @@
       
       <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
       
       
       <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of letters, which must be incorrect.</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
       
       <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
       
@@ -1647,7 +1647,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4694,6 +4694,10 @@
       <assert test="@specific-use" role="error" id="das-elem-cit-1">Every reference in the data availability section must have an @specific-use. The reference in position <value-of select="$pos"/> does not.</assert>
       
       <report test="@specific-use and not(@specific-use=('isSupplementedBy','references'))" role="error" id="das-elem-cit-2">The reference in position <value-of select="$pos"/> of the data availability section has a @specific-use value of <value-of select="@specific-use"/>, which is not allowed. It must be 'isSupplementedBy' or 'references'.</report>
+      
+      <report test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
+      
+      <report test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
       
     </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1815,7 +1815,7 @@
 		
 	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')"
 	  	role="warning" 
-	  	id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'</report>
+	  	id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
     </rule>
 	
 	<rule context="funding-group/award-group" 
@@ -1985,11 +1985,11 @@
       
       <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')"
         role="warning"
-        id="pre-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+        id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
       <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')"
         role="error"
-        id="final-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+        id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
       <report test="matches(.,'^[\d]+$')"
         role="error"
@@ -1997,7 +1997,7 @@
       
       <report test="matches(.,' [Oo]ur |^[Oo]ur ')"
         role="warning"
-        id="custom-meta-test-11">Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?</report>
+        id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
       
       <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))"
         role="warning"
@@ -2121,7 +2121,7 @@
         role="error" 
         id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')"
+      <report test="((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')"
         role="warning" 
         id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
@@ -6085,6 +6085,14 @@
       <report test="@specific-use and not(@specific-use=('isSupplementedBy','references'))" 
         role="error" 
         id="das-elem-cit-2">The reference in position <value-of select="$pos"/> of the data availability section has a @specific-use value of <value-of select="@specific-use"/>, which is not allowed. It must be 'isSupplementedBy' or 'references'.</report>
+      
+      <report test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" 
+        role="error" 
+        id="das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
+      
+      <report test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" 
+        role="warning" 
+        id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
       
     </rule>
     

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/fail.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-3.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    (count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')
-Message: Is fundingstatement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'-->
+Message: Is fundingstatement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/pass.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-3.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    (count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')
-Message: Is fundingstatement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'-->
+Message: Is fundingstatement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/gen-das-tests/das-elem-cit-3/das-elem-cit-3.sch
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-3/das-elem-cit-3.sch
@@ -722,14 +722,15 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="article-metadata">
-    <rule context="article-meta/funding-group" id="funding-group-tests">
-      <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+  <pattern id="das-element-citation-tests">
+    <rule context="sec[@sec-type='data-availability']//element-citation[@publication-type='data']" id="gen-das-tests">
+      <let name="pos" value="count(ancestor::sec[@sec-type='data-availability']//element-citation[@publication-type='data']) - count(following::element-citation[@publication-type='data' and ancestor::sec[@sec-type='data-availability']])"/>
+      <report test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article-meta/funding-group" role="error" id="funding-group-tests-xspec-assert">article-meta/funding-group must be present.</assert>
+      <assert test="descendant::sec[@sec-type='data-availability']//element-citation[@publication-type='data']" role="error" id="gen-das-tests-xspec-assert">sec[@sec-type='data-availability']//element-citation[@publication-type='data'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/gen-das-tests/das-elem-cit-3/fail.xml
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-3/fail.xml
@@ -1,0 +1,114 @@
+<?oxygen SCHSchema="das-elem-cit-3.sch"?>
+<!--Context: sec[@sec-type='data-availability']//element-citation[@publication-type='data']
+Test: report    pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href
+Message: The reference in position  of the data availability section has a link () which is the same as another dataset reference in that section. Dataset reference links should be distinct.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec id="s7" sec-type="data-availability">
+      <title>Data availability</title>
+      <p>The mass spectrometry proteomics data have been deposited to the ProteomeXchange Consortium
+        via the PRIDE [1] partner repository with the dataset identifier PXD016458 (<ext-link ext-link-type="uri" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">http://www.ebi.ac.uk/pride/archive/projects/PXD016458</ext-link>).</p>
+      <p>The following dataset was generated:</p>
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Montellese</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Van</surname>
+              <given-names>den</given-names>
+            </name>
+            <name>
+              <surname>Ashiono</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dörner</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Melnik</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Jonas</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Zemp</surname>
+              <given-names>I</given-names>
+            </name>
+            <name>
+              <surname>Picotti</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Gillet</surname>
+              <given-names>L</given-names>
+            </name>
+            <name>
+              <surname>Kutay</surname>
+              <given-names>U</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>AP-MS analysis of human RIOK1 and USP16</data-title>
+          <source>PRIDE</source>
+          <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">PXD016458</pub-id>
+        </element-citation>
+      </p>
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Montellese</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Van</surname>
+              <given-names>den</given-names>
+            </name>
+            <name>
+              <surname>Ashiono</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dörner</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Melnik</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Jonas</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Zemp</surname>
+              <given-names>I</given-names>
+            </name>
+            <name>
+              <surname>Picotti</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Gillet</surname>
+              <given-names>L</given-names>
+            </name>
+            <name>
+              <surname>Kutay</surname>
+              <given-names>U</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>AP-MS analysis of human RIOK1 and USP16</data-title>
+          <source>PRIDE</source>
+          <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">PXD016458</pub-id>
+        </element-citation>
+      </p>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/gen-das-tests/das-elem-cit-3/pass.xml
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-3/pass.xml
@@ -1,0 +1,114 @@
+<?oxygen SCHSchema="das-elem-cit-3.sch"?>
+<!--Context: sec[@sec-type='data-availability']//element-citation[@publication-type='data']
+Test: report    pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href
+Message: The reference in position  of the data availability section has a link () which is the same as another dataset reference in that section. Dataset reference links should be distinct.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec id="s7" sec-type="data-availability">
+      <title>Data availability</title>
+      <p>The mass spectrometry proteomics data have been deposited to the ProteomeXchange Consortium
+        via the PRIDE [1] partner repository with the dataset identifier PXD016458 (<ext-link ext-link-type="uri" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">http://www.ebi.ac.uk/pride/archive/projects/PXD016458</ext-link>).</p>
+      <p>The following dataset was generated:</p>
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Montellese</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Van</surname>
+              <given-names>den</given-names>
+            </name>
+            <name>
+              <surname>Ashiono</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dörner</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Melnik</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Jonas</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Zemp</surname>
+              <given-names>I</given-names>
+            </name>
+            <name>
+              <surname>Picotti</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Gillet</surname>
+              <given-names>L</given-names>
+            </name>
+            <name>
+              <surname>Kutay</surname>
+              <given-names>U</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>AP-MS analysis of human RIOK1 and USP16</data-title>
+          <source>PRIDE</source>
+          <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">PXD016458</pub-id>
+        </element-citation>
+      </p>
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Montellese</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Van</surname>
+              <given-names>den</given-names>
+            </name>
+            <name>
+              <surname>Ashiono</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dörner</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Melnik</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Jonas</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Zemp</surname>
+              <given-names>I</given-names>
+            </name>
+            <name>
+              <surname>Picotti</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Gillet</surname>
+              <given-names>L</given-names>
+            </name>
+            <name>
+              <surname>Kutay</surname>
+              <given-names>U</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>AP-MS analysis of human RIOK1 and USP16</data-title>
+          <source>PRIDE</source>
+          <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016459">PXD016459</pub-id>
+        </element-citation>
+      </p>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/gen-das-tests/das-elem-cit-4/das-elem-cit-4.sch
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-4/das-elem-cit-4.sch
@@ -722,14 +722,15 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:function>
-  <pattern id="article-metadata">
-    <rule context="article-meta/funding-group" id="funding-group-tests">
-      <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+  <pattern id="das-element-citation-tests">
+    <rule context="sec[@sec-type='data-availability']//element-citation[@publication-type='data']" id="gen-das-tests">
+      <let name="pos" value="count(ancestor::sec[@sec-type='data-availability']//element-citation[@publication-type='data']) - count(following::element-citation[@publication-type='data' and ancestor::sec[@sec-type='data-availability']])"/>
+      <report test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article-meta/funding-group" role="error" id="funding-group-tests-xspec-assert">article-meta/funding-group must be present.</assert>
+      <assert test="descendant::sec[@sec-type='data-availability']//element-citation[@publication-type='data']" role="error" id="gen-das-tests-xspec-assert">sec[@sec-type='data-availability']//element-citation[@publication-type='data'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/gen-das-tests/das-elem-cit-4/fail.xml
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-4/fail.xml
@@ -1,0 +1,114 @@
+<?oxygen SCHSchema="das-elem-cit-4.sch"?>
+<!--Context: sec[@sec-type='data-availability']//element-citation[@publication-type='data']
+Test: report    pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]
+Message: The reference in position  of the data availability section has a pubid () which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pubid should be distinct.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec id="s7" sec-type="data-availability">
+      <title>Data availability</title>
+      <p>The mass spectrometry proteomics data have been deposited to the ProteomeXchange Consortium
+        via the PRIDE [1] partner repository with the dataset identifier PXD016458 (<ext-link ext-link-type="uri" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">http://www.ebi.ac.uk/pride/archive/projects/PXD016458</ext-link>).</p>
+      <p>The following dataset was generated:</p>
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Montellese</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Van</surname>
+              <given-names>den</given-names>
+            </name>
+            <name>
+              <surname>Ashiono</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dörner</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Melnik</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Jonas</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Zemp</surname>
+              <given-names>I</given-names>
+            </name>
+            <name>
+              <surname>Picotti</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Gillet</surname>
+              <given-names>L</given-names>
+            </name>
+            <name>
+              <surname>Kutay</surname>
+              <given-names>U</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>AP-MS analysis of human RIOK1 and USP16</data-title>
+          <source>PRIDE</source>
+          <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">PXD016458</pub-id>
+        </element-citation>
+      </p>
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Montellese</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Van</surname>
+              <given-names>den</given-names>
+            </name>
+            <name>
+              <surname>Ashiono</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dörner</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Melnik</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Jonas</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Zemp</surname>
+              <given-names>I</given-names>
+            </name>
+            <name>
+              <surname>Picotti</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Gillet</surname>
+              <given-names>L</given-names>
+            </name>
+            <name>
+              <surname>Kutay</surname>
+              <given-names>U</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>AP-MS analysis of human RIOK1 and USP16</data-title>
+          <source>PRIDE</source>
+          <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">PXD016458</pub-id>
+        </element-citation>
+      </p>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/gen-das-tests/das-elem-cit-4/pass.xml
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-4/pass.xml
@@ -1,0 +1,114 @@
+<?oxygen SCHSchema="das-elem-cit-4.sch"?>
+<!--Context: sec[@sec-type='data-availability']//element-citation[@publication-type='data']
+Test: report    pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]
+Message: The reference in position  of the data availability section has a pubid () which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pubid should be distinct.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec id="s7" sec-type="data-availability">
+      <title>Data availability</title>
+      <p>The mass spectrometry proteomics data have been deposited to the ProteomeXchange Consortium
+        via the PRIDE [1] partner repository with the dataset identifier PXD016458 (<ext-link ext-link-type="uri" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">http://www.ebi.ac.uk/pride/archive/projects/PXD016458</ext-link>).</p>
+      <p>The following dataset was generated:</p>
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Montellese</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Van</surname>
+              <given-names>den</given-names>
+            </name>
+            <name>
+              <surname>Ashiono</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dörner</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Melnik</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Jonas</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Zemp</surname>
+              <given-names>I</given-names>
+            </name>
+            <name>
+              <surname>Picotti</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Gillet</surname>
+              <given-names>L</given-names>
+            </name>
+            <name>
+              <surname>Kutay</surname>
+              <given-names>U</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>AP-MS analysis of human RIOK1 and USP16</data-title>
+          <source>PRIDE</source>
+          <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016458">PXD016458</pub-id>
+        </element-citation>
+      </p>
+      <p>
+        <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Montellese</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Van</surname>
+              <given-names>den</given-names>
+            </name>
+            <name>
+              <surname>Ashiono</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dörner</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Melnik</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Jonas</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Zemp</surname>
+              <given-names>I</given-names>
+            </name>
+            <name>
+              <surname>Picotti</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Gillet</surname>
+              <given-names>L</given-names>
+            </name>
+            <name>
+              <surname>Kutay</surname>
+              <given-names>U</given-names>
+            </name>
+          </person-group>
+          <year iso-8601-date="2019">2019</year>
+          <data-title>AP-MS analysis of human RIOK1 and USP16</data-title>
+          <source>PRIDE</source>
+          <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="http://www.ebi.ac.uk/pride/archive/projects/PXD016459">PXD016459</pub-id>
+        </element-citation>
+      </p>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-11/custom-meta-test-11.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-11/custom-meta-test-11.sch
@@ -726,7 +726,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-11/fail.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-11/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-11.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,' [Oo]ur |^[Oo]ur ')
-Message: Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?-->
+Message: Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-11/pass.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-11/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-11.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,' [Oo]ur |^[Oo]ur ')
-Message: Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?-->
+Message: Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/fail.xml
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="final-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')
-Message: Impact statement contains a possesive phrase. This is not allowed-->
+Message: Impact statement contains a possessive phrase. This is not allowed-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/final-custom-meta-test-9.sch
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/final-custom-meta-test-9.sch
@@ -726,7 +726,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/pass.xml
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="final-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')
-Message: Impact statement contains a possesive phrase. This is not allowed-->
+Message: Impact statement contains a possessive phrase. This is not allowed-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/fail.xml
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="pre-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')
-Message: Impact statement contains a possesive phrase. This is not allowed-->
+Message: Impact statement contains a possessive phrase. This is not allowed-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pass.xml
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="pre-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')
-Message: Impact statement contains a possesive phrase. This is not allowed-->
+Message: Impact statement contains a possessive phrase. This is not allowed-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pre-custom-meta-test-9.sch
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pre-custom-meta-test-9.sch
@@ -726,7 +726,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/p-tests/p-test-5/fail.xml
+++ b/test/tests/gen/p-tests/p-test-5/fail.xml
@@ -1,9 +1,9 @@
 <?oxygen SCHSchema="p-test-5.sch"?>
 <!--Context: p
-Test: report    (ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')
+Test: report    ((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')
 Message: p element starts with bolded text    Should it be a header?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
-  <article>
+  <article article-type="research-article">
     <body>
       <sec>
         <p><bold>Experiment 1</bold> Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>

--- a/test/tests/gen/p-tests/p-test-5/p-test-5.sch
+++ b/test/tests/gen/p-tests/p-test-5/p-test-5.sch
@@ -726,7 +726,7 @@
     <rule context="p" id="p-tests">
       <let name="article-type" value="ancestor::article/@article-type"/>
       <let name="text-tokens" value="for $x in tokenize(.,' ') return if (matches($x,'±[Ss][Dd]|±standard|±SEM|±S\.E\.M|±s\.e\.m|\+[Ss][Dd]|\+standard|\+SEM|\+S\.E\.M|\+s\.e\.m')) then $x else ()"/>
-      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/p-tests/p-test-5/pass.xml
+++ b/test/tests/gen/p-tests/p-test-5/pass.xml
@@ -1,13 +1,12 @@
 <?oxygen SCHSchema="p-test-5.sch"?>
 <!--Context: p
-Test: report    (ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')
+Test: report    ((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')
 Message: p element starts with bolded text    Should it be a header?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
-  <article>
+  <article article-type="correction">
     <body>
       <sec>
-        <title>Experiment 1</title>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        <p><bold>Experiment 1</bold> Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       </sec>
     </body>
   </article>

--- a/test/xspec/journals.xml
+++ b/test/xspec/journals.xml
@@ -34,6 +34,7 @@
   <journal title="journal of pharmacology and experimental therapeutics" year="2002"/>
   <journal title="journal of physiology" year="1998"/>
   <journal title="journal of virology" year="2001"/>
+  <journal title="jmlr" year="9999"/>
   <journal title="learning &amp; memory" year="1997"/>
   <journal title="microbiological reviews" year="2000"/>
   <journal title="molecular pharmacology" year="1995"/>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1447,7 +1447,7 @@
 		
 		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1557,13 +1557,13 @@
       
       <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
       <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of letters, which must be incorrect.</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
       
       <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
       
@@ -1650,7 +1650,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4709,6 +4709,10 @@
       <assert test="@specific-use" role="error" id="das-elem-cit-1">Every reference in the data availability section must have an @specific-use. The reference in position <value-of select="$pos"/> does not.</assert>
       
       <report test="@specific-use and not(@specific-use=('isSupplementedBy','references'))" role="error" id="das-elem-cit-2">The reference in position <value-of select="$pos"/> of the data availability section has a @specific-use value of <value-of select="@specific-use"/>, which is not allowed. It must be 'isSupplementedBy' or 'references'.</report>
+      
+      <report test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
+      
+      <report test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
       
     </rule>
   </pattern>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -8475,6 +8475,26 @@
         <x:expect-report id="das-elem-cit-2" role="error"/>
         <x:expect-not-assert id="gen-das-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="das-elem-cit-3-pass">
+        <x:context href="../tests/gen/gen-das-tests/das-elem-cit-3/pass.xml"/>
+        <x:expect-not-report id="das-elem-cit-3" role="error"/>
+        <x:expect-not-assert id="gen-das-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="das-elem-cit-3-fail">
+        <x:context href="../tests/gen/gen-das-tests/das-elem-cit-3/fail.xml"/>
+        <x:expect-report id="das-elem-cit-3" role="error"/>
+        <x:expect-not-assert id="gen-das-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="das-elem-cit-4-pass">
+        <x:context href="../tests/gen/gen-das-tests/das-elem-cit-4/pass.xml"/>
+        <x:expect-not-report id="das-elem-cit-4" role="warning"/>
+        <x:expect-not-assert id="gen-das-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="das-elem-cit-4-fail">
+        <x:context href="../tests/gen/gen-das-tests/das-elem-cit-4/fail.xml"/>
+        <x:expect-report id="das-elem-cit-4" role="warning"/>
+        <x:expect-not-assert id="gen-das-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="das-elem-citation-data-pub-id">
       <x:scenario label="das-pub-id-1-pass">

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -1447,7 +1447,7 @@
 		
 		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1559,11 +1559,11 @@
       
       
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
       <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of letters, which must be incorrect.</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
       
       <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
       
@@ -1650,7 +1650,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4696,6 +4696,10 @@
       <assert test="@specific-use" role="error" id="das-elem-cit-1">Every reference in the data availability section must have an @specific-use. The reference in position <value-of select="$pos"/> does not.</assert>
       
       <report test="@specific-use and not(@specific-use=('isSupplementedBy','references'))" role="error" id="das-elem-cit-2">The reference in position <value-of select="$pos"/> of the data availability section has a @specific-use value of <value-of select="@specific-use"/>, which is not allowed. It must be 'isSupplementedBy' or 'references'.</report>
+      
+      <report test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
+      
+      <report test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
       
     </rule>
   </pattern>

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -1445,7 +1445,7 @@
 		
 		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'The author[s] declare[s] that there was no funding for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is funding-statement this correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1555,13 +1555,13 @@
       
       <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possesive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
       
       
       
       <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of letters, which must be incorrect.</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possesive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
       
       <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
       
@@ -1647,7 +1647,7 @@
       
       <assert test="count($text-tokens) = 0" role="error" id="p-test-3">p element contains <value-of select="string-join($text-tokens,', ')"/> - The spacing is incorrect.</assert>
       
-      <report test="(ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
+      <report test="((ancestor::article/@article-type = ('article-commentary', 'discussion', 'editorial', 'research-article', 'review-article')) and ancestor::body[parent::article]) and (descendant::*[1]/local-name() = 'bold') and not(ancestor::caption) and not(descendant::*[1]/preceding-sibling::text()) and matches(descendant::bold[1],'\p{L}') and (descendant::bold[1] != 'Related research article')" role="warning" id="p-test-5">p element starts with bolded text - <value-of select="descendant::*[1]"/> - Should it be a header?</report>
       
       <report test="(ancestor::body) and (string-length(.) le 100) and not(parent::*[local-name() = ('fn','td','th')]) and (preceding-sibling::*[1]/local-name() = 'p') and (string-length(preceding-sibling::p[1]) le 100) and ($article-type != 'correction') and ($article-type != 'retraction') and not(ancestor::sub-article) and not((count(*) = 1) and child::supplementary-material)" role="warning" id="p-test-6">Should this be captured as a list-item in a list? p element is less than 100 characters long, and is preceded by another p element less than 100 characters long.</report>
       
@@ -4694,6 +4694,10 @@
       <assert test="@specific-use" role="error" id="das-elem-cit-1">Every reference in the data availability section must have an @specific-use. The reference in position <value-of select="$pos"/> does not.</assert>
       
       <report test="@specific-use and not(@specific-use=('isSupplementedBy','references'))" role="error" id="das-elem-cit-2">The reference in position <value-of select="$pos"/> of the data availability section has a @specific-use value of <value-of select="@specific-use"/>, which is not allowed. It must be 'isSupplementedBy' or 'references'.</report>
+      
+      <report test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
+      
+      <report test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
       
     </rule>
   </pattern>


### PR DESCRIPTION
- Distinct dataset url conformity - `das-elem-cit-3`.
- Distinct dataset pub-id conformity - `das-elem-cit-4`.
- Exclude corrections and retractions from `p-test-5`.
- Correct `poessesive` typos.
- Correct text for `funding-group-test-3`.