### PR TITLE
perf and improvement: country tests

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -5991,7 +5991,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
+      <!--<let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>-->
       
       <report test="$text = 'United States of America'" role="error" id="united-states-test-1">
         <value-of select="."/> is not allowed it. This should be 'United States'.</report>
@@ -6010,6 +6010,12 @@
       
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
         <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">
@@ -6030,8 +6036,6 @@
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
       <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
-      
-      <report test="(parent::*/following-sibling::country[1] != 'Taiwan') and  (matches(lower-case(.),'taipei|taichung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua'))" role="warning" id="taiwan-test">Affiliaiton has a Taiwanese city <value-of select="."/> but it's country is <value-of select="parent::*/following-sibling::country[1]"/>. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -5997,7 +5997,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
+      <!--<let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>-->
       
       <report test="$text = 'United States of America'" role="error" id="united-states-test-1">
         <value-of select="."/> is not allowed it. This should be 'United States'.</report>
@@ -6016,6 +6016,12 @@
       
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
         <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">
@@ -6036,8 +6042,6 @@
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
       <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
-      
-      <report test="(parent::*/following-sibling::country[1] != 'Taiwan') and  (matches(lower-case(.),'taipei|taichung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua'))" role="warning" id="taiwan-test">Affiliaiton has a Taiwanese city <value-of select="."/> but it's country is <value-of select="parent::*/following-sibling::country[1]"/>. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -5989,7 +5989,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
+      <!--<let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>-->
       
       <report test="$text = 'United States of America'" role="error" id="united-states-test-1">
         <value-of select="."/> is not allowed it. This should be 'United States'.</report>
@@ -6008,6 +6008,12 @@
       
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
         <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">
@@ -6028,8 +6034,6 @@
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
       <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
-      
-      <report test="(parent::*/following-sibling::country[1] != 'Taiwan') and  (matches(lower-case(.),'taipei|taichung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua'))" role="warning" id="taiwan-test">Affiliaiton has a Taiwanese city <value-of select="."/> but it's country is <value-of select="parent::*/following-sibling::country[1]"/>. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -8041,7 +8041,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
+      <!--<let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>-->
       
       <report test="$text = 'United States of America'"
         role="error"
@@ -8066,6 +8066,18 @@
       <report test="(. = 'Singapore') and ($city != 'Singapore')"
         role="error"
         id="singapore-test-1"><value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))"
+        role="warning"
+        id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))"
+        role="warning"
+        id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'"
+        role="warning"
+        id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
     </rule>
     
     <rule context="front//aff//named-content[@content-type='city']"
@@ -8096,10 +8108,6 @@
       <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')"
         role="warning"
         id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
-      
-      <report test="(parent::*/following-sibling::country[1] != 'Taiwan') and  (matches(lower-case(.),'taipei|taichung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua'))"
-        role="warning"
-        id="taiwan-test">Affiliaiton has a Taiwanese city <value-of select="."/> but it's country is <value-of select="parent::*/following-sibling::country[1]"/>. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
     
     <rule context="aff/institution[not(@*)]" 

--- a/test/tests/gen/country-tests/gen-country-test/gen-country-test.sch
+++ b/test/tests/gen/country-tests/gen-country-test/gen-country-test.sch
@@ -728,7 +728,6 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
       <assert test="$text = document($countries)/countries/country" role="error" id="gen-country-test">affiliation contains a country which is not in the allowed list - <value-of select="."/>. For a list of allowed countries, refer to https://github.com/elifesciences/eLife-JATS-schematron/blob/master/src/countries.xml.</assert>
     </rule>
   </pattern>

--- a/test/tests/gen/country-tests/n-korea-test/fail.xml
+++ b/test/tests/gen/country-tests/n-korea-test/fail.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="n-korea-test.sch"?>
+<!--Context: front//aff/country
+Test: report    replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'
+Message: Affiliation has '' as it's country which is very likely to be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff id="aff8">
+        <label>8</label>
+        <institution/>
+        <addr-line><named-content content-type="city">Pyongyang</named-content></addr-line>
+        <country>Democratic People's Republic of Korea</country>
+      </aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/country-tests/n-korea-test/n-korea-test.sch
+++ b/test/tests/gen/country-tests/n-korea-test/n-korea-test.sch
@@ -728,8 +728,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
-        <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/country-tests/n-korea-test/pass.xml
+++ b/test/tests/gen/country-tests/n-korea-test/pass.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="n-korea-test.sch"?>
+<!--Context: front//aff/country
+Test: report    replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'
+Message: Affiliation has '' as it's country which is very likely to be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff id="aff8">
+        <label>8</label>
+        <institution/>
+        <addr-line><named-content content-type="city">Seoul</named-content></addr-line>
+        <country>Republic of Korea</country>
+      </aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/country-tests/s-korea-test/fail.xml
+++ b/test/tests/gen/country-tests/s-korea-test/fail.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="s-korea-test.sch"?>
+<!--Context: front//aff/country
+Test: report    (. != 'Republic of Korea') and (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))
+Message: Affiliation has a South Korean city -  - but it's country is '', instead of 'Republic of Korea'.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff id="aff8">
+        <label>8</label>
+        <institution/>
+        <addr-line><named-content content-type="city">Seoul</named-content></addr-line>
+        <country>Democtratic People's Republic of Korea</country>
+      </aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/country-tests/s-korea-test/pass.xml
+++ b/test/tests/gen/country-tests/s-korea-test/pass.xml
@@ -1,0 +1,16 @@
+<?oxygen SCHSchema="s-korea-test.sch"?>
+<!--Context: front//aff/country
+Test: report    (. != 'Republic of Korea') and (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))
+Message: Affiliation has a South Korean city -  - but it's country is '', instead of 'Republic of Korea'.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff id="aff8">
+        <label>8</label>
+        <institution/>
+        <addr-line><named-content content-type="city">Seoul</named-content></addr-line>
+        <country>Republic of Korea</country>
+      </aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/country-tests/s-korea-test/s-korea-test.sch
+++ b/test/tests/gen/country-tests/s-korea-test/s-korea-test.sch
@@ -728,8 +728,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
-        <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/country-tests/taiwan-test/fail.xml
+++ b/test/tests/gen/country-tests/taiwan-test/fail.xml
@@ -1,0 +1,11 @@
+<?oxygen SCHSchema="taiwan-test.sch"?>
+<!--Context: front//aff/country
+Test: report    (. != 'Taiwan') and (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))
+Message: Affiliation has a Taiwanese city -  - but it's country is ''. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff id="aff8"><label>8</label><institution>Department of Electrical Engineering, National Taiwan University</institution><addr-line><named-content content-type="city">Taipei</named-content></addr-line><country>China</country></aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/country-tests/taiwan-test/pass.xml
+++ b/test/tests/gen/country-tests/taiwan-test/pass.xml
@@ -1,0 +1,11 @@
+<?oxygen SCHSchema="taiwan-test.sch"?>
+<!--Context: front//aff/country
+Test: report    (. != 'Taiwan') and (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))
+Message: Affiliation has a Taiwanese city -  - but it's country is ''. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <aff id="aff8"><label>8</label><institution>Department of Electrical Engineering, National Taiwan University</institution><addr-line><named-content content-type="city">Taipei</named-content></addr-line><country>Taiwan</country></aff>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/country-tests/taiwan-test/taiwan-test.sch
+++ b/test/tests/gen/country-tests/taiwan-test/taiwan-test.sch
@@ -728,8 +728,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
-        <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/country-tests/united-kingdom-test-2/united-kingdom-test-2.sch
+++ b/test/tests/gen/country-tests/united-kingdom-test-2/united-kingdom-test-2.sch
@@ -728,7 +728,6 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
       <report test="$text = 'UK'" role="error" id="united-kingdom-test-2">
         <value-of select="."/> is not allowed it. This should be 'United Kingdom'</report>
     </rule>

--- a/test/tests/gen/country-tests/united-states-test-1/united-states-test-1.sch
+++ b/test/tests/gen/country-tests/united-states-test-1/united-states-test-1.sch
@@ -728,7 +728,6 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
       <report test="$text = 'United States of America'" role="error" id="united-states-test-1">
         <value-of select="."/> is not allowed it. This should be 'United States'.</report>
     </rule>

--- a/test/tests/gen/country-tests/united-states-test-2/united-states-test-2.sch
+++ b/test/tests/gen/country-tests/united-states-test-2/united-states-test-2.sch
@@ -728,7 +728,6 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
       <report test="$text = 'USA'" role="error" id="united-states-test-2">
         <value-of select="."/> is not allowed it. This should be 'United States'</report>
     </rule>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -5995,7 +5995,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
+      <!--<let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>-->
       
       <report test="$text = 'United States of America'" role="error" id="united-states-test-1">
         <value-of select="."/> is not allowed it. This should be 'United States'.</report>
@@ -6014,6 +6014,12 @@
       
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
         <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">
@@ -6034,8 +6040,6 @@
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
       <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
-      
-      <report test="(parent::*/following-sibling::country[1] != 'Taiwan') and  (matches(lower-case(.),'taipei|taichung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua'))" role="warning" id="taiwan-test">Affiliaiton has a Taiwanese city <value-of select="."/> but it's country is <value-of select="parent::*/following-sibling::country[1]"/>. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -12521,6 +12521,36 @@
         <x:expect-report id="singapore-test-1" role="error"/>
         <x:expect-not-assert id="country-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="taiwan-test-pass">
+        <x:context href="../tests/gen/country-tests/taiwan-test/pass.xml"/>
+        <x:expect-not-report id="taiwan-test" role="warning"/>
+        <x:expect-not-assert id="country-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="taiwan-test-fail">
+        <x:context href="../tests/gen/country-tests/taiwan-test/fail.xml"/>
+        <x:expect-report id="taiwan-test" role="warning"/>
+        <x:expect-not-assert id="country-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="s-korea-test-pass">
+        <x:context href="../tests/gen/country-tests/s-korea-test/pass.xml"/>
+        <x:expect-not-report id="s-korea-test" role="warning"/>
+        <x:expect-not-assert id="country-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="s-korea-test-fail">
+        <x:context href="../tests/gen/country-tests/s-korea-test/fail.xml"/>
+        <x:expect-report id="s-korea-test" role="warning"/>
+        <x:expect-not-assert id="country-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="n-korea-test-pass">
+        <x:context href="../tests/gen/country-tests/n-korea-test/pass.xml"/>
+        <x:expect-not-report id="n-korea-test" role="warning"/>
+        <x:expect-not-assert id="country-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="n-korea-test-fail">
+        <x:context href="../tests/gen/country-tests/n-korea-test/fail.xml"/>
+        <x:expect-report id="n-korea-test" role="warning"/>
+        <x:expect-not-assert id="country-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="city-tests">
       <x:scenario label="pre-US-states-test-pass">
@@ -12581,16 +12611,6 @@
       <x:scenario label="city-street-presence-fail">
         <x:context href="../tests/gen/city-tests/city-street-presence/fail.xml"/>
         <x:expect-report id="city-street-presence" role="warning"/>
-        <x:expect-not-assert id="city-tests-xspec-assert" role="error"/>
-      </x:scenario>
-      <x:scenario label="taiwan-test-pass">
-        <x:context href="../tests/gen/city-tests/taiwan-test/pass.xml"/>
-        <x:expect-not-report id="taiwan-test" role="warning"/>
-        <x:expect-not-assert id="city-tests-xspec-assert" role="error"/>
-      </x:scenario>
-      <x:scenario label="taiwan-test-fail">
-        <x:context href="../tests/gen/city-tests/taiwan-test/fail.xml"/>
-        <x:expect-report id="taiwan-test" role="warning"/>
         <x:expect-not-assert id="city-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -5991,7 +5991,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
+      <!--<let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>-->
       
       <report test="$text = 'United States of America'" role="error" id="united-states-test-1">
         <value-of select="."/> is not allowed it. This should be 'United States'.</report>
@@ -6010,6 +6010,12 @@
       
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
         <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">
@@ -6030,8 +6036,6 @@
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
       <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
-      
-      <report test="(parent::*/following-sibling::country[1] != 'Taiwan') and  (matches(lower-case(.),'taipei|taichung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua'))" role="warning" id="taiwan-test">Affiliaiton has a Taiwanese city <value-of select="."/> but it's country is <value-of select="parent::*/following-sibling::country[1]"/>. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -5989,7 +5989,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>
+      <!--<let name="valid-country" value="document($countries)/countries/country[text() = $text]"/>-->
       
       <report test="$text = 'United States of America'" role="error" id="united-states-test-1">
         <value-of select="."/> is not allowed it. This should be 'United States'.</report>
@@ -6008,6 +6008,12 @@
       
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
         <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
+      
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">
@@ -6028,8 +6034,6 @@
       <report test="matches(.,'\d')" role="warning" id="city-number-presence">city contains a number, which is almost certainly incorrect - <value-of select="."/>.</report>
       
       <report test="matches(lower-case(.),'^rue | rue |^street | street |^building | building |^straße | straße |^stadt | stadt |^platz | platz |^strada | strada |^cedex | cedex ')" role="warning" id="city-street-presence">city likely contains a street or building name, which is almost certainly incorrect - <value-of select="."/>.</report>
-      
-      <report test="(parent::*/following-sibling::country[1] != 'Taiwan') and  (matches(lower-case(.),'taipei|taichung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua'))" role="warning" id="taiwan-test">Affiliaiton has a Taiwanese city <value-of select="."/> but it's country is <value-of select="parent::*/following-sibling::country[1]"/>. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
   </pattern>
   <pattern id="institution-tests-pattern">


### PR DESCRIPTION
perf: Move Taiwan tests to rules which already use both city and country as variables
perf: comment out currently unnecessary variable `$valid-country`
improvement: Add tests for South and North Korea in affiliations