### PR TITLE
feat: GitBook edits and editorial test

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -896,6 +896,13 @@
    
    </rule>
   </pattern>
+  <pattern id="editorial-metadata-pattern">
+    <rule context="article[@article-type='editorial']/front/article-meta" id="editorial-metadata">
+      
+      <report test="contrib-group[@content-type='section']" role="error" id="editorial-editors-presence">Editorials cannot contain Editors and/or Reviewers. This one has a contrib-group[@content-type='section'] containing <value-of select="string-join(for $x in contrib-group[@content-type='section']/contrib return concat('&quot;',e:get-name($x/*[1][name()=('name','collab')]),'&quot;',' as ','&quot;',$x/role[1],'&quot;'),' and ')"/>.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="test-article-categories-pattern">
     <rule context="article-meta/article-categories" id="test-article-categories">
 	 <let name="article-type" value="ancestor::article/@article-type"/>
@@ -1446,9 +1453,9 @@
 		
 		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1464,9 +1471,12 @@
 		
 		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
 		
-		<assert test="count(funding-source/institution-wrap/institution) = 1" role="error" id="award-group-test-6">One and only one institution must be present.</assert>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
 	  
 	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
+      </report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
@@ -1487,7 +1497,7 @@
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, institution-id[@institution-id-type="FundRef"] should be present in institution-wrap; warn staff if not</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
       
     </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -902,6 +902,13 @@
    
    </rule>
   </pattern>
+  <pattern id="editorial-metadata-pattern">
+    <rule context="article[@article-type='editorial']/front/article-meta" id="editorial-metadata">
+      
+      <report test="contrib-group[@content-type='section']" role="error" id="editorial-editors-presence">Editorials cannot contain Editors and/or Reviewers. This one has a contrib-group[@content-type='section'] containing <value-of select="string-join(for $x in contrib-group[@content-type='section']/contrib return concat('&quot;',e:get-name($x/*[1][name()=('name','collab')]),'&quot;',' as ','&quot;',$x/role[1],'&quot;'),' and ')"/>.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="test-article-categories-pattern">
     <rule context="article-meta/article-categories" id="test-article-categories">
 	 <let name="article-type" value="ancestor::article/@article-type"/>
@@ -1452,9 +1459,9 @@
 		
 		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1470,9 +1477,12 @@
 		
 		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
 		
-		<assert test="count(funding-source/institution-wrap/institution) = 1" role="error" id="award-group-test-6">One and only one institution must be present.</assert>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
 	  
 	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
+      </report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
@@ -1493,7 +1503,7 @@
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, institution-id[@institution-id-type="FundRef"] should be present in institution-wrap; warn staff if not</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -896,6 +896,13 @@
    
    </rule>
   </pattern>
+  <pattern id="editorial-metadata-pattern">
+    <rule context="article[@article-type='editorial']/front/article-meta" id="editorial-metadata">
+      
+      <report test="contrib-group[@content-type='section']" role="error" id="editorial-editors-presence">Editorials cannot contain Editors and/or Reviewers. This one has a contrib-group[@content-type='section'] containing <value-of select="string-join(for $x in contrib-group[@content-type='section']/contrib return concat('&quot;',e:get-name($x/*[1][name()=('name','collab')]),'&quot;',' as ','&quot;',$x/role[1],'&quot;'),' and ')"/>.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="test-article-categories-pattern">
     <rule context="article-meta/article-categories" id="test-article-categories">
 	 <let name="article-type" value="ancestor::article/@article-type"/>
@@ -1444,9 +1451,9 @@
 		
 		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1462,9 +1469,12 @@
 		
 		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
 		
-		<assert test="count(funding-source/institution-wrap/institution) = 1" role="error" id="award-group-test-6">One and only one institution must be present.</assert>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
 	  
 	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
+      </report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
@@ -1485,7 +1495,7 @@
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, institution-id[@institution-id-type="FundRef"] should be present in institution-wrap; warn staff if not</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
       
     </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -994,6 +994,15 @@
        id="test-contrib-group-presence-2">contrib-group[@content-type='section'] must be present (as a child of article-meta) for research articles (this is the contrib-group which contains reviewers and editors).</assert>
    
    </rule>
+    
+    <rule context="article[@article-type='editorial']/front/article-meta" 
+      id="editorial-metadata">
+      
+      <report test="contrib-group[@content-type='section']"
+        role="error" 
+        id="editorial-editors-presence">Editorials cannot contain Editors and/or Reviewers. This one has a contrib-group[@content-type='section'] containing <value-of select="string-join(for $x in contrib-group[@content-type='section']/contrib return concat('&quot;',e:get-name($x/*[1][name()=('name','collab')]),'&quot;',' as ','&quot;',$x/role[1],'&quot;'),' and ')"/>.</report>
+      
+    </rule>
 	 
    <rule context="article-meta/article-categories" id="test-article-categories">
 	 <let name="article-type" value="ancestor::article/@article-type"/>
@@ -1812,11 +1821,11 @@
 		
 		<report test="count(award-group) = 0"
 	  	role="warning" 
-	  	id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
+	  	id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
 		
 	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')"
 	  	role="warning" 
-	  	id="funding-group-test-3">Is this funding-statement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+	  	id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
     </rule>
 	
 	<rule context="funding-group/award-group" 
@@ -1840,13 +1849,17 @@
   		role="error"
   		id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
 		
-		<assert test="count(funding-source/institution-wrap/institution) = 1"
+		<report test="count(funding-source/institution-wrap/institution) = 0"
   		role="error"
-  		id="award-group-test-6">One and only one institution must be present.</assert>
+  		id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"> does not have one.</report>
 	  
 	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id"
 	    role="error"
 	    id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>">)</assert>
+	  
+	  <report test="count(funding-source/institution-wrap/institution) gt 1"
+	    role="error"
+	    id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"> has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/></report>
 	</rule>
     
     <rule context="funding-group/award-group/award-id" 
@@ -1877,7 +1890,7 @@
       <assert test="institution-id[@institution-id-type='FundRef']"
         role="warning"
         flag="pub-check"
-        id="institution-id-test">Whenever possible, institution-id[@institution-id-type="FundRef"] should be present in institution-wrap; warn staff if not</assert>
+        id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
       
     </rule>
     

--- a/test/tests/gen/award-group-tests/award-group-test-6/award-group-test-6.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-6/award-group-test-6.sch
@@ -727,7 +727,7 @@
     <rule context="funding-group/award-group" id="award-group-tests">
       <let name="id" value="@id"/>
       <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
-      <assert test="count(funding-source/institution-wrap/institution) = 1" role="error" id="award-group-test-6">One and only one institution must be present.</assert>
+      <report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-group-tests/award-group-test-6/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-6/fail.xml
@@ -1,21 +1,12 @@
 <?oxygen SCHSchema="award-group-test-6.sch"?>
 <!--Context: funding-group/award-group
-Test: assert    count(funding-source/institution-wrap/institution) = 1
-Message: One and only one institution must be present.-->
+Test: report    count(funding-source/institution-wrap/institution) = 0
+Message: Every piece of funding must have an institution. <awardgroup id=""> does not have one.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>
       <funding-group>
-        <award-group>
-          <funding-source>
-            <institution-wrap>
-              <institution/>
-              <institution/>
-            </institution-wrap>
-          </funding-source>
-          <principal-award-recipient/>
-          <award-id/>
-        </award-group>
+        <award-group/>
       </funding-group>
     </article-meta>
   </article>

--- a/test/tests/gen/award-group-tests/award-group-test-8/award-group-test-8.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-8/award-group-test-8.sch
@@ -724,13 +724,16 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="article-meta/funding-group" id="funding-group-tests">
-      <report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+    <rule context="funding-group/award-group" id="award-group-tests">
+      <let name="id" value="@id"/>
+      <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
+      <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
+      </report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article-meta/funding-group" role="error" id="funding-group-tests-xspec-assert">article-meta/funding-group must be present.</assert>
+      <assert test="descendant::funding-group/award-group" role="error" id="award-group-tests-xspec-assert">funding-group/award-group must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/award-group-tests/award-group-test-8/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-8/fail.xml
@@ -1,7 +1,7 @@
-<?oxygen SCHSchema="award-group-test-6.sch"?>
+<?oxygen SCHSchema="award-group-test-8.sch"?>
 <!--Context: funding-group/award-group
-Test: report    count(funding-source/institution-wrap/institution) = 0
-Message: Every piece of funding must have an institution. <awardgroup id=""> does not have one.-->
+Test: report    count(funding-source/institution-wrap/institution) gt 1
+Message: Every piece of funding must only have 1 institution. <awardgroup id=""> has   -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>
@@ -9,6 +9,7 @@ Message: Every piece of funding must have an institution. <awardgroup id=""> doe
         <award-group>
           <funding-source>
             <institution-wrap>
+              <institution/>
               <institution/>
             </institution-wrap>
           </funding-source>

--- a/test/tests/gen/award-group-tests/award-group-test-8/pass.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-8/pass.xml
@@ -1,7 +1,7 @@
-<?oxygen SCHSchema="award-group-test-6.sch"?>
+<?oxygen SCHSchema="award-group-test-8.sch"?>
 <!--Context: funding-group/award-group
-Test: report    count(funding-source/institution-wrap/institution) = 0
-Message: Every piece of funding must have an institution. <awardgroup id=""> does not have one.-->
+Test: report    count(funding-source/institution-wrap/institution) gt 1
+Message: Every piece of funding must only have 1 institution. <awardgroup id=""> has   -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/editorial-metadata/editorial-editors-presence/editorial-editors-presence.sch
+++ b/test/tests/gen/editorial-metadata/editorial-editors-presence/editorial-editors-presence.sch
@@ -724,13 +724,13 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="article-meta/funding-group" id="funding-group-tests">
-      <report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+    <rule context="article[@article-type='editorial']/front/article-meta" id="editorial-metadata">
+      <report test="contrib-group[@content-type='section']" role="error" id="editorial-editors-presence">Editorials cannot contain Editors and/or Reviewers. This one has a contrib-group[@content-type='section'] containing <value-of select="string-join(for $x in contrib-group[@content-type='section']/contrib return concat('&quot;',e:get-name($x/*[1][name()=('name','collab')]),'&quot;',' as ','&quot;',$x/role[1],'&quot;'),' and ')"/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article-meta/funding-group" role="error" id="funding-group-tests-xspec-assert">article-meta/funding-group must be present.</assert>
+      <assert test="descendant::article[@article-type='editorial']/front/article-meta" role="error" id="editorial-metadata-xspec-assert">article[@article-type='editorial']/front/article-meta must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/editorial-metadata/editorial-editors-presence/fail.xml
+++ b/test/tests/gen/editorial-metadata/editorial-editors-presence/fail.xml
@@ -1,0 +1,129 @@
+<?oxygen SCHSchema="editorial-editors-presence.sch"?>
+<!--Context: article[@article-type='editorial']/front/article-meta
+Test: report    contrib-group[@content-type='section']
+Message: Editorials cannot contain Editors and/or Reviewers. This one has a contribgroup[@contenttype='section'] containing .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="editorial">
+    <front>
+      <article-meta>
+        <contrib-group>
+          <contrib contrib-type="author" corresp="yes" id="author-90400">
+            <name>
+              <surname>Eisen</surname>
+              <given-names>Michael B</given-names>
+            </name>
+            <contrib-id contrib-id-type="orcid" authenticated="true"
+              >https://orcid.org/0000-0002-7528-738X</contrib-id>
+            <email>mbeisen@gmail.com</email>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="fn" rid="con1"/>
+            <xref ref-type="fn" rid="conf1"/>
+            <bio>
+              <p><bold>Michael B Eisen</bold> is the Editor-in-Chief of eLife</p>
+            </bio>
+          </contrib>
+          <contrib contrib-type="author" id="author-8518">
+            <name>
+              <surname>Akhmanova</surname>
+              <given-names>Anna</given-names>
+            </name>
+            <contrib-id contrib-id-type="orcid" authenticated="true"
+              >https://orcid.org/0000-0002-9048-8614</contrib-id>
+            <xref ref-type="aff" rid="aff2">2</xref>
+            <xref ref-type="fn" rid="con2"/>
+            <xref ref-type="fn" rid="conf2"/>
+            <bio>
+              <p><bold>Anna Akhmanova</bold> is a Deputy Editor of eLife</p>
+            </bio>
+          </contrib>
+          <contrib contrib-type="author" id="author-1044">
+            <name>
+              <surname>Behrens</surname>
+              <given-names>Timothy E</given-names>
+            </name>
+            <contrib-id contrib-id-type="orcid" authenticated="true"
+              >https://orcid.org/0000-0003-0048-1177</contrib-id>
+            <xref ref-type="aff" rid="aff3">3</xref>
+            <xref ref-type="fn" rid="con3"/>
+            <xref ref-type="fn" rid="conf2"/>
+            <bio>
+              <p><bold>Timothy E Behrens</bold> is a Deputy Editor of eLife</p>
+            </bio>
+          </contrib>
+          <contrib contrib-type="author" id="author-1030">
+            <name>
+              <surname>Weigel</surname>
+              <given-names>Detlef</given-names>
+            </name>
+            <contrib-id contrib-id-type="orcid" authenticated="true"
+              >https://orcid.org/0000-0002-2114-7963</contrib-id>
+            <xref ref-type="aff" rid="aff4">4</xref>
+            <xref ref-type="fn" rid="con4"/>
+            <xref ref-type="fn" rid="conf2"/>
+            <bio>
+              <p><bold>Detlef Weigel</bold> is a Deputy Editor of eLife</p>
+            </bio>
+          </contrib>
+          <aff id="aff1">
+            <label>1</label>
+            <institution>Department of Molecular and Cell Biology, HHMI, University of California,
+              Berkeley</institution>
+            <addr-line>
+              <named-content content-type="city">Berkeley</named-content>
+            </addr-line>
+            <country>United States</country>
+          </aff>
+          <aff id="aff2">
+            <label>2</label>
+            <institution>Department of Biology, Utrecht University</institution>
+            <addr-line>
+              <named-content content-type="city">Utrecht</named-content>
+            </addr-line>
+            <country>Netherlands</country>
+          </aff>
+          <aff id="aff3">
+            <label>3</label>
+            <institution>Wellcome Trust Centre for Neuroimaging, University of Oxford</institution>
+            <addr-line>
+              <named-content content-type="city">Oxford</named-content>
+            </addr-line>
+            <country>United Kingdom</country>
+          </aff>
+          <aff id="aff4">
+            <label>4</label>
+            <institution>Department of Molecular Biology, Max Planck Institute for Developmental
+              Biology</institution>
+            <addr-line>
+              <named-content content-type="city">T&#x00FC;bingen</named-content>
+            </addr-line>
+            <country>Germany</country>
+          </aff>
+        </contrib-group>
+        <contrib-group content-type="section">
+          <contrib contrib-type="editor">
+            <name>
+              <surname/>
+              <given-names/>
+            </name>
+            <role>Reviewing Editor</role>
+            <aff>
+              <institution/>
+            </aff>
+          </contrib>
+          <contrib contrib-type="senior_editor">
+            <name>
+              <surname>Rodgers</surname>
+              <given-names>Peter</given-names>
+            </name>
+            <role>Senior Editor</role>
+            <aff>
+              <institution>eLife</institution>
+              <country>United Kingdom</country>
+            </aff>
+          </contrib>
+        </contrib-group>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/editorial-metadata/editorial-editors-presence/pass.xml
+++ b/test/tests/gen/editorial-metadata/editorial-editors-presence/pass.xml
@@ -1,0 +1,106 @@
+<?oxygen SCHSchema="editorial-editors-presence.sch"?>
+<!--Context: article[@article-type='editorial']/front/article-meta
+Test: report    contrib-group[@content-type='section']
+Message: Editorials cannot contain Editors and/or Reviewers. This one has a contribgroup[@contenttype='section'] containing .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="editorial">
+    <front>
+      <article-meta>
+        <contrib-group>
+          <contrib contrib-type="author" corresp="yes" id="author-90400">
+            <name>
+              <surname>Eisen</surname>
+              <given-names>Michael B</given-names>
+            </name>
+            <contrib-id contrib-id-type="orcid" authenticated="true"
+              >https://orcid.org/0000-0002-7528-738X</contrib-id>
+            <email>mbeisen@gmail.com</email>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="fn" rid="con1"/>
+            <xref ref-type="fn" rid="conf1"/>
+            <bio>
+              <p><bold>Michael B Eisen</bold> is the Editor-in-Chief of eLife</p>
+            </bio>
+          </contrib>
+          <contrib contrib-type="author" id="author-8518">
+            <name>
+              <surname>Akhmanova</surname>
+              <given-names>Anna</given-names>
+            </name>
+            <contrib-id contrib-id-type="orcid" authenticated="true"
+              >https://orcid.org/0000-0002-9048-8614</contrib-id>
+            <xref ref-type="aff" rid="aff2">2</xref>
+            <xref ref-type="fn" rid="con2"/>
+            <xref ref-type="fn" rid="conf2"/>
+            <bio>
+              <p><bold>Anna Akhmanova</bold> is a Deputy Editor of eLife</p>
+            </bio>
+          </contrib>
+          <contrib contrib-type="author" id="author-1044">
+            <name>
+              <surname>Behrens</surname>
+              <given-names>Timothy E</given-names>
+            </name>
+            <contrib-id contrib-id-type="orcid" authenticated="true"
+              >https://orcid.org/0000-0003-0048-1177</contrib-id>
+            <xref ref-type="aff" rid="aff3">3</xref>
+            <xref ref-type="fn" rid="con3"/>
+            <xref ref-type="fn" rid="conf2"/>
+            <bio>
+              <p><bold>Timothy E Behrens</bold> is a Deputy Editor of eLife</p>
+            </bio>
+          </contrib>
+          <contrib contrib-type="author" id="author-1030">
+            <name>
+              <surname>Weigel</surname>
+              <given-names>Detlef</given-names>
+            </name>
+            <contrib-id contrib-id-type="orcid" authenticated="true"
+              >https://orcid.org/0000-0002-2114-7963</contrib-id>
+            <xref ref-type="aff" rid="aff4">4</xref>
+            <xref ref-type="fn" rid="con4"/>
+            <xref ref-type="fn" rid="conf2"/>
+            <bio>
+              <p><bold>Detlef Weigel</bold> is a Deputy Editor of eLife</p>
+            </bio>
+          </contrib>
+          <aff id="aff1">
+            <label>1</label>
+            <institution>Department of Molecular and Cell Biology, HHMI, University of California,
+              Berkeley</institution>
+            <addr-line>
+              <named-content content-type="city">Berkeley</named-content>
+            </addr-line>
+            <country>United States</country>
+          </aff>
+          <aff id="aff2">
+            <label>2</label>
+            <institution>Department of Biology, Utrecht University</institution>
+            <addr-line>
+              <named-content content-type="city">Utrecht</named-content>
+            </addr-line>
+            <country>Netherlands</country>
+          </aff>
+          <aff id="aff3">
+            <label>3</label>
+            <institution>Wellcome Trust Centre for Neuroimaging, University of Oxford</institution>
+            <addr-line>
+              <named-content content-type="city">Oxford</named-content>
+            </addr-line>
+            <country>United Kingdom</country>
+          </aff>
+          <aff id="aff4">
+            <label>4</label>
+            <institution>Department of Molecular Biology, Max Planck Institute for Developmental
+              Biology</institution>
+            <addr-line>
+              <named-content content-type="city">T&#x00FC;bingen</named-content>
+            </addr-line>
+            <country>Germany</country>
+          </aff>
+        </contrib-group>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/funding-group-tests/funding-group-test-2/fail.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-2.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    count(award-group) = 0
-Message: fundinggroup contains no awardgroups. Is this correct? Please check with eLife staff.-->
+Message: There is no funding for this article. Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-2/pass.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-2.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    count(award-group) = 0
-Message: fundinggroup contains no awardgroups. Is this correct? Please check with eLife staff.-->
+Message: There is no funding for this article. Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/fail.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-3.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    (count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')
-Message: Is this fundingstatement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'-->
+Message: Is this fundingstatement correct?  '' Usually it should be 'No external funding was received for this work.'-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/funding-group-test-3.sch
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/funding-group-test-3.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="article-meta/funding-group" id="funding-group-tests">
-      <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+      <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/pass.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-3.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    (count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')
-Message: Is this fundingstatement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'-->
+Message: Is this fundingstatement correct?  '' Usually it should be 'No external funding was received for this work.'-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/institution-wrap-tests/institution-id-test/fail.xml
+++ b/test/tests/gen/institution-wrap-tests/institution-id-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="institution-id-test.sch"?>
 <!--Context: article-meta//award-group//institution-wrap
 Test: assert    institution-id[@institution-id-type='FundRef']
-Message: Whenever possible, institutionid[@institutionidtype="FundRef"] should be present in institutionwrap; warn staff if not-->
+Message: Whenever possible, a funder should have a doi  please check whether there is an appropriate doi in the open funder registry. (institutionid[@institutionidtype="FundRef"] is not present in institutionwrap).-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/institution-wrap-tests/institution-id-test/institution-id-test.sch
+++ b/test/tests/gen/institution-wrap-tests/institution-id-test/institution-id-test.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, institution-id[@institution-id-type="FundRef"] should be present in institution-wrap; warn staff if not</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/institution-wrap-tests/institution-id-test/pass.xml
+++ b/test/tests/gen/institution-wrap-tests/institution-id-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="institution-id-test.sch"?>
 <!--Context: article-meta//award-group//institution-wrap
 Test: assert    institution-id[@institution-id-type='FundRef']
-Message: Whenever possible, institutionid[@institutionidtype="FundRef"] should be present in institutionwrap; warn staff if not-->
+Message: Whenever possible, a funder should have a doi  please check whether there is an appropriate doi in the open funder registry. (institutionid[@institutionidtype="FundRef"] is not present in institutionwrap).-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -896,6 +896,13 @@
    
    </rule>
   </pattern>
+  <pattern id="editorial-metadata-pattern">
+    <rule context="article[@article-type='editorial']/front/article-meta" id="editorial-metadata">
+      
+      <report test="contrib-group[@content-type='section']" role="error" id="editorial-editors-presence">Editorials cannot contain Editors and/or Reviewers. This one has a contrib-group[@content-type='section'] containing <value-of select="string-join(for $x in contrib-group[@content-type='section']/contrib return concat('&quot;',e:get-name($x/*[1][name()=('name','collab')]),'&quot;',' as ','&quot;',$x/role[1],'&quot;'),' and ')"/>.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="test-article-categories-pattern">
     <rule context="article-meta/article-categories" id="test-article-categories">
 	 <let name="article-type" value="ancestor::article/@article-type"/>
@@ -1446,9 +1453,9 @@
 		
 		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1464,9 +1471,12 @@
 		
 		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
 		
-		<assert test="count(funding-source/institution-wrap/institution) = 1" role="error" id="award-group-test-6">One and only one institution must be present.</assert>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
 	  
 	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
+      </report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
@@ -1487,7 +1497,7 @@
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, institution-id[@institution-id-type="FundRef"] should be present in institution-wrap; warn staff if not</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
       
     </rule>
   </pattern>
@@ -6859,6 +6869,7 @@
       <assert test="descendant::article/front/journal-meta" role="error" id="test-journal-meta-xspec-assert">article/front/journal-meta must be present.</assert>
       <assert test="descendant::article/front/article-meta" role="error" id="test-article-metadata-xspec-assert">article/front/article-meta must be present.</assert>
       <assert test="descendant::article[@article-type='research-article']/front/article-meta" role="error" id="test-research-article-metadata-xspec-assert">article[@article-type='research-article']/front/article-meta must be present.</assert>
+      <assert test="descendant::article[@article-type='editorial']/front/article-meta" role="error" id="editorial-metadata-xspec-assert">article[@article-type='editorial']/front/article-meta must be present.</assert>
       <assert test="descendant::article-meta/article-categories" role="error" id="test-article-categories-xspec-assert">article-meta/article-categories must be present.</assert>
       <assert test="descendant::article-categories/subj-group[@subj-group-type='display-channel']/subject" role="error" id="disp-channel-checks-xspec-assert">article-categories/subj-group[@subj-group-type='display-channel']/subject must be present.</assert>
       <assert test="descendant::article-categories/subj-group[@subj-group-type='heading']/subject" role="error" id="MSA-checks-xspec-assert">article-categories/subj-group[@subj-group-type='heading']/subject must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -422,6 +422,18 @@
         <x:expect-not-assert id="test-research-article-metadata-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="editorial-metadata">
+      <x:scenario label="editorial-editors-presence-pass">
+        <x:context href="../tests/gen/editorial-metadata/editorial-editors-presence/pass.xml"/>
+        <x:expect-not-report id="editorial-editors-presence" role="error"/>
+        <x:expect-not-assert id="editorial-metadata-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="editorial-editors-presence-fail">
+        <x:context href="../tests/gen/editorial-metadata/editorial-editors-presence/fail.xml"/>
+        <x:expect-report id="editorial-editors-presence" role="error"/>
+        <x:expect-not-assert id="editorial-metadata-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
     <x:scenario label="test-article-categories">
       <x:scenario label="disp-subj-test-pass">
         <x:context href="../tests/gen/test-article-categories/disp-subj-test/pass.xml"/>
@@ -1975,12 +1987,12 @@
       </x:scenario>
       <x:scenario label="award-group-test-6-pass">
         <x:context href="../tests/gen/award-group-tests/award-group-test-6/pass.xml"/>
-        <x:expect-not-assert id="award-group-test-6" role="error"/>
+        <x:expect-not-report id="award-group-test-6" role="error"/>
         <x:expect-not-assert id="award-group-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="award-group-test-6-fail">
         <x:context href="../tests/gen/award-group-tests/award-group-test-6/fail.xml"/>
-        <x:expect-assert id="award-group-test-6" role="error"/>
+        <x:expect-report id="award-group-test-6" role="error"/>
         <x:expect-not-assert id="award-group-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="award-group-test-7-pass">
@@ -1991,6 +2003,16 @@
       <x:scenario label="award-group-test-7-fail">
         <x:context href="../tests/gen/award-group-tests/award-group-test-7/fail.xml"/>
         <x:expect-assert id="award-group-test-7" role="error"/>
+        <x:expect-not-assert id="award-group-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="award-group-test-8-pass">
+        <x:context href="../tests/gen/award-group-tests/award-group-test-8/pass.xml"/>
+        <x:expect-not-report id="award-group-test-8" role="error"/>
+        <x:expect-not-assert id="award-group-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="award-group-test-8-fail">
+        <x:context href="../tests/gen/award-group-tests/award-group-test-8/fail.xml"/>
+        <x:expect-report id="award-group-test-8" role="error"/>
         <x:expect-not-assert id="award-group-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -896,6 +896,13 @@
    
    </rule>
   </pattern>
+  <pattern id="editorial-metadata-pattern">
+    <rule context="article[@article-type='editorial']/front/article-meta" id="editorial-metadata">
+      
+      <report test="contrib-group[@content-type='section']" role="error" id="editorial-editors-presence">Editorials cannot contain Editors and/or Reviewers. This one has a contrib-group[@content-type='section'] containing <value-of select="string-join(for $x in contrib-group[@content-type='section']/contrib return concat('&quot;',e:get-name($x/*[1][name()=('name','collab')]),'&quot;',' as ','&quot;',$x/role[1],'&quot;'),' and ')"/>.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="test-article-categories-pattern">
     <rule context="article-meta/article-categories" id="test-article-categories">
 	 <let name="article-type" value="ancestor::article/@article-type"/>
@@ -1446,9 +1453,9 @@
 		
 		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1464,9 +1471,12 @@
 		
 		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
 		
-		<assert test="count(funding-source/institution-wrap/institution) = 1" role="error" id="award-group-test-6">One and only one institution must be present.</assert>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
 	  
 	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
+      </report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
@@ -1487,7 +1497,7 @@
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, institution-id[@institution-id-type="FundRef"] should be present in institution-wrap; warn staff if not</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
       
     </rule>
   </pattern>

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -896,6 +896,13 @@
    
    </rule>
   </pattern>
+  <pattern id="editorial-metadata-pattern">
+    <rule context="article[@article-type='editorial']/front/article-meta" id="editorial-metadata">
+      
+      <report test="contrib-group[@content-type='section']" role="error" id="editorial-editors-presence">Editorials cannot contain Editors and/or Reviewers. This one has a contrib-group[@content-type='section'] containing <value-of select="string-join(for $x in contrib-group[@content-type='section']/contrib return concat('&quot;',e:get-name($x/*[1][name()=('name','collab')]),'&quot;',' as ','&quot;',$x/role[1],'&quot;'),' and ')"/>.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="test-article-categories-pattern">
     <rule context="article-meta/article-categories" id="test-article-categories">
 	 <let name="article-type" value="ancestor::article/@article-type"/>
@@ -1444,9 +1451,9 @@
 		
 		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">funding-group contains no award-groups. Is this correct? Please check with eLife staff.</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? Please check with eLife staff. Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1462,9 +1469,12 @@
 		
 		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
 		
-		<assert test="count(funding-source/institution-wrap/institution) = 1" role="error" id="award-group-test-6">One and only one institution must be present.</assert>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
 	  
 	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
+      </report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
@@ -1485,7 +1495,7 @@
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, institution-id[@institution-id-type="FundRef"] should be present in institution-wrap; warn staff if not</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
       
     </rule>
   </pattern>


### PR DESCRIPTION
- Do not allow editors in editorial articles `editorial-editors-presence`
- Split `award-group-test-6` into two separate tests for readability
- Message text edits in line with GitBook changes