### PR TITLE
fix: fixes for extra space and full stop tests

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -5928,10 +5928,10 @@
       <report test="matches(.,'&amp;#x\d')" role="warning" id="broken-unicode-presence">
         <name/> element contains what looks like a broken unicode - <value-of select="."/>.</report>
       
-      <report test="contains(.,'..')" role="warning" id="extra-full-stop-presence">
+      <report test="contains(.,'..') and not(contains(.,'...'))" role="warning" id="extra-full-stop-presence">
         <name/> element contains what looks two full stops right next to each other (..) - Is that correct? - <value-of select="."/>.</report>
       
-      <report test="matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
+      <report test="not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
         <name/> element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - <value-of select="."/>.</report>
     </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -5934,10 +5934,10 @@
       <report test="matches(.,'&amp;#x\d')" role="warning" id="broken-unicode-presence">
         <name/> element contains what looks like a broken unicode - <value-of select="."/>.</report>
       
-      <report test="contains(.,'..')" role="warning" id="extra-full-stop-presence">
+      <report test="contains(.,'..') and not(contains(.,'...'))" role="warning" id="extra-full-stop-presence">
         <name/> element contains what looks two full stops right next to each other (..) - Is that correct? - <value-of select="."/>.</report>
       
-      <report test="matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
+      <report test="not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
         <name/> element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - <value-of select="."/>.</report>
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -5926,10 +5926,10 @@
       <report test="matches(.,'&amp;#x\d')" role="warning" id="broken-unicode-presence">
         <name/> element contains what looks like a broken unicode - <value-of select="."/>.</report>
       
-      <report test="contains(.,'..')" role="warning" id="extra-full-stop-presence">
+      <report test="contains(.,'..') and not(contains(.,'...'))" role="warning" id="extra-full-stop-presence">
         <name/> element contains what looks two full stops right next to each other (..) - Is that correct? - <value-of select="."/>.</report>
       
-      <report test="matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
+      <report test="not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
         <name/> element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - <value-of select="."/>.</report>
     </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -7951,11 +7951,11 @@
         role="warning"
         id="broken-unicode-presence"><name/> element contains what looks like a broken unicode - <value-of select="."/>.</report>
       
-      <report test="contains(.,'..')"
+      <report test="contains(.,'..') and not(contains(.,'...'))"
         role="warning"
         id="extra-full-stop-presence"><name/> element contains what looks two full stops right next to each other (..) - Is that correct? - <value-of select="."/>.</report>
       
-      <report test="matches(replace(.,'&#x00A0;',' '),'\s\s+')"
+      <report test="not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,'&#x00A0;',' '),'\s\s+')"
         role="warning"
         id="extra-space-presence"><name/> element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - <value-of select="."/>.</report>
     </rule>

--- a/test/tests/gen/unallowed-symbol-tests/extra-full-stop-presence/extra-full-stop-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/extra-full-stop-presence/extra-full-stop-presence.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="house-style">
     <rule context="p|td|th|title|xref|bold|italic|sub|sc|named-content|monospace|code|underline|fn|institution|ext-link" id="unallowed-symbol-tests">
-      <report test="contains(.,'..')" role="warning" id="extra-full-stop-presence">
+      <report test="contains(.,'..') and not(contains(.,'...'))" role="warning" id="extra-full-stop-presence">
         <name/> element contains what looks two full stops right next to each other (..) - Is that correct? - <value-of select="."/>.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/unallowed-symbol-tests/extra-full-stop-presence/fail.xml
+++ b/test/tests/gen/unallowed-symbol-tests/extra-full-stop-presence/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="extra-full-stop-presence.sch"?>
 <!--Context: p|td|th|title|xref|bold|italic|sub|sc|named-content|monospace|code|underline|fn|institution|ext-link
-Test: report    contains(.,'..')
+Test: report    contains(.,'..') and not(contains(.,'...'))
 Message:  element contains what looks two full stops right next to each other (..) - Is that correct? - .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/unallowed-symbol-tests/extra-full-stop-presence/pass.xml
+++ b/test/tests/gen/unallowed-symbol-tests/extra-full-stop-presence/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="extra-full-stop-presence.sch"?>
 <!--Context: p|td|th|title|xref|bold|italic|sub|sc|named-content|monospace|code|underline|fn|institution|ext-link
-Test: report    contains(.,'..')
+Test: report    contains(.,'..') and not(contains(.,'...'))
 Message:  element contains what looks two full stops right next to each other (..) - Is that correct? - .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/unallowed-symbol-tests/extra-space-presence/extra-space-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/extra-space-presence/extra-space-presence.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="house-style">
     <rule context="p|td|th|title|xref|bold|italic|sub|sc|named-content|monospace|code|underline|fn|institution|ext-link" id="unallowed-symbol-tests">
-      <report test="matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
+      <report test="not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
         <name/> element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - <value-of select="."/>.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/unallowed-symbol-tests/extra-space-presence/fail.xml
+++ b/test/tests/gen/unallowed-symbol-tests/extra-space-presence/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="extra-space-presence.sch"?>
 <!--Context: p|td|th|title|xref|bold|italic|sub|sc|named-content|monospace|code|underline|fn|institution|ext-link
-Test: report    matches(replace(.,' ',' '),'\s\s+')
+Test: report    not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')
 Message:  element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/unallowed-symbol-tests/extra-space-presence/pass.xml
+++ b/test/tests/gen/unallowed-symbol-tests/extra-space-presence/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="extra-space-presence.sch"?>
 <!--Context: p|td|th|title|xref|bold|italic|sub|sc|named-content|monospace|code|underline|fn|institution|ext-link
-Test: report    matches(replace(.,' ',' '),'\s\s+')
+Test: report    not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')
 Message:  element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -5931,10 +5931,10 @@
       <report test="matches(.,'&amp;#x\d')" role="warning" id="broken-unicode-presence">
         <name/> element contains what looks like a broken unicode - <value-of select="."/>.</report>
       
-      <report test="contains(.,'..')" role="warning" id="extra-full-stop-presence">
+      <report test="contains(.,'..') and not(contains(.,'...'))" role="warning" id="extra-full-stop-presence">
         <name/> element contains what looks two full stops right next to each other (..) - Is that correct? - <value-of select="."/>.</report>
       
-      <report test="matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
+      <report test="not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
         <name/> element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - <value-of select="."/>.</report>
     </rule>
   </pattern>

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -5928,10 +5928,10 @@
       <report test="matches(.,'&amp;#x\d')" role="warning" id="broken-unicode-presence">
         <name/> element contains what looks like a broken unicode - <value-of select="."/>.</report>
       
-      <report test="contains(.,'..')" role="warning" id="extra-full-stop-presence">
+      <report test="contains(.,'..') and not(contains(.,'...'))" role="warning" id="extra-full-stop-presence">
         <name/> element contains what looks two full stops right next to each other (..) - Is that correct? - <value-of select="."/>.</report>
       
-      <report test="matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
+      <report test="not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
         <name/> element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - <value-of select="."/>.</report>
     </rule>
   </pattern>

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -5926,10 +5926,10 @@
       <report test="matches(.,'&amp;#x\d')" role="warning" id="broken-unicode-presence">
         <name/> element contains what looks like a broken unicode - <value-of select="."/>.</report>
       
-      <report test="contains(.,'..')" role="warning" id="extra-full-stop-presence">
+      <report test="contains(.,'..') and not(contains(.,'...'))" role="warning" id="extra-full-stop-presence">
         <name/> element contains what looks two full stops right next to each other (..) - Is that correct? - <value-of select="."/>.</report>
       
-      <report test="matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
+      <report test="not(inline-formula|element-citation|code|disp-formula|table-wrap|list|inline-graphic|supplementary-material|break) and matches(replace(.,' ',' '),'\s\s+')" role="warning" id="extra-space-presence">
         <name/> element contains two or more spaces right next to each other - it is very likely that only 1 space is necessary - <value-of select="."/>.</report>
     </rule>
   </pattern>


### PR DESCRIPTION
- Don't fire `extra-full-stop-presence` when elipses are present.
- Don't fire `extra-space-presence` whn certain child elements are present.