### PR TITLE
improvement: unicode, dataset refs and gitbook

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1457,11 +1457,11 @@
   <pattern id="funding-group-tests-pattern">
     <rule context="article-meta/funding-group" id="funding-group-tests">
 		
-		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
+		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1469,41 +1469,39 @@
 	  <let name="id" value="@id"/>
 	  <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
 		
-		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source.</assert>
+		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2</assert>
 		
-		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient.</assert>
+		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3</assert>
 		
-		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id.</report>
+		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4</report>
 		
-		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
+		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5</assert>
 		
-		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6</report>
 	  
-	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7</assert>
 	  
-	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
-      </report>
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8</report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
       
-      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>
-      </report>
+      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1</report>
       
-      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2</report>
       
-      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3</report>
       
-      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>.</report>
+      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4</report>
       
     </rule>
   </pattern>
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test</assert>
       
     </rule>
   </pattern>
@@ -1548,15 +1546,15 @@
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
       
-      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta.</assert>
+      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1</assert>
       
-      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2</report>
       
-      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta.</assert>
+      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3</assert>
       
-      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14</report>
       
-      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15</report>
       
     </rule>
   </pattern>
@@ -1566,28 +1564,27 @@
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
       <report test="not(child::*) and normalize-space(.)=''" role="error" id="custom-meta-test-4">The value of meta-value cannot be empty</report>
       
-      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed.</report>
+      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5</report>
       
-      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark.</assert>
+      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-6</assert>
       
-      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.</report>
+      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7</report>
       
-      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
-      
-      
-      
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
-      
-      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
-      
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
-      
-      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
+      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8</report>
       
       
       
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>
-      </report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-9</report>
+      
+      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10</report>
+      
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11</report>
+      
+      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13</report>
+      
+      
+      
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-rep-study-custom-meta-test</report>
     </rule>
   </pattern>
   <pattern id="meta-value-child-tests-pattern">
@@ -1595,7 +1592,7 @@
       <let name="allowed-elements" value="('italic','sup','sub')"/>
       
       <assert test="local-name() = $allowed-elements" role="error" id="custom-meta-child-test-1">
-        <name/> is not allowed in impact statement.</assert>
+        <name/> is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1</assert>
       
     </rule>
   </pattern>
@@ -4917,9 +4914,9 @@
      <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]"/>
      <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]/*)"/>
      
-     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1</assert>
      
-     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2</assert>
      
    </rule>
   </pattern>
@@ -6236,6 +6233,8 @@
       
       <report test="matches(lower-case(source[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
+      <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
+      
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
@@ -6282,11 +6281,15 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
       
       <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')" role="warning" id="data-empiar-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-empiar-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
       
@@ -6897,6 +6900,285 @@
       
       <report test="some $funder in document($funders)//funder satisfies ((contains($ack,concat(' ',$funder,' ')) or contains($ack,concat(' ',$funder,'.'))) and not($funder/@fundref = $funding-group))" role="warning" id="fundref-test-1">Acknowledgements contains funder(s) in the open funder registry, but their doi is not listed in the funding section. Please check - <value-of select="string-join(for $x in document($funders)//funder[((contains($ack,concat(' ',.,' ')) or contains($ack,concat(' ',.,'.'))) and not(@fundref = $funding-group))] return concat($x,' - ',$x/@fundref),'; ')"/>.</report>
     </rule>
+  </pattern>
+  
+  <pattern id="unicode-tests-pattern">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+    
+    
+    <report test="contains(.,'â‚¬')" role="warning" id="unicode-test-1">
+        <name/> element contains 'â‚¬' - this should instead be the character '€'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã€')" role="warning" id="unicode-test-2">
+        <name/> element contains 'Ã€' - this should instead be the character 'À'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-3">
+        <name/> element contains 'Ã' - this should instead be the character 'Á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€š')" role="warning" id="unicode-test-4">
+        <name/> element contains 'â€š' - this should instead be the character '‚'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‚')" role="warning" id="unicode-test-5">
+        <name/> element contains 'Ã‚' - this should instead be the character 'Â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Æ’')" role="warning" id="unicode-test-6">
+        <name/> element contains 'Æ’' - this should instead be the character 'ƒ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãƒ')" role="warning" id="unicode-test-7">
+        <name/> element contains 'Ãƒ' - this should instead be the character 'Ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€ž')" role="warning" id="unicode-test-8">
+        <name/> element contains 'â€ž' - this should instead be the character '„'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã„')" role="warning" id="unicode-test-9">
+        <name/> element contains 'Ã„' - this should instead be the character 'Ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¦')" role="warning" id="unicode-test-10">
+        <name/> element contains 'â€¦' - this should instead be the character '…'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã…')" role="warning" id="unicode-test-11">
+        <name/> element contains 'Ã…' - this should instead be the character 'Å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã†')" role="warning" id="unicode-test-13">
+        <name/> element contains 'Ã†' - this should instead be the character 'Æ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¡')" role="warning" id="unicode-test-14">
+        <name/> element contains 'â€¡' - this should instead be the character '‡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‡')" role="warning" id="unicode-test-15">
+        <name/> element contains 'Ã‡' - this should instead be the character 'Ç'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ë†')" role="warning" id="unicode-test-16">
+        <name/> element contains 'Ë†' - this should instead be the character 'ˆ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãˆ')" role="warning" id="unicode-test-17">
+        <name/> element contains 'Ãˆ' - this should instead be the character 'È'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€°')" role="warning" id="unicode-test-18">
+        <name/> element contains 'â€°' - this should instead be the character '‰'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‰')" role="warning" id="unicode-test-19">
+        <name/> element contains 'Ã‰' - this should instead be the character 'É'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŠ')" role="warning" id="unicode-test-21">
+        <name/> element contains 'ÃŠ' - this should instead be the character 'Ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¹')" role="warning" id="unicode-test-22">
+        <name/> element contains 'â€¹' - this should instead be the character '‹'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‹')" role="warning" id="unicode-test-23">
+        <name/> element contains 'Ã‹' - this should instead be the character 'Ë'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å’')" role="warning" id="unicode-test-24">
+        <name/> element contains 'Å’' - this should instead be the character 'Œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŒ')" role="warning" id="unicode-test-25">
+        <name/> element contains 'ÃŒ' - this should instead be the character 'Ì'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-26">
+        <name/> element contains 'Ã' - this should instead be the character 'Í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å½')" role="warning" id="unicode-test-27">
+        <name/> element contains 'Å½' - this should instead be the character 'Ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŽ')" role="warning" id="unicode-test-28">
+        <name/> element contains 'ÃŽ' - this should instead be the character 'Î'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-29">
+        <name/> element contains 'Ã' - this should instead be the character 'Ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-30">
+        <name/> element contains 'Ã' - this should instead be the character 'Ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€˜')" role="warning" id="unicode-test-31">
+        <name/> element contains 'â€˜' - this should instead be the character '‘'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‘')" role="warning" id="unicode-test-32">
+        <name/> element contains 'Ã‘' - this should instead be the character 'Ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€™')" role="warning" id="unicode-test-33">
+        <name/> element contains 'â€™' - this should instead be the character '’'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã’')" role="warning" id="unicode-test-34">
+        <name/> element contains 'Ã’' - this should instead be the character 'Ò'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€œ')" role="warning" id="unicode-test-35">
+        <name/> element contains 'â€œ' - this should instead be the character '“'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã“')" role="warning" id="unicode-test-36">
+        <name/> element contains 'Ã“' - this should instead be the character 'Ó'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€')" role="warning" id="unicode-test-37">
+        <name/> element contains 'â€' - this should instead be the character '”'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã”')" role="warning" id="unicode-test-38">
+        <name/> element contains 'Ã”' - this should instead be the character 'Ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã•')" role="warning" id="unicode-test-39">
+        <name/> element contains 'Ã•' - this should instead be the character 'Õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€“')" role="warning" id="unicode-test-40">
+        <name/> element contains 'â€“' - this should instead be the character '–'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã–')" role="warning" id="unicode-test-41">
+        <name/> element contains 'Ã–' - this should instead be the character 'Ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€”')" role="warning" id="unicode-test-42">
+        <name/> element contains 'â€”' - this should instead be the character '—'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã—')" role="warning" id="unicode-test-43">
+        <name/> element contains 'Ã—' - this should instead be the character '×'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ëœ')" role="warning" id="unicode-test-44">
+        <name/> element contains 'Ëœ' - this should instead be the character '˜'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã˜')" role="warning" id="unicode-test-45">
+        <name/> element contains 'Ã˜' - this should instead be the character 'Ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã™')" role="warning" id="unicode-test-46">
+        <name/> element contains 'Ã™' - this should instead be the character 'Ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¡')" role="warning" id="unicode-test-47">
+        <name/> element contains 'Å¡' - this should instead be the character 'š'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãš')" role="warning" id="unicode-test-48">
+        <name/> element contains 'Ãš' - this should instead be the character 'Ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€º')" role="warning" id="unicode-test-49">
+        <name/> element contains 'â€º' - this should instead be the character '›'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã›')" role="warning" id="unicode-test-50">
+        <name/> element contains 'Ã›' - this should instead be the character 'Û'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å“')" role="warning" id="unicode-test-51">
+        <name/> element contains 'Å“' - this should instead be the character 'œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãœ')" role="warning" id="unicode-test-52">
+        <name/> element contains 'Ãœ' - this should instead be the character 'Ü'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-53">
+        <name/> element contains 'Ã' - this should instead be the character 'Ý'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¾')" role="warning" id="unicode-test-54">
+        <name/> element contains 'Å¾' - this should instead be the character 'ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãž')" role="warning" id="unicode-test-55">
+        <name/> element contains 'Ãž' - this should instead be the character 'Þ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¸')" role="warning" id="unicode-test-56">
+        <name/> element contains 'Å¸' - this should instead be the character 'Ÿ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŸ')" role="warning" id="unicode-test-57">
+        <name/> element contains 'ÃŸ' - this should instead be the character 'ß'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¡')" role="warning" id="unicode-test-58">
+        <name/> element contains 'Â¡' - this should instead be the character '¡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¡')" role="warning" id="unicode-test-59">
+        <name/> element contains 'Ã¡' - this should instead be the character 'á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¢')" role="warning" id="unicode-test-60">
+        <name/> element contains 'Â¢' - this should instead be the character '¢'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¢')" role="warning" id="unicode-test-61">
+        <name/> element contains 'Ã¢' - this should instead be the character 'â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â£')" role="warning" id="unicode-test-62">
+        <name/> element contains 'Â£' - this should instead be the character '£'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã£')" role="warning" id="unicode-test-63">
+        <name/> element contains 'Ã£' - this should instead be the character 'ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¤')" role="warning" id="unicode-test-64">
+        <name/> element contains 'Â¤' - this should instead be the character '¤'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¤')" role="warning" id="unicode-test-65">
+        <name/> element contains 'Ã¤' - this should instead be the character 'ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¥')" role="warning" id="unicode-test-66">
+        <name/> element contains 'Ã¥' - this should instead be the character 'å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¨')" role="warning" id="unicode-test-67">
+        <name/> element contains 'Â¨' - this should instead be the character '¨'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¨')" role="warning" id="unicode-test-68">
+        <name/> element contains 'Ã¨' - this should instead be the character 'è'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âª')" role="warning" id="unicode-test-69">
+        <name/> element contains 'Âª' - this should instead be the character 'ª'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãª')" role="warning" id="unicode-test-70">
+        <name/> element contains 'Ãª' - this should instead be the character 'ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â­')" role="warning" id="unicode-test-71">
+        <name/> element contains 'Â­' - this should instead be the character '­'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã­')" role="warning" id="unicode-test-72">
+        <name/> element contains 'Ã­' - this should instead be the character 'í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¯')" role="warning" id="unicode-test-73">
+        <name/> element contains 'Â¯' - this should instead be the character '¯'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¯')" role="warning" id="unicode-test-74">
+        <name/> element contains 'Ã¯' - this should instead be the character 'ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â°')" role="warning" id="unicode-test-75">
+        <name/> element contains 'Â°' - this should instead be the character '°'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã°')" role="warning" id="unicode-test-76">
+        <name/> element contains 'Ã°' - this should instead be the character 'ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â±')" role="warning" id="unicode-test-77">
+        <name/> element contains 'Â±' - this should instead be the character '±'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã±')" role="warning" id="unicode-test-78">
+        <name/> element contains 'Ã±' - this should instead be the character 'ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â´')" role="warning" id="unicode-test-79">
+        <name/> element contains 'Â´' - this should instead be the character '´'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã´')" role="warning" id="unicode-test-80">
+        <name/> element contains 'Ã´' - this should instead be the character 'ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âµ')" role="warning" id="unicode-test-81">
+        <name/> element contains 'Âµ' - this should instead be the character 'µ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãµ')" role="warning" id="unicode-test-82">
+        <name/> element contains 'Ãµ' - this should instead be the character 'õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¶')" role="warning" id="unicode-test-83">
+        <name/> element contains 'Â¶' - this should instead be the character '¶'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¶')" role="warning" id="unicode-test-84">
+        <name/> element contains 'Ã¶' - this should instead be the character 'ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â·')" role="warning" id="unicode-test-85">
+        <name/> element contains 'Â·' - this should instead be the character '·'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã·')" role="warning" id="unicode-test-86">
+        <name/> element contains 'Ã·' - this should instead be the character '÷'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¸')" role="warning" id="unicode-test-87">
+        <name/> element contains 'Â¸' - this should instead be the character '¸'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¸')" role="warning" id="unicode-test-88">
+        <name/> element contains 'Ã¸' - this should instead be the character 'ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¹')" role="warning" id="unicode-test-89">
+        <name/> element contains 'Ã¹' - this should instead be the character 'ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âº')" role="warning" id="unicode-test-90">
+        <name/> element contains 'Âº' - this should instead be the character 'º'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãº')" role="warning" id="unicode-test-91">
+        <name/> element contains 'Ãº' - this should instead be the character 'ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¿')" role="warning" id="unicode-test-92">
+        <name/> element contains 'Â¿' - this should instead be the character '¿'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¿')" role="warning" id="unicode-test-93">
+        <name/> element contains 'Ã¿' - this should instead be the character 'ÿ'. - <value-of select="."/>.</report>
+</rule>
   </pattern>
   
   <pattern id="element-whitelist-pattern">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1463,11 +1463,11 @@
   <pattern id="funding-group-tests-pattern">
     <rule context="article-meta/funding-group" id="funding-group-tests">
 		
-		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
+		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1475,41 +1475,39 @@
 	  <let name="id" value="@id"/>
 	  <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
 		
-		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source.</assert>
+		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2</assert>
 		
-		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient.</assert>
+		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3</assert>
 		
-		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id.</report>
+		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4</report>
 		
-		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
+		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5</assert>
 		
-		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6</report>
 	  
-	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7</assert>
 	  
-	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
-      </report>
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8</report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
       
-      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>
-      </report>
+      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1</report>
       
-      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2</report>
       
-      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3</report>
       
-      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>.</report>
+      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4</report>
       
     </rule>
   </pattern>
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test</assert>
       
     </rule>
   </pattern>
@@ -1554,15 +1552,15 @@
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
       
-      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta.</assert>
+      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1</assert>
       
-      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2</report>
       
-      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta.</assert>
+      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3</assert>
       
-      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14</report>
       
-      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15</report>
       
     </rule>
   </pattern>
@@ -1572,28 +1570,27 @@
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
       <report test="not(child::*) and normalize-space(.)=''" role="error" id="custom-meta-test-4">The value of meta-value cannot be empty</report>
       
-      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed.</report>
+      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5</report>
       
-      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark.</assert>
+      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-6</assert>
       
-      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.</report>
+      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7</report>
       
-      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
-      
-      
-      
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
-      
-      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
-      
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
-      
-      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
+      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8</report>
       
       
       
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>
-      </report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-9</report>
+      
+      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10</report>
+      
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11</report>
+      
+      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13</report>
+      
+      
+      
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-rep-study-custom-meta-test</report>
     </rule>
   </pattern>
   <pattern id="meta-value-child-tests-pattern">
@@ -1601,7 +1598,7 @@
       <let name="allowed-elements" value="('italic','sup','sub')"/>
       
       <assert test="local-name() = $allowed-elements" role="error" id="custom-meta-child-test-1">
-        <name/> is not allowed in impact statement.</assert>
+        <name/> is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1</assert>
       
     </rule>
   </pattern>
@@ -4923,9 +4920,9 @@
      <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]"/>
      <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]/*)"/>
      
-     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1</assert>
      
-     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2</assert>
      
    </rule>
   </pattern>
@@ -6242,6 +6239,8 @@
       
       <report test="matches(lower-case(source[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
+      <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
+      
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
@@ -6288,11 +6287,15 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
       
       <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')" role="warning" id="data-empiar-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-empiar-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
       
@@ -6903,6 +6906,285 @@
       
       <report test="some $funder in document($funders)//funder satisfies ((contains($ack,concat(' ',$funder,' ')) or contains($ack,concat(' ',$funder,'.'))) and not($funder/@fundref = $funding-group))" role="warning" id="fundref-test-1">Acknowledgements contains funder(s) in the open funder registry, but their doi is not listed in the funding section. Please check - <value-of select="string-join(for $x in document($funders)//funder[((contains($ack,concat(' ',.,' ')) or contains($ack,concat(' ',.,'.'))) and not(@fundref = $funding-group))] return concat($x,' - ',$x/@fundref),'; ')"/>.</report>
     </rule>
+  </pattern>
+  
+  <pattern id="unicode-tests-pattern">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+    
+    
+    <report test="contains(.,'â‚¬')" role="warning" id="unicode-test-1">
+        <name/> element contains 'â‚¬' - this should instead be the character '€'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã€')" role="warning" id="unicode-test-2">
+        <name/> element contains 'Ã€' - this should instead be the character 'À'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-3">
+        <name/> element contains 'Ã' - this should instead be the character 'Á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€š')" role="warning" id="unicode-test-4">
+        <name/> element contains 'â€š' - this should instead be the character '‚'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‚')" role="warning" id="unicode-test-5">
+        <name/> element contains 'Ã‚' - this should instead be the character 'Â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Æ’')" role="warning" id="unicode-test-6">
+        <name/> element contains 'Æ’' - this should instead be the character 'ƒ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãƒ')" role="warning" id="unicode-test-7">
+        <name/> element contains 'Ãƒ' - this should instead be the character 'Ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€ž')" role="warning" id="unicode-test-8">
+        <name/> element contains 'â€ž' - this should instead be the character '„'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã„')" role="warning" id="unicode-test-9">
+        <name/> element contains 'Ã„' - this should instead be the character 'Ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¦')" role="warning" id="unicode-test-10">
+        <name/> element contains 'â€¦' - this should instead be the character '…'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã…')" role="warning" id="unicode-test-11">
+        <name/> element contains 'Ã…' - this should instead be the character 'Å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã†')" role="warning" id="unicode-test-13">
+        <name/> element contains 'Ã†' - this should instead be the character 'Æ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¡')" role="warning" id="unicode-test-14">
+        <name/> element contains 'â€¡' - this should instead be the character '‡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‡')" role="warning" id="unicode-test-15">
+        <name/> element contains 'Ã‡' - this should instead be the character 'Ç'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ë†')" role="warning" id="unicode-test-16">
+        <name/> element contains 'Ë†' - this should instead be the character 'ˆ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãˆ')" role="warning" id="unicode-test-17">
+        <name/> element contains 'Ãˆ' - this should instead be the character 'È'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€°')" role="warning" id="unicode-test-18">
+        <name/> element contains 'â€°' - this should instead be the character '‰'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‰')" role="warning" id="unicode-test-19">
+        <name/> element contains 'Ã‰' - this should instead be the character 'É'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŠ')" role="warning" id="unicode-test-21">
+        <name/> element contains 'ÃŠ' - this should instead be the character 'Ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¹')" role="warning" id="unicode-test-22">
+        <name/> element contains 'â€¹' - this should instead be the character '‹'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‹')" role="warning" id="unicode-test-23">
+        <name/> element contains 'Ã‹' - this should instead be the character 'Ë'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å’')" role="warning" id="unicode-test-24">
+        <name/> element contains 'Å’' - this should instead be the character 'Œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŒ')" role="warning" id="unicode-test-25">
+        <name/> element contains 'ÃŒ' - this should instead be the character 'Ì'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-26">
+        <name/> element contains 'Ã' - this should instead be the character 'Í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å½')" role="warning" id="unicode-test-27">
+        <name/> element contains 'Å½' - this should instead be the character 'Ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŽ')" role="warning" id="unicode-test-28">
+        <name/> element contains 'ÃŽ' - this should instead be the character 'Î'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-29">
+        <name/> element contains 'Ã' - this should instead be the character 'Ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-30">
+        <name/> element contains 'Ã' - this should instead be the character 'Ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€˜')" role="warning" id="unicode-test-31">
+        <name/> element contains 'â€˜' - this should instead be the character '‘'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‘')" role="warning" id="unicode-test-32">
+        <name/> element contains 'Ã‘' - this should instead be the character 'Ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€™')" role="warning" id="unicode-test-33">
+        <name/> element contains 'â€™' - this should instead be the character '’'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã’')" role="warning" id="unicode-test-34">
+        <name/> element contains 'Ã’' - this should instead be the character 'Ò'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€œ')" role="warning" id="unicode-test-35">
+        <name/> element contains 'â€œ' - this should instead be the character '“'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã“')" role="warning" id="unicode-test-36">
+        <name/> element contains 'Ã“' - this should instead be the character 'Ó'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€')" role="warning" id="unicode-test-37">
+        <name/> element contains 'â€' - this should instead be the character '”'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã”')" role="warning" id="unicode-test-38">
+        <name/> element contains 'Ã”' - this should instead be the character 'Ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã•')" role="warning" id="unicode-test-39">
+        <name/> element contains 'Ã•' - this should instead be the character 'Õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€“')" role="warning" id="unicode-test-40">
+        <name/> element contains 'â€“' - this should instead be the character '–'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã–')" role="warning" id="unicode-test-41">
+        <name/> element contains 'Ã–' - this should instead be the character 'Ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€”')" role="warning" id="unicode-test-42">
+        <name/> element contains 'â€”' - this should instead be the character '—'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã—')" role="warning" id="unicode-test-43">
+        <name/> element contains 'Ã—' - this should instead be the character '×'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ëœ')" role="warning" id="unicode-test-44">
+        <name/> element contains 'Ëœ' - this should instead be the character '˜'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã˜')" role="warning" id="unicode-test-45">
+        <name/> element contains 'Ã˜' - this should instead be the character 'Ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã™')" role="warning" id="unicode-test-46">
+        <name/> element contains 'Ã™' - this should instead be the character 'Ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¡')" role="warning" id="unicode-test-47">
+        <name/> element contains 'Å¡' - this should instead be the character 'š'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãš')" role="warning" id="unicode-test-48">
+        <name/> element contains 'Ãš' - this should instead be the character 'Ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€º')" role="warning" id="unicode-test-49">
+        <name/> element contains 'â€º' - this should instead be the character '›'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã›')" role="warning" id="unicode-test-50">
+        <name/> element contains 'Ã›' - this should instead be the character 'Û'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å“')" role="warning" id="unicode-test-51">
+        <name/> element contains 'Å“' - this should instead be the character 'œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãœ')" role="warning" id="unicode-test-52">
+        <name/> element contains 'Ãœ' - this should instead be the character 'Ü'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-53">
+        <name/> element contains 'Ã' - this should instead be the character 'Ý'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¾')" role="warning" id="unicode-test-54">
+        <name/> element contains 'Å¾' - this should instead be the character 'ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãž')" role="warning" id="unicode-test-55">
+        <name/> element contains 'Ãž' - this should instead be the character 'Þ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¸')" role="warning" id="unicode-test-56">
+        <name/> element contains 'Å¸' - this should instead be the character 'Ÿ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŸ')" role="warning" id="unicode-test-57">
+        <name/> element contains 'ÃŸ' - this should instead be the character 'ß'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¡')" role="warning" id="unicode-test-58">
+        <name/> element contains 'Â¡' - this should instead be the character '¡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¡')" role="warning" id="unicode-test-59">
+        <name/> element contains 'Ã¡' - this should instead be the character 'á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¢')" role="warning" id="unicode-test-60">
+        <name/> element contains 'Â¢' - this should instead be the character '¢'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¢')" role="warning" id="unicode-test-61">
+        <name/> element contains 'Ã¢' - this should instead be the character 'â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â£')" role="warning" id="unicode-test-62">
+        <name/> element contains 'Â£' - this should instead be the character '£'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã£')" role="warning" id="unicode-test-63">
+        <name/> element contains 'Ã£' - this should instead be the character 'ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¤')" role="warning" id="unicode-test-64">
+        <name/> element contains 'Â¤' - this should instead be the character '¤'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¤')" role="warning" id="unicode-test-65">
+        <name/> element contains 'Ã¤' - this should instead be the character 'ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¥')" role="warning" id="unicode-test-66">
+        <name/> element contains 'Ã¥' - this should instead be the character 'å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¨')" role="warning" id="unicode-test-67">
+        <name/> element contains 'Â¨' - this should instead be the character '¨'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¨')" role="warning" id="unicode-test-68">
+        <name/> element contains 'Ã¨' - this should instead be the character 'è'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âª')" role="warning" id="unicode-test-69">
+        <name/> element contains 'Âª' - this should instead be the character 'ª'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãª')" role="warning" id="unicode-test-70">
+        <name/> element contains 'Ãª' - this should instead be the character 'ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â­')" role="warning" id="unicode-test-71">
+        <name/> element contains 'Â­' - this should instead be the character '­'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã­')" role="warning" id="unicode-test-72">
+        <name/> element contains 'Ã­' - this should instead be the character 'í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¯')" role="warning" id="unicode-test-73">
+        <name/> element contains 'Â¯' - this should instead be the character '¯'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¯')" role="warning" id="unicode-test-74">
+        <name/> element contains 'Ã¯' - this should instead be the character 'ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â°')" role="warning" id="unicode-test-75">
+        <name/> element contains 'Â°' - this should instead be the character '°'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã°')" role="warning" id="unicode-test-76">
+        <name/> element contains 'Ã°' - this should instead be the character 'ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â±')" role="warning" id="unicode-test-77">
+        <name/> element contains 'Â±' - this should instead be the character '±'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã±')" role="warning" id="unicode-test-78">
+        <name/> element contains 'Ã±' - this should instead be the character 'ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â´')" role="warning" id="unicode-test-79">
+        <name/> element contains 'Â´' - this should instead be the character '´'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã´')" role="warning" id="unicode-test-80">
+        <name/> element contains 'Ã´' - this should instead be the character 'ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âµ')" role="warning" id="unicode-test-81">
+        <name/> element contains 'Âµ' - this should instead be the character 'µ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãµ')" role="warning" id="unicode-test-82">
+        <name/> element contains 'Ãµ' - this should instead be the character 'õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¶')" role="warning" id="unicode-test-83">
+        <name/> element contains 'Â¶' - this should instead be the character '¶'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¶')" role="warning" id="unicode-test-84">
+        <name/> element contains 'Ã¶' - this should instead be the character 'ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â·')" role="warning" id="unicode-test-85">
+        <name/> element contains 'Â·' - this should instead be the character '·'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã·')" role="warning" id="unicode-test-86">
+        <name/> element contains 'Ã·' - this should instead be the character '÷'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¸')" role="warning" id="unicode-test-87">
+        <name/> element contains 'Â¸' - this should instead be the character '¸'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¸')" role="warning" id="unicode-test-88">
+        <name/> element contains 'Ã¸' - this should instead be the character 'ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¹')" role="warning" id="unicode-test-89">
+        <name/> element contains 'Ã¹' - this should instead be the character 'ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âº')" role="warning" id="unicode-test-90">
+        <name/> element contains 'Âº' - this should instead be the character 'º'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãº')" role="warning" id="unicode-test-91">
+        <name/> element contains 'Ãº' - this should instead be the character 'ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¿')" role="warning" id="unicode-test-92">
+        <name/> element contains 'Â¿' - this should instead be the character '¿'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¿')" role="warning" id="unicode-test-93">
+        <name/> element contains 'Ã¿' - this should instead be the character 'ÿ'. - <value-of select="."/>.</report>
+</rule>
   </pattern>
   
   <pattern id="element-whitelist-pattern">

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1455,11 +1455,11 @@
   <pattern id="funding-group-tests-pattern">
     <rule context="article-meta/funding-group" id="funding-group-tests">
 		
-		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
+		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1467,41 +1467,39 @@
 	  <let name="id" value="@id"/>
 	  <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
 		
-		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source.</assert>
+		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2</assert>
 		
-		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient.</assert>
+		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3</assert>
 		
-		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id.</report>
+		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4</report>
 		
-		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
+		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5</assert>
 		
-		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6</report>
 	  
-	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7</assert>
 	  
-	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
-      </report>
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8</report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
       
-      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>
-      </report>
+      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1</report>
       
-      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2</report>
       
-      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3</report>
       
-      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>.</report>
+      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4</report>
       
     </rule>
   </pattern>
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test</assert>
       
     </rule>
   </pattern>
@@ -1546,15 +1544,15 @@
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
       
-      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta.</assert>
+      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1</assert>
       
-      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2</report>
       
-      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta.</assert>
+      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3</assert>
       
-      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14</report>
       
-      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15</report>
       
     </rule>
   </pattern>
@@ -1564,25 +1562,25 @@
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
       <report test="not(child::*) and normalize-space(.)=''" role="error" id="custom-meta-test-4">The value of meta-value cannot be empty</report>
       
-      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed.</report>
+      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5</report>
       
       
       
-      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.</report>
+      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7</report>
       
-      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
+      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8</report>
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-custom-meta-test-9</report>
       
       
       
-      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
+      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11</report>
       
-      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
+      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13</report>
       
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="warning" id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>.</report>
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="warning" id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-rep-study-custom-meta-test</report>
       
       
     </rule>
@@ -1592,7 +1590,7 @@
       <let name="allowed-elements" value="('italic','sup','sub')"/>
       
       <assert test="local-name() = $allowed-elements" role="error" id="custom-meta-child-test-1">
-        <name/> is not allowed in impact statement.</assert>
+        <name/> is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1</assert>
       
     </rule>
   </pattern>
@@ -4915,9 +4913,9 @@
      <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]"/>
      <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]/*)"/>
      
-     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1</assert>
      
-     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2</assert>
      
    </rule>
   </pattern>
@@ -6234,6 +6232,8 @@
       
       <report test="matches(lower-case(source[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
+      <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
+      
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
@@ -6280,11 +6280,15 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
       
       <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')" role="warning" id="data-empiar-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-empiar-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
       
@@ -6895,6 +6899,285 @@
       
       <report test="some $funder in document($funders)//funder satisfies ((contains($ack,concat(' ',$funder,' ')) or contains($ack,concat(' ',$funder,'.'))) and not($funder/@fundref = $funding-group))" role="warning" id="fundref-test-1">Acknowledgements contains funder(s) in the open funder registry, but their doi is not listed in the funding section. Please check - <value-of select="string-join(for $x in document($funders)//funder[((contains($ack,concat(' ',.,' ')) or contains($ack,concat(' ',.,'.'))) and not(@fundref = $funding-group))] return concat($x,' - ',$x/@fundref),'; ')"/>.</report>
     </rule>
+  </pattern>
+  
+  <pattern id="unicode-tests-pattern">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+    
+    
+    <report test="contains(.,'â‚¬')" role="warning" id="unicode-test-1">
+        <name/> element contains 'â‚¬' - this should instead be the character '€'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã€')" role="warning" id="unicode-test-2">
+        <name/> element contains 'Ã€' - this should instead be the character 'À'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-3">
+        <name/> element contains 'Ã' - this should instead be the character 'Á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€š')" role="warning" id="unicode-test-4">
+        <name/> element contains 'â€š' - this should instead be the character '‚'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‚')" role="warning" id="unicode-test-5">
+        <name/> element contains 'Ã‚' - this should instead be the character 'Â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Æ’')" role="warning" id="unicode-test-6">
+        <name/> element contains 'Æ’' - this should instead be the character 'ƒ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãƒ')" role="warning" id="unicode-test-7">
+        <name/> element contains 'Ãƒ' - this should instead be the character 'Ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€ž')" role="warning" id="unicode-test-8">
+        <name/> element contains 'â€ž' - this should instead be the character '„'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã„')" role="warning" id="unicode-test-9">
+        <name/> element contains 'Ã„' - this should instead be the character 'Ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¦')" role="warning" id="unicode-test-10">
+        <name/> element contains 'â€¦' - this should instead be the character '…'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã…')" role="warning" id="unicode-test-11">
+        <name/> element contains 'Ã…' - this should instead be the character 'Å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã†')" role="warning" id="unicode-test-13">
+        <name/> element contains 'Ã†' - this should instead be the character 'Æ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¡')" role="warning" id="unicode-test-14">
+        <name/> element contains 'â€¡' - this should instead be the character '‡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‡')" role="warning" id="unicode-test-15">
+        <name/> element contains 'Ã‡' - this should instead be the character 'Ç'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ë†')" role="warning" id="unicode-test-16">
+        <name/> element contains 'Ë†' - this should instead be the character 'ˆ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãˆ')" role="warning" id="unicode-test-17">
+        <name/> element contains 'Ãˆ' - this should instead be the character 'È'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€°')" role="warning" id="unicode-test-18">
+        <name/> element contains 'â€°' - this should instead be the character '‰'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‰')" role="warning" id="unicode-test-19">
+        <name/> element contains 'Ã‰' - this should instead be the character 'É'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŠ')" role="warning" id="unicode-test-21">
+        <name/> element contains 'ÃŠ' - this should instead be the character 'Ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¹')" role="warning" id="unicode-test-22">
+        <name/> element contains 'â€¹' - this should instead be the character '‹'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‹')" role="warning" id="unicode-test-23">
+        <name/> element contains 'Ã‹' - this should instead be the character 'Ë'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å’')" role="warning" id="unicode-test-24">
+        <name/> element contains 'Å’' - this should instead be the character 'Œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŒ')" role="warning" id="unicode-test-25">
+        <name/> element contains 'ÃŒ' - this should instead be the character 'Ì'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-26">
+        <name/> element contains 'Ã' - this should instead be the character 'Í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å½')" role="warning" id="unicode-test-27">
+        <name/> element contains 'Å½' - this should instead be the character 'Ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŽ')" role="warning" id="unicode-test-28">
+        <name/> element contains 'ÃŽ' - this should instead be the character 'Î'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-29">
+        <name/> element contains 'Ã' - this should instead be the character 'Ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-30">
+        <name/> element contains 'Ã' - this should instead be the character 'Ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€˜')" role="warning" id="unicode-test-31">
+        <name/> element contains 'â€˜' - this should instead be the character '‘'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‘')" role="warning" id="unicode-test-32">
+        <name/> element contains 'Ã‘' - this should instead be the character 'Ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€™')" role="warning" id="unicode-test-33">
+        <name/> element contains 'â€™' - this should instead be the character '’'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã’')" role="warning" id="unicode-test-34">
+        <name/> element contains 'Ã’' - this should instead be the character 'Ò'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€œ')" role="warning" id="unicode-test-35">
+        <name/> element contains 'â€œ' - this should instead be the character '“'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã“')" role="warning" id="unicode-test-36">
+        <name/> element contains 'Ã“' - this should instead be the character 'Ó'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€')" role="warning" id="unicode-test-37">
+        <name/> element contains 'â€' - this should instead be the character '”'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã”')" role="warning" id="unicode-test-38">
+        <name/> element contains 'Ã”' - this should instead be the character 'Ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã•')" role="warning" id="unicode-test-39">
+        <name/> element contains 'Ã•' - this should instead be the character 'Õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€“')" role="warning" id="unicode-test-40">
+        <name/> element contains 'â€“' - this should instead be the character '–'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã–')" role="warning" id="unicode-test-41">
+        <name/> element contains 'Ã–' - this should instead be the character 'Ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€”')" role="warning" id="unicode-test-42">
+        <name/> element contains 'â€”' - this should instead be the character '—'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã—')" role="warning" id="unicode-test-43">
+        <name/> element contains 'Ã—' - this should instead be the character '×'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ëœ')" role="warning" id="unicode-test-44">
+        <name/> element contains 'Ëœ' - this should instead be the character '˜'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã˜')" role="warning" id="unicode-test-45">
+        <name/> element contains 'Ã˜' - this should instead be the character 'Ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã™')" role="warning" id="unicode-test-46">
+        <name/> element contains 'Ã™' - this should instead be the character 'Ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¡')" role="warning" id="unicode-test-47">
+        <name/> element contains 'Å¡' - this should instead be the character 'š'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãš')" role="warning" id="unicode-test-48">
+        <name/> element contains 'Ãš' - this should instead be the character 'Ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€º')" role="warning" id="unicode-test-49">
+        <name/> element contains 'â€º' - this should instead be the character '›'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã›')" role="warning" id="unicode-test-50">
+        <name/> element contains 'Ã›' - this should instead be the character 'Û'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å“')" role="warning" id="unicode-test-51">
+        <name/> element contains 'Å“' - this should instead be the character 'œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãœ')" role="warning" id="unicode-test-52">
+        <name/> element contains 'Ãœ' - this should instead be the character 'Ü'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-53">
+        <name/> element contains 'Ã' - this should instead be the character 'Ý'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¾')" role="warning" id="unicode-test-54">
+        <name/> element contains 'Å¾' - this should instead be the character 'ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãž')" role="warning" id="unicode-test-55">
+        <name/> element contains 'Ãž' - this should instead be the character 'Þ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¸')" role="warning" id="unicode-test-56">
+        <name/> element contains 'Å¸' - this should instead be the character 'Ÿ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŸ')" role="warning" id="unicode-test-57">
+        <name/> element contains 'ÃŸ' - this should instead be the character 'ß'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¡')" role="warning" id="unicode-test-58">
+        <name/> element contains 'Â¡' - this should instead be the character '¡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¡')" role="warning" id="unicode-test-59">
+        <name/> element contains 'Ã¡' - this should instead be the character 'á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¢')" role="warning" id="unicode-test-60">
+        <name/> element contains 'Â¢' - this should instead be the character '¢'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¢')" role="warning" id="unicode-test-61">
+        <name/> element contains 'Ã¢' - this should instead be the character 'â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â£')" role="warning" id="unicode-test-62">
+        <name/> element contains 'Â£' - this should instead be the character '£'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã£')" role="warning" id="unicode-test-63">
+        <name/> element contains 'Ã£' - this should instead be the character 'ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¤')" role="warning" id="unicode-test-64">
+        <name/> element contains 'Â¤' - this should instead be the character '¤'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¤')" role="warning" id="unicode-test-65">
+        <name/> element contains 'Ã¤' - this should instead be the character 'ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¥')" role="warning" id="unicode-test-66">
+        <name/> element contains 'Ã¥' - this should instead be the character 'å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¨')" role="warning" id="unicode-test-67">
+        <name/> element contains 'Â¨' - this should instead be the character '¨'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¨')" role="warning" id="unicode-test-68">
+        <name/> element contains 'Ã¨' - this should instead be the character 'è'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âª')" role="warning" id="unicode-test-69">
+        <name/> element contains 'Âª' - this should instead be the character 'ª'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãª')" role="warning" id="unicode-test-70">
+        <name/> element contains 'Ãª' - this should instead be the character 'ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â­')" role="warning" id="unicode-test-71">
+        <name/> element contains 'Â­' - this should instead be the character '­'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã­')" role="warning" id="unicode-test-72">
+        <name/> element contains 'Ã­' - this should instead be the character 'í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¯')" role="warning" id="unicode-test-73">
+        <name/> element contains 'Â¯' - this should instead be the character '¯'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¯')" role="warning" id="unicode-test-74">
+        <name/> element contains 'Ã¯' - this should instead be the character 'ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â°')" role="warning" id="unicode-test-75">
+        <name/> element contains 'Â°' - this should instead be the character '°'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã°')" role="warning" id="unicode-test-76">
+        <name/> element contains 'Ã°' - this should instead be the character 'ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â±')" role="warning" id="unicode-test-77">
+        <name/> element contains 'Â±' - this should instead be the character '±'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã±')" role="warning" id="unicode-test-78">
+        <name/> element contains 'Ã±' - this should instead be the character 'ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â´')" role="warning" id="unicode-test-79">
+        <name/> element contains 'Â´' - this should instead be the character '´'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã´')" role="warning" id="unicode-test-80">
+        <name/> element contains 'Ã´' - this should instead be the character 'ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âµ')" role="warning" id="unicode-test-81">
+        <name/> element contains 'Âµ' - this should instead be the character 'µ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãµ')" role="warning" id="unicode-test-82">
+        <name/> element contains 'Ãµ' - this should instead be the character 'õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¶')" role="warning" id="unicode-test-83">
+        <name/> element contains 'Â¶' - this should instead be the character '¶'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¶')" role="warning" id="unicode-test-84">
+        <name/> element contains 'Ã¶' - this should instead be the character 'ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â·')" role="warning" id="unicode-test-85">
+        <name/> element contains 'Â·' - this should instead be the character '·'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã·')" role="warning" id="unicode-test-86">
+        <name/> element contains 'Ã·' - this should instead be the character '÷'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¸')" role="warning" id="unicode-test-87">
+        <name/> element contains 'Â¸' - this should instead be the character '¸'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¸')" role="warning" id="unicode-test-88">
+        <name/> element contains 'Ã¸' - this should instead be the character 'ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¹')" role="warning" id="unicode-test-89">
+        <name/> element contains 'Ã¹' - this should instead be the character 'ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âº')" role="warning" id="unicode-test-90">
+        <name/> element contains 'Âº' - this should instead be the character 'º'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãº')" role="warning" id="unicode-test-91">
+        <name/> element contains 'Ãº' - this should instead be the character 'ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¿')" role="warning" id="unicode-test-92">
+        <name/> element contains 'Â¿' - this should instead be the character '¿'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¿')" role="warning" id="unicode-test-93">
+        <name/> element contains 'Ã¿' - this should instead be the character 'ÿ'. - <value-of select="."/>.</report>
+</rule>
   </pattern>
   
   <pattern id="element-whitelist-pattern">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1826,15 +1826,15 @@
 		
 		<assert test="count(funding-statement) = 1"
 	  	role="error" 
-	  	id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
+	  	id="funding-group-test-1">One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1</assert>
 		
 		<report test="count(award-group) = 0"
 	  	role="warning" 
-	  	id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+	  	id="funding-group-test-2">There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2</report>
 		
 	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')"
 	  	role="warning" 
-	  	id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
+	  	id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3</report>
     </rule>
 	
 	<rule context="funding-group/award-group" 
@@ -1844,31 +1844,31 @@
 		
 		<assert test="funding-source"
   		role="error" 
-  		id="award-group-test-2">award-group must contain a funding-source.</assert>
+  		id="award-group-test-2">award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2</assert>
 		
 		<assert test="principal-award-recipient"
   		role="error" 
-  		id="award-group-test-3">award-group must contain a principal-award-recipient.</assert>
+  		id="award-group-test-3">award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3</assert>
 		
 		<report test="count(award-id) gt 1"
   		role="error" 
-  		id="award-group-test-4">award-group may contain one and only one award-id.</report>
+  		id="award-group-test-4">award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4</report>
 		
 		<assert test="funding-source/institution-wrap"
   		role="error"
-  		id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
+  		id="award-group-test-5">funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5</assert>
 		
 		<report test="count(funding-source/institution-wrap/institution) = 0"
   		role="error"
-  		id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"> does not have one.</report>
+  		id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"> does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6</report>
 	  
 	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id"
 	    role="error"
-	    id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>">)</assert>
+	    id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>">). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7</assert>
 	  
 	  <report test="count(funding-source/institution-wrap/institution) gt 1"
 	    role="error"
-	    id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"> has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/></report>
+	    id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"> has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8</report>
 	</rule>
     
     <rule context="funding-group/award-group/award-id" 
@@ -1877,19 +1877,19 @@
       
       <report test="matches(.,',|;')"
         role="warning"
-        id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/></report>
+        id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1</report>
       
       <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')"
         role="error"
-        id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+        id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2</report>
       
       <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')"
         role="error"
-        id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+        id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3</report>
       
       <report test="matches(.,'&amp;#x\d')"
         role="warning"
-        id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>.</report>
+        id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4</report>
       
     </rule>
     
@@ -1899,7 +1899,7 @@
       <assert test="institution-id[@institution-id-type='FundRef']"
         role="warning"
         flag="pub-check"
-        id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
+        id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test</assert>
       
     </rule>
     
@@ -1962,23 +1962,23 @@
       
       <assert test="count(meta-name) = 1"
         role="error"
-        id="custom-meta-test-1">One meta-name must be present in custom-meta.</assert>
+        id="custom-meta-test-1">One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1</assert>
       
       <report test="($type = $research-subj) and (meta-name != 'Author impact statement')"
         role="error"
-        id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+        id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2</report>
       
       <assert test="count(meta-value) = 1"
         role="error"
-        id="custom-meta-test-3">One meta-value must be present in custom-meta.</assert>
+        id="custom-meta-test-3">One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3</assert>
       
       <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')"
         role="error"
-        id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+        id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14</report>
       
       <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')"
         role="error"
-        id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>.</report>
+        id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15</report>
       
     </rule>
       
@@ -1992,47 +1992,47 @@
       
       <report test="($count gt 30)"
         role="warning"
-        id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed.</report>
+        id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5</report>
       
       <assert test="matches(.,'[\.|\?]$')"
         role="error"
-        id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark.</assert>
+        id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-6</assert>
       
       <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')"
         role="warning"
-        id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.</report>
+        id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7</report>
       
       <report test="not($subj = 'Replication Study') and matches(.,'[:;]')"
         role="warning"
-        id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
+        id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8</report>
       
       <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')"
         role="warning"
-        id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
+        id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-custom-meta-test-9</report>
       
       <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')"
         role="error"
-        id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
+        id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-9</report>
       
       <report test="matches(.,'^[\d]+$')"
         role="error"
-        id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
+        id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10</report>
       
       <report test="matches(.,' [Oo]ur |^[Oo]ur ')"
         role="warning"
-        id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
+        id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11</report>
       
       <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))"
         role="warning"
-        id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
+        id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13</report>
       
       <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))"
         role="warning"
-        id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>.</report>
+        id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-rep-study-custom-meta-test</report>
       
       <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))"
         role="error"
-        id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/></report>
+        id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-rep-study-custom-meta-test</report>
     </rule>
     
     <rule context="article-meta/custom-meta-group/custom-meta/meta-value/*" 
@@ -2041,7 +2041,7 @@
       
       <assert test="local-name() = $allowed-elements"
         role="error"
-        id="custom-meta-child-test-1"><name/> is not allowed in impact statement.</assert>
+        id="custom-meta-child-test-1"><name/> is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1</assert>
       
     </rule>
     
@@ -6400,11 +6400,11 @@
      
      <assert test=". = $impact-statement"
        role="warning"
-       id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+       id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1</assert>
      
      <assert test="count(p/*) = $impact-statement-element-count"
        role="warning"
-       id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+       id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2</assert>
      
    </rule>
    
@@ -8399,6 +8399,10 @@
         role="error" 
         id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
+      <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')"
+        role="error" 
+        id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
+      
       <report test="matches(.,'�')"
         role="error"
         id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/></report>
@@ -8484,17 +8488,25 @@
         role="warning" 
         id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')"
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')"
         role="warning" 
         id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]"
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]"
         role="warning" 
         id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
       
       <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]"
         role="warning" 
         id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')"
+        role="warning" 
+        id="data-empiar-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]"
+        role="warning" 
+        id="data-empiar-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')"
         role="warning" 
@@ -9443,6 +9455,381 @@
         role="warning" 
         id="fundref-test-1">Acknowledgements contains funder(s) in the open funder registry, but their doi is not listed in the funding section. Please check - <value-of select="string-join(for $x in document($funders)//funder[((contains($ack,concat(' ',.,' ')) or contains($ack,concat(' ',.,'.'))) and not(@fundref = $funding-group))] return concat($x,' - ',$x/@fundref),'; ')"/>.</report>
     </rule>
+    
+  </pattern>
+  
+  <pattern id="unicode-checks">
+    
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|
+    td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|
+    th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]"
+        id='unicode-tests'>
+    
+    
+    <report test="contains(.,'â‚¬')" 
+        role="warning" 
+        id="unicode-test-1"><name/> element contains 'â‚¬' - this should instead be the character '€'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã€')" 
+        role="warning" 
+        id="unicode-test-2"><name/> element contains 'Ã€' - this should instead be the character 'À'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" 
+        role="warning" 
+        id="unicode-test-3"><name/> element contains 'Ã' - this should instead be the character 'Á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€š')" 
+        role="warning" 
+        id="unicode-test-4"><name/> element contains 'â€š' - this should instead be the character '‚'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‚')" 
+        role="warning" 
+        id="unicode-test-5"><name/> element contains 'Ã‚' - this should instead be the character 'Â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Æ’')" 
+        role="warning" 
+        id="unicode-test-6"><name/> element contains 'Æ’' - this should instead be the character 'ƒ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãƒ')" 
+        role="warning" 
+        id="unicode-test-7"><name/> element contains 'Ãƒ' - this should instead be the character 'Ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€ž')" 
+        role="warning" 
+        id="unicode-test-8"><name/> element contains 'â€ž' - this should instead be the character '„'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã„')" 
+        role="warning" 
+        id="unicode-test-9"><name/> element contains 'Ã„' - this should instead be the character 'Ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¦')" 
+        role="warning" 
+        id="unicode-test-10"><name/> element contains 'â€¦' - this should instead be the character '…'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã…')" 
+        role="warning" 
+        id="unicode-test-11"><name/> element contains 'Ã…' - this should instead be the character 'Å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã†')" 
+        role="warning" 
+        id="unicode-test-13"><name/> element contains 'Ã†' - this should instead be the character 'Æ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¡')" 
+        role="warning" 
+        id="unicode-test-14"><name/> element contains 'â€¡' - this should instead be the character '‡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‡')" 
+        role="warning" 
+        id="unicode-test-15"><name/> element contains 'Ã‡' - this should instead be the character 'Ç'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ë†')" 
+        role="warning" 
+        id="unicode-test-16"><name/> element contains 'Ë†' - this should instead be the character 'ˆ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãˆ')" 
+        role="warning" 
+        id="unicode-test-17"><name/> element contains 'Ãˆ' - this should instead be the character 'È'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€°')" 
+        role="warning" 
+        id="unicode-test-18"><name/> element contains 'â€°' - this should instead be the character '‰'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‰')" 
+        role="warning" 
+        id="unicode-test-19"><name/> element contains 'Ã‰' - this should instead be the character 'É'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŠ')" 
+        role="warning" 
+        id="unicode-test-21"><name/> element contains 'ÃŠ' - this should instead be the character 'Ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¹')" 
+        role="warning" 
+        id="unicode-test-22"><name/> element contains 'â€¹' - this should instead be the character '‹'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‹')" 
+        role="warning" 
+        id="unicode-test-23"><name/> element contains 'Ã‹' - this should instead be the character 'Ë'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å’')" 
+        role="warning" 
+        id="unicode-test-24"><name/> element contains 'Å’' - this should instead be the character 'Œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŒ')" 
+        role="warning" 
+        id="unicode-test-25"><name/> element contains 'ÃŒ' - this should instead be the character 'Ì'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" 
+        role="warning" 
+        id="unicode-test-26"><name/> element contains 'Ã' - this should instead be the character 'Í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å½')" 
+        role="warning" 
+        id="unicode-test-27"><name/> element contains 'Å½' - this should instead be the character 'Ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŽ')" 
+        role="warning" 
+        id="unicode-test-28"><name/> element contains 'ÃŽ' - this should instead be the character 'Î'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" 
+        role="warning" 
+        id="unicode-test-29"><name/> element contains 'Ã' - this should instead be the character 'Ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" 
+        role="warning" 
+        id="unicode-test-30"><name/> element contains 'Ã' - this should instead be the character 'Ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€˜')" 
+        role="warning" 
+        id="unicode-test-31"><name/> element contains 'â€˜' - this should instead be the character '‘'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‘')" 
+        role="warning" 
+        id="unicode-test-32"><name/> element contains 'Ã‘' - this should instead be the character 'Ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€™')" 
+        role="warning" 
+        id="unicode-test-33"><name/> element contains 'â€™' - this should instead be the character '’'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã’')" 
+        role="warning" 
+        id="unicode-test-34"><name/> element contains 'Ã’' - this should instead be the character 'Ò'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€œ')" 
+        role="warning" 
+        id="unicode-test-35"><name/> element contains 'â€œ' - this should instead be the character '“'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã“')" 
+        role="warning" 
+        id="unicode-test-36"><name/> element contains 'Ã“' - this should instead be the character 'Ó'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€')" 
+        role="warning" 
+        id="unicode-test-37"><name/> element contains 'â€' - this should instead be the character '”'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã”')" 
+        role="warning" 
+        id="unicode-test-38"><name/> element contains 'Ã”' - this should instead be the character 'Ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã•')" 
+        role="warning" 
+        id="unicode-test-39"><name/> element contains 'Ã•' - this should instead be the character 'Õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€“')" 
+        role="warning" 
+        id="unicode-test-40"><name/> element contains 'â€“' - this should instead be the character '–'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã–')" 
+        role="warning" 
+        id="unicode-test-41"><name/> element contains 'Ã–' - this should instead be the character 'Ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€”')" 
+        role="warning" 
+        id="unicode-test-42"><name/> element contains 'â€”' - this should instead be the character '—'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã—')" 
+        role="warning" 
+        id="unicode-test-43"><name/> element contains 'Ã—' - this should instead be the character '×'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ëœ')" 
+        role="warning" 
+        id="unicode-test-44"><name/> element contains 'Ëœ' - this should instead be the character '˜'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã˜')" 
+        role="warning" 
+        id="unicode-test-45"><name/> element contains 'Ã˜' - this should instead be the character 'Ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã™')" 
+        role="warning" 
+        id="unicode-test-46"><name/> element contains 'Ã™' - this should instead be the character 'Ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¡')" 
+        role="warning" 
+        id="unicode-test-47"><name/> element contains 'Å¡' - this should instead be the character 'š'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãš')" 
+        role="warning" 
+        id="unicode-test-48"><name/> element contains 'Ãš' - this should instead be the character 'Ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€º')" 
+        role="warning" 
+        id="unicode-test-49"><name/> element contains 'â€º' - this should instead be the character '›'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã›')" 
+        role="warning" 
+        id="unicode-test-50"><name/> element contains 'Ã›' - this should instead be the character 'Û'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å“')" 
+        role="warning" 
+        id="unicode-test-51"><name/> element contains 'Å“' - this should instead be the character 'œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãœ')" 
+        role="warning" 
+        id="unicode-test-52"><name/> element contains 'Ãœ' - this should instead be the character 'Ü'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" 
+        role="warning" 
+        id="unicode-test-53"><name/> element contains 'Ã' - this should instead be the character 'Ý'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¾')" 
+        role="warning" 
+        id="unicode-test-54"><name/> element contains 'Å¾' - this should instead be the character 'ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãž')" 
+        role="warning" 
+        id="unicode-test-55"><name/> element contains 'Ãž' - this should instead be the character 'Þ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¸')" 
+        role="warning" 
+        id="unicode-test-56"><name/> element contains 'Å¸' - this should instead be the character 'Ÿ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŸ')" 
+        role="warning" 
+        id="unicode-test-57"><name/> element contains 'ÃŸ' - this should instead be the character 'ß'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¡')" 
+        role="warning" 
+        id="unicode-test-58"><name/> element contains 'Â¡' - this should instead be the character '¡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¡')" 
+        role="warning" 
+        id="unicode-test-59"><name/> element contains 'Ã¡' - this should instead be the character 'á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¢')" 
+        role="warning" 
+        id="unicode-test-60"><name/> element contains 'Â¢' - this should instead be the character '¢'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¢')" 
+        role="warning" 
+        id="unicode-test-61"><name/> element contains 'Ã¢' - this should instead be the character 'â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â£')" 
+        role="warning" 
+        id="unicode-test-62"><name/> element contains 'Â£' - this should instead be the character '£'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã£')" 
+        role="warning" 
+        id="unicode-test-63"><name/> element contains 'Ã£' - this should instead be the character 'ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¤')" 
+        role="warning" 
+        id="unicode-test-64"><name/> element contains 'Â¤' - this should instead be the character '¤'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¤')" 
+        role="warning" 
+        id="unicode-test-65"><name/> element contains 'Ã¤' - this should instead be the character 'ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¥')" 
+        role="warning" 
+        id="unicode-test-66"><name/> element contains 'Ã¥' - this should instead be the character 'å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¨')" 
+        role="warning" 
+        id="unicode-test-67"><name/> element contains 'Â¨' - this should instead be the character '¨'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¨')" 
+        role="warning" 
+        id="unicode-test-68"><name/> element contains 'Ã¨' - this should instead be the character 'è'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âª')" 
+        role="warning" 
+        id="unicode-test-69"><name/> element contains 'Âª' - this should instead be the character 'ª'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãª')" 
+        role="warning" 
+        id="unicode-test-70"><name/> element contains 'Ãª' - this should instead be the character 'ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â­')" 
+        role="warning" 
+        id="unicode-test-71"><name/> element contains 'Â­' - this should instead be the character '­'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã­')" 
+        role="warning" 
+        id="unicode-test-72"><name/> element contains 'Ã­' - this should instead be the character 'í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¯')" 
+        role="warning" 
+        id="unicode-test-73"><name/> element contains 'Â¯' - this should instead be the character '¯'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¯')" 
+        role="warning" 
+        id="unicode-test-74"><name/> element contains 'Ã¯' - this should instead be the character 'ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â°')" 
+        role="warning" 
+        id="unicode-test-75"><name/> element contains 'Â°' - this should instead be the character '°'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã°')" 
+        role="warning" 
+        id="unicode-test-76"><name/> element contains 'Ã°' - this should instead be the character 'ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â±')" 
+        role="warning" 
+        id="unicode-test-77"><name/> element contains 'Â±' - this should instead be the character '±'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã±')" 
+        role="warning" 
+        id="unicode-test-78"><name/> element contains 'Ã±' - this should instead be the character 'ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â´')" 
+        role="warning" 
+        id="unicode-test-79"><name/> element contains 'Â´' - this should instead be the character '´'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã´')" 
+        role="warning" 
+        id="unicode-test-80"><name/> element contains 'Ã´' - this should instead be the character 'ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âµ')" 
+        role="warning" 
+        id="unicode-test-81"><name/> element contains 'Âµ' - this should instead be the character 'µ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãµ')" 
+        role="warning" 
+        id="unicode-test-82"><name/> element contains 'Ãµ' - this should instead be the character 'õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¶')" 
+        role="warning" 
+        id="unicode-test-83"><name/> element contains 'Â¶' - this should instead be the character '¶'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¶')" 
+        role="warning" 
+        id="unicode-test-84"><name/> element contains 'Ã¶' - this should instead be the character 'ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â·')" 
+        role="warning" 
+        id="unicode-test-85"><name/> element contains 'Â·' - this should instead be the character '·'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã·')" 
+        role="warning" 
+        id="unicode-test-86"><name/> element contains 'Ã·' - this should instead be the character '÷'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¸')" 
+        role="warning" 
+        id="unicode-test-87"><name/> element contains 'Â¸' - this should instead be the character '¸'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¸')" 
+        role="warning" 
+        id="unicode-test-88"><name/> element contains 'Ã¸' - this should instead be the character 'ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¹')" 
+        role="warning" 
+        id="unicode-test-89"><name/> element contains 'Ã¹' - this should instead be the character 'ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âº')" 
+        role="warning" 
+        id="unicode-test-90"><name/> element contains 'Âº' - this should instead be the character 'º'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãº')" 
+        role="warning" 
+        id="unicode-test-91"><name/> element contains 'Ãº' - this should instead be the character 'ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¿')" 
+        role="warning" 
+        id="unicode-test-92"><name/> element contains 'Â¿' - this should instead be the character '¿'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¿')" 
+        role="warning" 
+        id="unicode-test-93"><name/> element contains 'Ã¿' - this should instead be the character 'ÿ'. - <value-of select="."/>.</report>
+</rule>
     
   </pattern>
   

--- a/test/tests/gen/award-group-tests/award-group-test-2/award-group-test-2.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-2/award-group-test-2.sch
@@ -727,7 +727,7 @@
     <rule context="funding-group/award-group" id="award-group-tests">
       <let name="id" value="@id"/>
       <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
-      <assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source.</assert>
+      <assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-group-tests/award-group-test-2/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-2.sch"?>
 <!--Context: funding-group/award-group
 Test: assert    funding-source
-Message: award-group must contain a funding-source.-->
+Message: award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-2/pass.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-2.sch"?>
 <!--Context: funding-group/award-group
 Test: assert    funding-source
-Message: award-group must contain a funding-source.-->
+Message: award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-3/award-group-test-3.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-3/award-group-test-3.sch
@@ -727,7 +727,7 @@
     <rule context="funding-group/award-group" id="award-group-tests">
       <let name="id" value="@id"/>
       <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
-      <assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient.</assert>
+      <assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-group-tests/award-group-test-3/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-3.sch"?>
 <!--Context: funding-group/award-group
 Test: assert    principal-award-recipient
-Message: award-group must contain a principal-award-recipient.-->
+Message: award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-3/pass.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-3.sch"?>
 <!--Context: funding-group/award-group
 Test: assert    principal-award-recipient
-Message: award-group must contain a principal-award-recipient.-->
+Message: award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-4/award-group-test-4.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-4/award-group-test-4.sch
@@ -727,7 +727,7 @@
     <rule context="funding-group/award-group" id="award-group-tests">
       <let name="id" value="@id"/>
       <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
-      <report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id.</report>
+      <report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-group-tests/award-group-test-4/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-4/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-4.sch"?>
 <!--Context: funding-group/award-group
 Test: report    count(award-id) gt 1
-Message: award-group may contain one and only one award-id.-->
+Message: award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-4/pass.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-4/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-4.sch"?>
 <!--Context: funding-group/award-group
 Test: report    count(award-id) gt 1
-Message: award-group may contain one and only one award-id.-->
+Message: award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-5/award-group-test-5.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-5/award-group-test-5.sch
@@ -727,7 +727,7 @@
     <rule context="funding-group/award-group" id="award-group-tests">
       <let name="id" value="@id"/>
       <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
-      <assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
+      <assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-group-tests/award-group-test-5/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-5/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-5.sch"?>
 <!--Context: funding-group/award-group
 Test: assert    funding-source/institution-wrap
-Message: funding-source must contain an institution-wrap.-->
+Message: funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-5/pass.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-5/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-5.sch"?>
 <!--Context: funding-group/award-group
 Test: assert    funding-source/institution-wrap
-Message: funding-source must contain an institution-wrap.-->
+Message: funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-6/award-group-test-6.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-6/award-group-test-6.sch
@@ -727,7 +727,7 @@
     <rule context="funding-group/award-group" id="award-group-tests">
       <let name="id" value="@id"/>
       <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
-      <report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
+      <report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-group-tests/award-group-test-6/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-6/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-6.sch"?>
 <!--Context: funding-group/award-group
 Test: report    count(funding-source/institution-wrap/institution) = 0
-Message: Every piece of funding must have an institution. <award-group id=""> does not have one.-->
+Message: Every piece of funding must have an institution. <award-group id=""> does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-6/pass.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-6/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-6.sch"?>
 <!--Context: funding-group/award-group
 Test: report    count(funding-source/institution-wrap/institution) = 0
-Message: Every piece of funding must have an institution. <award-group id=""> does not have one.-->
+Message: Every piece of funding must have an institution. <award-group id=""> does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-7/award-group-test-7.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-7/award-group-test-7.sch
@@ -727,7 +727,7 @@
     <rule context="funding-group/award-group" id="award-group-tests">
       <let name="id" value="@id"/>
       <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
-      <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+      <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-group-tests/award-group-test-7/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-7/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-7.sch"?>
 <!--Context: funding-group/award-group
 Test: assert    ancestor::article//article-meta//contrib//xref/@rid = $id
-Message: There is no author associated with the funding for , which is incorrect. (There is no xref from a contrib pointing to this <award-group id="">)-->
+Message: There is no author associated with the funding for , which is incorrect. (There is no xref from a contrib pointing to this <award-group id="">). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-7/pass.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-7/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-7.sch"?>
 <!--Context: funding-group/award-group
 Test: assert    ancestor::article//article-meta//contrib//xref/@rid = $id
-Message: There is no author associated with the funding for , which is incorrect. (There is no xref from a contrib pointing to this <award-group id="">)-->
+Message: There is no author associated with the funding for , which is incorrect. (There is no xref from a contrib pointing to this <award-group id="">). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-8/award-group-test-8.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-8/award-group-test-8.sch
@@ -727,8 +727,7 @@
     <rule context="funding-group/award-group" id="award-group-tests">
       <let name="id" value="@id"/>
       <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
-      <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
-      </report>
+      <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-group-tests/award-group-test-8/fail.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-8/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-8.sch"?>
 <!--Context: funding-group/award-group
 Test: report    count(funding-source/institution-wrap/institution) gt 1
-Message: Every piece of funding must only have 1 institution. <award-group id=""> has  - -->
+Message: Every piece of funding must only have 1 institution. <award-group id=""> has  - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-group-tests/award-group-test-8/pass.xml
+++ b/test/tests/gen/award-group-tests/award-group-test-8/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-group-test-8.sch"?>
 <!--Context: funding-group/award-group
 Test: report    count(funding-source/institution-wrap/institution) gt 1
-Message: Every piece of funding must only have 1 institution. <award-group id=""> has  - -->
+Message: Every piece of funding must only have 1 institution. <award-group id=""> has  - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/award-id-tests/award-id-test-1/award-id-test-1.sch
+++ b/test/tests/gen/award-id-tests/award-id-test-1/award-id-test-1.sch
@@ -726,8 +726,7 @@
   <pattern id="article-metadata">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
-      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>
-      </report>
+      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-id-tests/award-id-test-1/fail.xml
+++ b/test/tests/gen/award-id-tests/award-id-test-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-id-test-1.sch"?>
 <!--Context: funding-group/award-group/award-id
 Test: report    matches(.,',|;')
-Message: Funding entry with id  has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - -->
+Message: Funding entry with id  has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/award-id-tests/award-id-test-1/pass.xml
+++ b/test/tests/gen/award-id-tests/award-id-test-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-id-test-1.sch"?>
 <!--Context: funding-group/award-group/award-id
 Test: report    matches(.,',|;')
-Message: Funding entry with id  has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - -->
+Message: Funding entry with id  has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/award-id-tests/award-id-test-2/award-id-test-2.sch
+++ b/test/tests/gen/award-id-tests/award-id-test-2/award-id-test-2.sch
@@ -726,7 +726,7 @@
   <pattern id="article-metadata">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
-      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-id-tests/award-id-test-2/fail.xml
+++ b/test/tests/gen/award-id-tests/award-id-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-id-test-2.sch"?>
 <!--Context: funding-group/award-group/award-id
 Test: report    matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')
-Message: Award id contains -  - This entry should be empty.-->
+Message: Award id contains -  - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/award-id-tests/award-id-test-2/pass.xml
+++ b/test/tests/gen/award-id-tests/award-id-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-id-test-2.sch"?>
 <!--Context: funding-group/award-group/award-id
 Test: report    matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')
-Message: Award id contains -  - This entry should be empty.-->
+Message: Award id contains -  - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/award-id-tests/award-id-test-3/award-id-test-3.sch
+++ b/test/tests/gen/award-id-tests/award-id-test-3/award-id-test-3.sch
@@ -726,7 +726,7 @@
   <pattern id="article-metadata">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
-      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-id-tests/award-id-test-3/fail.xml
+++ b/test/tests/gen/award-id-tests/award-id-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-id-test-3.sch"?>
 <!--Context: funding-group/award-group/award-id
 Test: report    matches(.,'^\s?[Nn]one[\.]?\s?$')
-Message: Award id contains -  - This entry should be empty.-->
+Message: Award id contains -  - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/award-id-tests/award-id-test-3/pass.xml
+++ b/test/tests/gen/award-id-tests/award-id-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-id-test-3.sch"?>
 <!--Context: funding-group/award-group/award-id
 Test: report    matches(.,'^\s?[Nn]one[\.]?\s?$')
-Message: Award id contains -  - This entry should be empty.-->
+Message: Award id contains -  - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/award-id-tests/award-id-test-4/award-id-test-4.sch
+++ b/test/tests/gen/award-id-tests/award-id-test-4/award-id-test-4.sch
@@ -726,7 +726,7 @@
   <pattern id="article-metadata">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
-      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>.</report>
+      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/award-id-tests/award-id-test-4/fail.xml
+++ b/test/tests/gen/award-id-tests/award-id-test-4/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-id-test-4.sch"?>
 <!--Context: funding-group/award-group/award-id
 Test: report    matches(.,'&#x\d')
-Message: Award id contains what looks like a broken unicode - .-->
+Message: Award id contains what looks like a broken unicode - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/award-id-tests/award-id-test-4/pass.xml
+++ b/test/tests/gen/award-id-tests/award-id-test-4/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="award-id-test-4.sch"?>
 <!--Context: funding-group/award-group/award-id
 Test: report    matches(.,'&#x\d')
-Message: Award id contains what looks like a broken unicode - .-->
+Message: Award id contains what looks like a broken unicode - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-1/custom-meta-test-1.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-1/custom-meta-test-1.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta" id="custom-meta-tests">
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
-      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta.</assert>
+      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-1/fail.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-1.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: assert    count(meta-name) = 1
-Message: One meta-name must be present in custom-meta.-->
+Message: One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-1/pass.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-1.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: assert    count(meta-name) = 1
-Message: One meta-name must be present in custom-meta.-->
+Message: One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-14/custom-meta-test-14.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-14/custom-meta-test-14.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta" id="custom-meta-tests">
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
-      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-14/fail.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-14/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-14.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: report    ($type = $features-subj) and ($pos=1) and (meta-name != 'Author impact statement')
-Message: The value of the 1st meta-name can only be 'Author impact statement'. Currently it is .-->
+Message: The value of the 1st meta-name can only be 'Author impact statement'. Currently it is . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="research-article">
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-14/pass.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-14/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-14.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: report    ($type = $features-subj) and ($pos=1) and (meta-name != 'Author impact statement')
-Message: The value of the 1st meta-name can only be 'Author impact statement'. Currently it is .-->
+Message: The value of the 1st meta-name can only be 'Author impact statement'. Currently it is . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="research-article">
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-15/custom-meta-test-15.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-15/custom-meta-test-15.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta" id="custom-meta-tests">
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
-      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-15/fail.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-15/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-15.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: report    ($type = $features-subj) and ($pos=2) and (meta-name != 'Template')
-Message: The value of the 2nd meta-name can only be 'Template'. Currently it is .-->
+Message: The value of the 2nd meta-name can only be 'Template'. Currently it is . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="research-article">
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-15/pass.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-15/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-15.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: report    ($type = $features-subj) and ($pos=2) and (meta-name != 'Template')
-Message: The value of the 2nd meta-name can only be 'Template'. Currently it is .-->
+Message: The value of the 2nd meta-name can only be 'Template'. Currently it is . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="research-article">
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-2/custom-meta-test-2.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-2/custom-meta-test-2.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta" id="custom-meta-tests">
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
-      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-2/fail.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-2.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: report    ($type = $research-subj) and (meta-name != 'Author impact statement')
-Message: The value of meta-name can only be 'Author impact statement'. Currently it is .-->
+Message: The value of meta-name can only be 'Author impact statement'. Currently it is . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-2/pass.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-2.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: report    ($type = $research-subj) and (meta-name != 'Author impact statement')
-Message: The value of meta-name can only be 'Author impact statement'. Currently it is .-->
+Message: The value of meta-name can only be 'Author impact statement'. Currently it is . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-3/custom-meta-test-3.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-3/custom-meta-test-3.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta" id="custom-meta-tests">
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
-      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta.</assert>
+      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-3/fail.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-3.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: assert    count(meta-value) = 1
-Message: One meta-value must be present in custom-meta.-->
+Message: One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-3/pass.xml
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-3.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta
 Test: assert    count(meta-value) = 1
-Message: One meta-value must be present in custom-meta.-->
+Message: One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-1/data-emdb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-1/data-emdb-test-1.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/data-ref-tests/data-emdb-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-1/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="data-emdb-test-1.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')
+Test: report    not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')
 Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - . Is that correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-1/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="data-emdb-test-1.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')
+Test: report    not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')
 Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - . Is that correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-2/data-emdb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-2/data-emdb-test-2.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/data-ref-tests/data-emdb-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-2/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="data-emdb-test-2.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]
+Test: report    not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]
 Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/data-ref-tests/data-emdb-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-2/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="data-emdb-test-2.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]
+Test: report    not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]
 Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/data-ref-tests/data-empiar-test-1/data-empiar-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-empiar-test-1/data-empiar-test-1.sch
@@ -1,0 +1,736 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')" role="warning" id="data-empiar-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-empiar-test-1/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-empiar-test-1/fail.xml
@@ -1,0 +1,29 @@
+<?oxygen SCHSchema="data-empiar-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')
+Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Reid</surname>
+          <given-names>MS</given-names>
+        </name>
+        <name>
+          <surname>Kern</surname>
+          <given-names>DM</given-names>
+        </name>
+        <name>
+          <surname>Brohawn</surname>
+          <given-names>SG</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Cryo-EM structure of the potassium-chloride cotransporter KCC4 in lipid
+        nanodiscs</data-title>
+      <source>EMPIAR</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/emdb/empiar/entry/10394">10394</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-empiar-test-1/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-empiar-test-1/pass.xml
@@ -1,0 +1,29 @@
+<?oxygen SCHSchema="data-empiar-test-1.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')
+Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - . Is that correct?-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Reid</surname>
+          <given-names>MS</given-names>
+        </name>
+        <name>
+          <surname>Kern</surname>
+          <given-names>DM</given-names>
+        </name>
+        <name>
+          <surname>Brohawn</surname>
+          <given-names>SG</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Cryo-EM structure of the potassium-chloride cotransporter KCC4 in lipid
+        nanodiscs</data-title>
+      <source>Electron Microscopy Public Image Archive</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/emdb/empiar/entry/10394">10394</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-empiar-test-2/data-empiar-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-empiar-test-2/data-empiar-test-2.sch
@@ -1,0 +1,736 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-empiar-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='data']" role="error" id="data-ref-tests-xspec-assert">element-citation[@publication-type='data'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/data-ref-tests/data-empiar-test-2/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-empiar-test-2/fail.xml
@@ -1,0 +1,29 @@
+<?oxygen SCHSchema="data-empiar-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Reid</surname>
+          <given-names>MS</given-names>
+        </name>
+        <name>
+          <surname>Kern</surname>
+          <given-names>DM</given-names>
+        </name>
+        <name>
+          <surname>Brohawn</surname>
+          <given-names>SG</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Cryo-EM structure of the potassium-chloride cotransporter KCC4 in lipid
+        nanodiscs</data-title>
+      <source>Electron Microscopy Public Image Archive</source>
+      <pub-id assigning-authority="EMDB" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/emdb/empiar/entry/10394">10394</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/data-ref-tests/data-empiar-test-2/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-empiar-test-2/pass.xml
@@ -1,0 +1,29 @@
+<?oxygen SCHSchema="data-empiar-test-2.sch"?>
+<!--Context: element-citation[@publication-type='data']
+Test: report    contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]
+Message: Data reference with the title '' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Reid</surname>
+          <given-names>MS</given-names>
+        </name>
+        <name>
+          <surname>Kern</surname>
+          <given-names>DM</given-names>
+        </name>
+        <name>
+          <surname>Brohawn</surname>
+          <given-names>SG</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Cryo-EM structure of the potassium-chloride cotransporter KCC4 in lipid
+        nanodiscs</data-title>
+      <source>Electron Microscopy Public Image Archive</source>
+      <pub-id assigning-authority="EBI" pub-id-type="accession" xlink:href="https://www.ebi.ac.uk/pdbe/emdb/empiar/entry/10394">10394</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/funding-group-tests/funding-group-test-1/fail.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-1.sch"?>
 <!--Context: article-meta/funding-group
 Test: assert    count(funding-statement) = 1
-Message: One funding-statement should be present in funding-group.-->
+Message: One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-1/funding-group-test-1.sch
+++ b/test/tests/gen/funding-group-tests/funding-group-test-1/funding-group-test-1.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="article-meta/funding-group" id="funding-group-tests">
-      <assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
+      <assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/funding-group-tests/funding-group-test-1/pass.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-1.sch"?>
 <!--Context: article-meta/funding-group
 Test: assert    count(funding-statement) = 1
-Message: One funding-statement should be present in funding-group.-->
+Message: One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-2/fail.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-2.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    count(award-group) = 0
-Message: There is no funding for this article. Is this correct?-->
+Message: There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-2/funding-group-test-2.sch
+++ b/test/tests/gen/funding-group-tests/funding-group-test-2/funding-group-test-2.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="article-meta/funding-group" id="funding-group-tests">
-      <report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+      <report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/funding-group-tests/funding-group-test-2/pass.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-2.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    count(award-group) = 0
-Message: There is no funding for this article. Is this correct?-->
+Message: There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/fail.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-3.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    (count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')
-Message: Is this funding-statement correct? - '' Usually it should be 'No external funding was received for this work.'-->
+Message: Is this funding-statement correct? - '' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/funding-group-test-3.sch
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/funding-group-test-3.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="article-meta/funding-group" id="funding-group-tests">
-      <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
+      <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/pass.xml
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="funding-group-test-3.sch"?>
 <!--Context: article-meta/funding-group
 Test: report    (count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')
-Message: Is this funding-statement correct? - '' Usually it should be 'No external funding was received for this work.'-->
+Message: Is this funding-statement correct? - '' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/fail.xml
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="insight-asbtract-impact-test-1.sch"?>
 <!--Context: article[@article-type='article-commentary']//article-meta/abstract
 Test: assert    . = $impact-statement
-Message: In insights, abtsracts must be the same as impact statements. Here the abstract reads "", whereas the impact statement reads "".-->
+Message: In insights, abtsracts must be the same as impact statements. Here the abstract reads "", whereas the impact statement reads "". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="article-commentary">
     <article-meta>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/insight-asbtract-impact-test-1.sch
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/insight-asbtract-impact-test-1.sch
@@ -727,7 +727,7 @@
     <rule context="article[@article-type='article-commentary']//article-meta/abstract" id="insight-asbtract-tests">
       <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]"/>
       <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]/*)"/>
-      <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+      <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/pass.xml
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="insight-asbtract-impact-test-1.sch"?>
 <!--Context: article[@article-type='article-commentary']//article-meta/abstract
 Test: assert    . = $impact-statement
-Message: In insights, abtsracts must be the same as impact statements. Here the abstract reads "", whereas the impact statement reads "".-->
+Message: In insights, abtsracts must be the same as impact statements. Here the abstract reads "", whereas the impact statement reads "". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="article-commentary">
     <article-meta>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/fail.xml
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="insight-asbtract-impact-test-2.sch"?>
 <!--Context: article[@article-type='article-commentary']//article-meta/abstract
 Test: assert    count(p/*) = $impact-statement-element-count
-Message: In insights, abtsracts must be the same as impact statements. Here the abstract has  child element(s), whereas the impact statement has  child element(s). Check for possible missing formatting.-->
+Message: In insights, abtsracts must be the same as impact statements. Here the abstract has  child element(s), whereas the impact statement has  child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="article-commentary">
     <article-meta>

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/insight-asbtract-impact-test-2.sch
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/insight-asbtract-impact-test-2.sch
@@ -727,7 +727,7 @@
     <rule context="article[@article-type='article-commentary']//article-meta/abstract" id="insight-asbtract-tests">
       <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]"/>
       <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]/*)"/>
-      <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+      <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/pass.xml
+++ b/test/tests/gen/insight-asbtract-tests/insight-asbtract-impact-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="insight-asbtract-impact-test-2.sch"?>
 <!--Context: article[@article-type='article-commentary']//article-meta/abstract
 Test: assert    count(p/*) = $impact-statement-element-count
-Message: In insights, abtsracts must be the same as impact statements. Here the abstract has  child element(s), whereas the impact statement has  child element(s). Check for possible missing formatting.-->
+Message: In insights, abtsracts must be the same as impact statements. Here the abstract has  child element(s), whereas the impact statement has  child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="article-commentary">
     <article-meta>

--- a/test/tests/gen/institution-wrap-tests/institution-id-test/fail.xml
+++ b/test/tests/gen/institution-wrap-tests/institution-id-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="institution-id-test.sch"?>
 <!--Context: article-meta//award-group//institution-wrap
 Test: assert    institution-id[@institution-id-type='FundRef']
-Message: Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).-->
+Message: Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/institution-wrap-tests/institution-id-test/institution-id-test.sch
+++ b/test/tests/gen/institution-wrap-tests/institution-id-test/institution-id-test.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/institution-wrap-tests/institution-id-test/pass.xml
+++ b/test/tests/gen/institution-wrap-tests/institution-id-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="institution-id-test.sch"?>
 <!--Context: article-meta//award-group//institution-wrap
 Test: assert    institution-id[@institution-id-type='FundRef']
-Message: Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).-->
+Message: Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/meta-value-child-tests/custom-meta-child-test-1/custom-meta-child-test-1.sch
+++ b/test/tests/gen/meta-value-child-tests/custom-meta-child-test-1/custom-meta-child-test-1.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta/meta-value/*" id="meta-value-child-tests">
       <let name="allowed-elements" value="('italic','sup','sub')"/>
       <assert test="local-name() = $allowed-elements" role="error" id="custom-meta-child-test-1">
-        <name/> is not allowed in impact statement.</assert>
+        <name/> is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-child-tests/custom-meta-child-test-1/fail.xml
+++ b/test/tests/gen/meta-value-child-tests/custom-meta-child-test-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-child-test-1.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta/meta-value/*
 Test: assert    local-name() = $allowed-elements
-Message:  is not allowed in impact statement.-->
+Message:  is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-child-tests/custom-meta-child-test-1/pass.xml
+++ b/test/tests/gen/meta-value-child-tests/custom-meta-child-test-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-child-test-1.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta/meta-value/*
 Test: assert    local-name() = $allowed-elements
-Message:  is not allowed in impact statement.-->
+Message:  is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-10/custom-meta-test-10.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-10/custom-meta-test-10.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
+      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-10/fail.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-10/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-10.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'^[\d]+$')
-Message: Impact statement is comprised entirely of numbers, which must be incorrect.-->
+Message: Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-10/pass.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-10/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-10.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'^[\d]+$')
-Message: Impact statement is comprised entirely of numbers, which must be incorrect.-->
+Message: Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-11/custom-meta-test-11.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-11/custom-meta-test-11.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-11/fail.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-11/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-11.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,' [Oo]ur |^[Oo]ur ')
-Message: Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?-->
+Message: Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-11/pass.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-11/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-11.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,' [Oo]ur |^[Oo]ur ')
-Message: Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?-->
+Message: Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-13/custom-meta-test-13.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-13/custom-meta-test-13.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
+      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-13/fail.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-13/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-13.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,' study ') and not(matches(.,'[Tt]his study'))
-Message: Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.-->
+Message: Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-13/pass.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-13/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-13.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,' study ') and not(matches(.,'[Tt]his study'))
-Message: Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.-->
+Message: Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-5/custom-meta-test-5.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-5/custom-meta-test-5.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed.</report>
+      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-5/fail.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-5/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-5.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    ($count gt 30)
-Message: Impact statement contains more than 30 words. This is not allowed.-->
+Message: Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-5/pass.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-5/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-5.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    ($count gt 30)
-Message: Impact statement contains more than 30 words. This is not allowed.-->
+Message: Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-7/custom-meta-test-7.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-7/custom-meta-test-7.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.</report>
+      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-7/fail.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-7/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-7.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')
-Message: Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.-->
+Message: Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-7/pass.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-7/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-7.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')
-Message: Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.-->
+Message: Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-8/custom-meta-test-8.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-8/custom-meta-test-8.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
+      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-8/fail.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-8/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-8.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    not($subj = 'Replication Study') and matches(.,'[:;]')
-Message: Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.-->
+Message: Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/custom-meta-test-8/pass.xml
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-8/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="custom-meta-test-8.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    not($subj = 'Replication Study') and matches(.,'[:;]')
-Message: Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.-->
+Message: Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-6/fail.xml
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-6/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="final-custom-meta-test-6.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: assert    matches(.,'[\.|\?]$')
-Message: Impact statement must end with a full stop or question mark.-->
+Message: Impact statement must end with a full stop or question mark. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-6-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-6/final-custom-meta-test-6.sch
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-6/final-custom-meta-test-6.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark.</assert>
+      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-6</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-6/pass.xml
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-6/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="final-custom-meta-test-6.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: assert    matches(.,'[\.|\?]$')
-Message: Impact statement must end with a full stop or question mark.-->
+Message: Impact statement must end with a full stop or question mark. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-6-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/fail.xml
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="final-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')
-Message: Impact statement contains a possessive phrase. This is not allowed-->
+Message: Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-9-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/final-custom-meta-test-9.sch
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/final-custom-meta-test-9.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-9</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/pass.xml
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="final-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')
-Message: Impact statement contains a possessive phrase. This is not allowed-->
+Message: Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-9-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/final-rep-study-custom-meta-test/fail.xml
+++ b/test/tests/gen/meta-value-tests/final-rep-study-custom-meta-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="final-rep-study-custom-meta-test.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    ($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))
-Message: Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - -->
+Message: Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-rep-study-custom-meta-test-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/final-rep-study-custom-meta-test/final-rep-study-custom-meta-test.sch
+++ b/test/tests/gen/meta-value-tests/final-rep-study-custom-meta-test/final-rep-study-custom-meta-test.sch
@@ -727,8 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>
-      </report>
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-rep-study-custom-meta-test</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/final-rep-study-custom-meta-test/pass.xml
+++ b/test/tests/gen/meta-value-tests/final-rep-study-custom-meta-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="final-rep-study-custom-meta-test.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    ($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))
-Message: Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - -->
+Message: Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-rep-study-custom-meta-test-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/fail.xml
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="pre-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')
-Message: Impact statement contains a possessive phrase. This is not allowed-->
+Message: Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-custom-meta-test-9-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pass.xml
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="pre-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')
-Message: Impact statement contains a possessive phrase. This is not allowed-->
+Message: Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-custom-meta-test-9-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pre-custom-meta-test-9.sch
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pre-custom-meta-test-9.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-custom-meta-test-9</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/pre-rep-study-custom-meta-test/fail.xml
+++ b/test/tests/gen/meta-value-tests/pre-rep-study-custom-meta-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="pre-rep-study-custom-meta-test.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    ($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))
-Message: Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - .-->
+Message: Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-rep-study-custom-meta-test-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/pre-rep-study-custom-meta-test/pass.xml
+++ b/test/tests/gen/meta-value-tests/pre-rep-study-custom-meta-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="pre-rep-study-custom-meta-test.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
 Test: report    ($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))
-Message: Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - .-->
+Message: Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - . More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-rep-study-custom-meta-test-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <article-meta>

--- a/test/tests/gen/meta-value-tests/pre-rep-study-custom-meta-test/pre-rep-study-custom-meta-test.sch
+++ b/test/tests/gen/meta-value-tests/pre-rep-study-custom-meta-test/pre-rep-study-custom-meta-test.sch
@@ -727,7 +727,7 @@
     <rule context="article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value" id="meta-value-tests">
       <let name="subj" value="ancestor::article-meta//subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="warning" id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>.</report>
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="warning" id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-rep-study-custom-meta-test</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/software-ref-tests/R-test-6/R-test-6.sch
+++ b/test/tests/gen/software-ref-tests/R-test-6/R-test-6.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
+      <let name="lc" value="lower-case(data-title[1])"/>
+      <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::element-citation[@publication-type='software']" role="error" id="software-ref-tests-xspec-assert">element-citation[@publication-type='software'] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/software-ref-tests/R-test-6/fail.xml
+++ b/test/tests/gen/software-ref-tests/R-test-6/fail.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="R-test-6.sch"?>
+<!--Context: element-citation[@publication-type='software']
+Test: report    matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')
+Message: software ref '' has a publisher-name -  - but this is the data-title.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article>
+    <ref id="bib33"><element-citation publication-type="software">
+      <person-group person-group-type="author">
+        <collab>R Development Core Team</collab>
+      </person-group>
+      <publisher-name>R: a language and environment for statistical computing</publisher-name>
+      <version designator="3.2.2">3.2.2</version>
+      <year iso-8601-date="2015">2015</year>
+      <source>R Foundation for Statistical Computing</source>
+      <publisher-loc>Vienna, Austria</publisher-loc>
+      <ext-link ext-link-type="uri" xlink:href="http://www.r-project.org/">http://www.r-project.org/</ext-link>
+    </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/software-ref-tests/R-test-6/pass.xml
+++ b/test/tests/gen/software-ref-tests/R-test-6/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="R-test-6.sch"?>
+<!--Context: element-citation[@publication-type='software']
+Test: report    matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')
+Message: software ref '' has a publisher-name -  - but this is the data-title.-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article>
+    <ref id="bib33"><element-citation publication-type="software">
+      <person-group person-group-type="author">
+        <collab>R Development Core Team</collab>
+      </person-group>
+      <data-title>R: a language and environment for statistical computing</data-title>
+      <version designator="3.2.2">3.2.2</version>
+      <year iso-8601-date="2015">2015</year>
+      <publisher-loc>Vienna, Austria</publisher-loc>
+      <publisher-name>R Foundation for Statistical Computing</publisher-name>
+      <ext-link ext-link-type="uri" xlink:href="http://www.r-project.org/">http://www.r-project.org/</ext-link>
+    </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-1/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-1/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-1.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â‚¬')
+Message:  element contains 'â‚¬' - this should instead be the character '€'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â‚¬</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-1/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-1/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-1.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â‚¬')
+Message:  element contains 'â‚¬' - this should instead be the character '€'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test €</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-1/unicode-test-1.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-1/unicode-test-1.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â‚¬')" role="warning" id="unicode-test-1">
+        <name/> element contains 'â‚¬' - this should instead be the character '€'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-10/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-10/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-10.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€¦')
+Message:  element contains 'â€¦' - this should instead be the character '…'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€¦ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-10/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-10/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-10.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€¦')
+Message:  element contains 'â€¦' - this should instead be the character '…'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test …</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-10/unicode-test-10.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-10/unicode-test-10.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€¦')" role="warning" id="unicode-test-10">
+        <name/> element contains 'â€¦' - this should instead be the character '…'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-11/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-11/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-11.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã…')
+Message:  element contains 'Ã…' - this should instead be the character 'Å'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã…</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-11/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-11/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-11.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã…')
+Message:  element contains 'Ã…' - this should instead be the character 'Å'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Å</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-11/unicode-test-11.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-11/unicode-test-11.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã…')" role="warning" id="unicode-test-11">
+        <name/> element contains 'Ã…' - this should instead be the character 'Å'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-12/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-12/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-12.sch"?>
+<!--Context: 
+Test: report    contains(.,'â€ ')
+Message:  element contains 'â€ ' - this should instead be the character '†'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-12/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-12/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-12.sch"?>
+<!--Context: 
+Test: report    contains(.,'â€ ')
+Message:  element contains 'â€ ' - this should instead be the character '†'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test †</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-12/unicode-test-12.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-12/unicode-test-12.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€ ')" role="warning" id="unicode-test-12">
+        <name/> element contains 'â€ ' - this should instead be the character '†'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-13/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-13/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-13.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã†')
+Message:  element contains 'Ã†' - this should instead be the character 'Æ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã†</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-13/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-13/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-13.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã†')
+Message:  element contains 'Ã†' - this should instead be the character 'Æ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Æ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-13/unicode-test-13.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-13/unicode-test-13.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã†')" role="warning" id="unicode-test-13">
+        <name/> element contains 'Ã†' - this should instead be the character 'Æ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-14/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-14/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-14.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€¡')
+Message:  element contains 'â€¡' - this should instead be the character '‡'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€¡ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-14/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-14/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-14.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€¡')
+Message:  element contains 'â€¡' - this should instead be the character '‡'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ‡</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-14/unicode-test-14.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-14/unicode-test-14.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€¡')" role="warning" id="unicode-test-14">
+        <name/> element contains 'â€¡' - this should instead be the character '‡'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-15/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-15/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-15.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‡')
+Message:  element contains 'Ã‡' - this should instead be the character 'Ç'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã‡</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-15/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-15/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-15.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‡')
+Message:  element contains 'Ã‡' - this should instead be the character 'Ç'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ç</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-15/unicode-test-15.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-15/unicode-test-15.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã‡')" role="warning" id="unicode-test-15">
+        <name/> element contains 'Ã‡' - this should instead be the character 'Ç'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-16/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-16/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-16.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ë†')
+Message:  element contains 'Ë†' - this should instead be the character 'ˆ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ë† </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-16/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-16/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-16.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ë†')
+Message:  element contains 'Ë†' - this should instead be the character 'ˆ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ˆ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-16/unicode-test-16.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-16/unicode-test-16.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ë†')" role="warning" id="unicode-test-16">
+        <name/> element contains 'Ë†' - this should instead be the character 'ˆ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-17/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-17/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-17.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãˆ')
+Message:  element contains 'Ãˆ' - this should instead be the character 'È'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ãˆ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-17/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-17/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-17.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãˆ')
+Message:  element contains 'Ãˆ' - this should instead be the character 'È'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test È</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-17/unicode-test-17.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-17/unicode-test-17.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ãˆ')" role="warning" id="unicode-test-17">
+        <name/> element contains 'Ãˆ' - this should instead be the character 'È'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-18/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-18/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-18.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€°')
+Message:  element contains 'â€°' - this should instead be the character '‰'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€° </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-18/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-18/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-18.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€°')
+Message:  element contains 'â€°' - this should instead be the character '‰'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ‰</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-18/unicode-test-18.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-18/unicode-test-18.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€°')" role="warning" id="unicode-test-18">
+        <name/> element contains 'â€°' - this should instead be the character '‰'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-19/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-19/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-19.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‰')
+Message:  element contains 'Ã‰' - this should instead be the character 'É'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã‰</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-19/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-19/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-19.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‰')
+Message:  element contains 'Ã‰' - this should instead be the character 'É'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test É</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-19/unicode-test-19.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-19/unicode-test-19.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã‰')" role="warning" id="unicode-test-19">
+        <name/> element contains 'Ã‰' - this should instead be the character 'É'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-2/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-2/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-2.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã€')
+Message:  element contains 'Ã€' - this should instead be the character 'À'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã€</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-2/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-2/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-2.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã€')
+Message:  element contains 'Ã€' - this should instead be the character 'À'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test À</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-2/unicode-test-2.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-2/unicode-test-2.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã€')" role="warning" id="unicode-test-2">
+        <name/> element contains 'Ã€' - this should instead be the character 'À'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-20/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-20/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-20.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å')
+Message:  element contains 'Å' - this should instead be the character 'Š'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Å </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-20/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-20/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-20.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å')
+Message:  element contains 'Å' - this should instead be the character 'Š'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Š</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-20/unicode-test-20.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-20/unicode-test-20.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Å')" role="warning" id="unicode-test-20">
+        <name/> element contains 'Å' - this should instead be the character 'Š'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-21/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-21/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-21.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'ÃŠ')
+Message:  element contains 'ÃŠ' - this should instead be the character 'Ê'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>ÃŠ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-21/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-21/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-21.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'ÃŠ')
+Message:  element contains 'ÃŠ' - this should instead be the character 'Ê'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ê</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-21/unicode-test-21.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-21/unicode-test-21.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'ÃŠ')" role="warning" id="unicode-test-21">
+        <name/> element contains 'ÃŠ' - this should instead be the character 'Ê'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-22/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-22/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-22.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€¹')
+Message:  element contains 'â€¹' - this should instead be the character '‹'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€¹ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-22/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-22/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-22.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€¹')
+Message:  element contains 'â€¹' - this should instead be the character '‹'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ‹</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-22/unicode-test-22.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-22/unicode-test-22.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€¹')" role="warning" id="unicode-test-22">
+        <name/> element contains 'â€¹' - this should instead be the character '‹'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-23/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-23/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-23.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‹')
+Message:  element contains 'Ã‹' - this should instead be the character 'Ë'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã‹</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-23/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-23/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-23.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‹')
+Message:  element contains 'Ã‹' - this should instead be the character 'Ë'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ë</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-23/unicode-test-23.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-23/unicode-test-23.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã‹')" role="warning" id="unicode-test-23">
+        <name/> element contains 'Ã‹' - this should instead be the character 'Ë'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-24/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-24/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-24.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å’')
+Message:  element contains 'Å’' - this should instead be the character 'Œ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Å’ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-24/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-24/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-24.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å’')
+Message:  element contains 'Å’' - this should instead be the character 'Œ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Œ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-24/unicode-test-24.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-24/unicode-test-24.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Å’')" role="warning" id="unicode-test-24">
+        <name/> element contains 'Å’' - this should instead be the character 'Œ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-25/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-25/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-25.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'ÃŒ')
+Message:  element contains 'ÃŒ' - this should instead be the character 'Ì'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>ÃŒ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-25/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-25/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-25.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'ÃŒ')
+Message:  element contains 'ÃŒ' - this should instead be the character 'Ì'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ì</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-25/unicode-test-25.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-25/unicode-test-25.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'ÃŒ')" role="warning" id="unicode-test-25">
+        <name/> element contains 'ÃŒ' - this should instead be the character 'Ì'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-26/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-26/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-26.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Í'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-26/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-26/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-26.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Í'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Í</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-26/unicode-test-26.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-26/unicode-test-26.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã')" role="warning" id="unicode-test-26">
+        <name/> element contains 'Ã' - this should instead be the character 'Í'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-27/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-27/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-27.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å½')
+Message:  element contains 'Å½' - this should instead be the character 'Ž'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Å½ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-27/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-27/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-27.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å½')
+Message:  element contains 'Å½' - this should instead be the character 'Ž'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ž</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-27/unicode-test-27.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-27/unicode-test-27.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Å½')" role="warning" id="unicode-test-27">
+        <name/> element contains 'Å½' - this should instead be the character 'Ž'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-28/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-28/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-28.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'ÃŽ')
+Message:  element contains 'ÃŽ' - this should instead be the character 'Î'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>ÃŽ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-28/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-28/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-28.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'ÃŽ')
+Message:  element contains 'ÃŽ' - this should instead be the character 'Î'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Î</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-28/unicode-test-28.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-28/unicode-test-28.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'ÃŽ')" role="warning" id="unicode-test-28">
+        <name/> element contains 'ÃŽ' - this should instead be the character 'Î'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-29/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-29/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-29.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Ï'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-29/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-29/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-29.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Ï'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ï</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-29/unicode-test-29.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-29/unicode-test-29.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã')" role="warning" id="unicode-test-29">
+        <name/> element contains 'Ã' - this should instead be the character 'Ï'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-3/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-3/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-3.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Á'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-3/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-3/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-3.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Á'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Á</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-3/unicode-test-3.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-3/unicode-test-3.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã')" role="warning" id="unicode-test-3">
+        <name/> element contains 'Ã' - this should instead be the character 'Á'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-30/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-30/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-30.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Ð'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-30/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-30/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-30.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Ð'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ð</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-30/unicode-test-30.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-30/unicode-test-30.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã')" role="warning" id="unicode-test-30">
+        <name/> element contains 'Ã' - this should instead be the character 'Ð'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-31/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-31/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-31.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€˜')
+Message:  element contains 'â€˜' - this should instead be the character '‘'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€˜ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-31/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-31/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-31.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€˜')
+Message:  element contains 'â€˜' - this should instead be the character '‘'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ‘</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-31/unicode-test-31.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-31/unicode-test-31.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€˜')" role="warning" id="unicode-test-31">
+        <name/> element contains 'â€˜' - this should instead be the character '‘'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-32/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-32/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-32.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‘')
+Message:  element contains 'Ã‘' - this should instead be the character 'Ñ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã‘</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-32/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-32/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-32.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‘')
+Message:  element contains 'Ã‘' - this should instead be the character 'Ñ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ñ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-32/unicode-test-32.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-32/unicode-test-32.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã‘')" role="warning" id="unicode-test-32">
+        <name/> element contains 'Ã‘' - this should instead be the character 'Ñ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-33/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-33/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-33.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€™')
+Message:  element contains 'â€™' - this should instead be the character '’'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€™ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-33/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-33/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-33.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€™')
+Message:  element contains 'â€™' - this should instead be the character '’'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ’</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-33/unicode-test-33.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-33/unicode-test-33.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€™')" role="warning" id="unicode-test-33">
+        <name/> element contains 'â€™' - this should instead be the character '’'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-34/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-34/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-34.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã’')
+Message:  element contains 'Ã’' - this should instead be the character 'Ò'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã’</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-34/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-34/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-34.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã’')
+Message:  element contains 'Ã’' - this should instead be the character 'Ò'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ò</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-34/unicode-test-34.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-34/unicode-test-34.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã’')" role="warning" id="unicode-test-34">
+        <name/> element contains 'Ã’' - this should instead be the character 'Ò'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-35/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-35/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-35.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€œ')
+Message:  element contains 'â€œ' - this should instead be the character '“'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€œ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-35/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-35/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-35.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€œ')
+Message:  element contains 'â€œ' - this should instead be the character '“'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test “</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-35/unicode-test-35.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-35/unicode-test-35.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€œ')" role="warning" id="unicode-test-35">
+        <name/> element contains 'â€œ' - this should instead be the character '“'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-36/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-36/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-36.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã“')
+Message:  element contains 'Ã“' - this should instead be the character 'Ó'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã“</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-36/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-36/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-36.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã“')
+Message:  element contains 'Ã“' - this should instead be the character 'Ó'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ó</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-36/unicode-test-36.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-36/unicode-test-36.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã“')" role="warning" id="unicode-test-36">
+        <name/> element contains 'Ã“' - this should instead be the character 'Ó'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-37/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-37/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-37.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€')
+Message:  element contains 'â€' - this should instead be the character '”'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-37/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-37/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-37.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€')
+Message:  element contains 'â€' - this should instead be the character '”'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ”</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-37/unicode-test-37.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-37/unicode-test-37.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€')" role="warning" id="unicode-test-37">
+        <name/> element contains 'â€' - this should instead be the character '”'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-38/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-38/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-38.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã”')
+Message:  element contains 'Ã”' - this should instead be the character 'Ô'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã”</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-38/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-38/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-38.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã”')
+Message:  element contains 'Ã”' - this should instead be the character 'Ô'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ô</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-38/unicode-test-38.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-38/unicode-test-38.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã”')" role="warning" id="unicode-test-38">
+        <name/> element contains 'Ã”' - this should instead be the character 'Ô'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-39/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-39/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-39.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã•')
+Message:  element contains 'Ã•' - this should instead be the character 'Õ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã•</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-39/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-39/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-39.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã•')
+Message:  element contains 'Ã•' - this should instead be the character 'Õ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Õ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-39/unicode-test-39.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-39/unicode-test-39.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã•')" role="warning" id="unicode-test-39">
+        <name/> element contains 'Ã•' - this should instead be the character 'Õ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-4/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-4/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-4.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€š')
+Message:  element contains 'â€š' - this should instead be the character '‚'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€š </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-4/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-4/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-4.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€š')
+Message:  element contains 'â€š' - this should instead be the character '‚'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ‚</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-4/unicode-test-4.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-4/unicode-test-4.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€š')" role="warning" id="unicode-test-4">
+        <name/> element contains 'â€š' - this should instead be the character '‚'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-40/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-40/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-40.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€“')
+Message:  element contains 'â€“' - this should instead be the character '–'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€“ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-40/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-40/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-40.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€“')
+Message:  element contains 'â€“' - this should instead be the character '–'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test –</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-40/unicode-test-40.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-40/unicode-test-40.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€“')" role="warning" id="unicode-test-40">
+        <name/> element contains 'â€“' - this should instead be the character '–'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-41/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-41/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-41.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã–')
+Message:  element contains 'Ã–' - this should instead be the character 'Ö'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã–</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-41/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-41/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-41.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã–')
+Message:  element contains 'Ã–' - this should instead be the character 'Ö'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ö</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-41/unicode-test-41.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-41/unicode-test-41.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã–')" role="warning" id="unicode-test-41">
+        <name/> element contains 'Ã–' - this should instead be the character 'Ö'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-42/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-42/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-42.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€”')
+Message:  element contains 'â€”' - this should instead be the character '—'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€” </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-42/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-42/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-42.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€”')
+Message:  element contains 'â€”' - this should instead be the character '—'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test —</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-42/unicode-test-42.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-42/unicode-test-42.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€”')" role="warning" id="unicode-test-42">
+        <name/> element contains 'â€”' - this should instead be the character '—'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-43/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-43/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-43.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã—')
+Message:  element contains 'Ã—' - this should instead be the character '×'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã—</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-43/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-43/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-43.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã—')
+Message:  element contains 'Ã—' - this should instead be the character '×'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ×</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-43/unicode-test-43.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-43/unicode-test-43.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã—')" role="warning" id="unicode-test-43">
+        <name/> element contains 'Ã—' - this should instead be the character '×'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-44/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-44/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-44.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ëœ')
+Message:  element contains 'Ëœ' - this should instead be the character '˜'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ëœ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-44/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-44/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-44.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ëœ')
+Message:  element contains 'Ëœ' - this should instead be the character '˜'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ˜</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-44/unicode-test-44.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-44/unicode-test-44.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ëœ')" role="warning" id="unicode-test-44">
+        <name/> element contains 'Ëœ' - this should instead be the character '˜'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-45/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-45/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-45.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã˜')
+Message:  element contains 'Ã˜' - this should instead be the character 'Ø'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã˜</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-45/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-45/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-45.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã˜')
+Message:  element contains 'Ã˜' - this should instead be the character 'Ø'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ø</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-45/unicode-test-45.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-45/unicode-test-45.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã˜')" role="warning" id="unicode-test-45">
+        <name/> element contains 'Ã˜' - this should instead be the character 'Ø'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-46/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-46/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-46.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã™')
+Message:  element contains 'Ã™' - this should instead be the character 'Ù'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã™</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-46/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-46/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-46.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã™')
+Message:  element contains 'Ã™' - this should instead be the character 'Ù'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ù</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-46/unicode-test-46.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-46/unicode-test-46.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã™')" role="warning" id="unicode-test-46">
+        <name/> element contains 'Ã™' - this should instead be the character 'Ù'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-47/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-47/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-47.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å¡')
+Message:  element contains 'Å¡' - this should instead be the character 'š'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Å¡ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-47/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-47/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-47.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å¡')
+Message:  element contains 'Å¡' - this should instead be the character 'š'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test š</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-47/unicode-test-47.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-47/unicode-test-47.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Å¡')" role="warning" id="unicode-test-47">
+        <name/> element contains 'Å¡' - this should instead be the character 'š'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-48/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-48/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-48.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãš')
+Message:  element contains 'Ãš' - this should instead be the character 'Ú'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ãš</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-48/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-48/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-48.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãš')
+Message:  element contains 'Ãš' - this should instead be the character 'Ú'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ú</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-48/unicode-test-48.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-48/unicode-test-48.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ãš')" role="warning" id="unicode-test-48">
+        <name/> element contains 'Ãš' - this should instead be the character 'Ú'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-49/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-49/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-49.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€º')
+Message:  element contains 'â€º' - this should instead be the character '›'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€º </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-49/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-49/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-49.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€º')
+Message:  element contains 'â€º' - this should instead be the character '›'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ›</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-49/unicode-test-49.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-49/unicode-test-49.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€º')" role="warning" id="unicode-test-49">
+        <name/> element contains 'â€º' - this should instead be the character '›'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-5/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-5/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-5.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‚')
+Message:  element contains 'Ã‚' - this should instead be the character 'Â'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã‚</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-5/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-5/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-5.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã‚')
+Message:  element contains 'Ã‚' - this should instead be the character 'Â'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Â</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-5/unicode-test-5.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-5/unicode-test-5.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã‚')" role="warning" id="unicode-test-5">
+        <name/> element contains 'Ã‚' - this should instead be the character 'Â'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-50/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-50/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-50.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã›')
+Message:  element contains 'Ã›' - this should instead be the character 'Û'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã›</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-50/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-50/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-50.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã›')
+Message:  element contains 'Ã›' - this should instead be the character 'Û'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Û</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-50/unicode-test-50.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-50/unicode-test-50.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã›')" role="warning" id="unicode-test-50">
+        <name/> element contains 'Ã›' - this should instead be the character 'Û'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-51/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-51/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-51.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å“')
+Message:  element contains 'Å“' - this should instead be the character 'œ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Å“ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-51/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-51/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-51.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å“')
+Message:  element contains 'Å“' - this should instead be the character 'œ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test œ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-51/unicode-test-51.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-51/unicode-test-51.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Å“')" role="warning" id="unicode-test-51">
+        <name/> element contains 'Å“' - this should instead be the character 'œ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-52/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-52/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-52.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãœ')
+Message:  element contains 'Ãœ' - this should instead be the character 'Ü'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ãœ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-52/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-52/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-52.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãœ')
+Message:  element contains 'Ãœ' - this should instead be the character 'Ü'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ü</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-52/unicode-test-52.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-52/unicode-test-52.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ãœ')" role="warning" id="unicode-test-52">
+        <name/> element contains 'Ãœ' - this should instead be the character 'Ü'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-53/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-53/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-53.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Ý'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-53/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-53/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-53.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã')
+Message:  element contains 'Ã' - this should instead be the character 'Ý'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ý</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-53/unicode-test-53.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-53/unicode-test-53.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã')" role="warning" id="unicode-test-53">
+        <name/> element contains 'Ã' - this should instead be the character 'Ý'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-54/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-54/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-54.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å¾')
+Message:  element contains 'Å¾' - this should instead be the character 'ž'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Å¾ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-54/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-54/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-54.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å¾')
+Message:  element contains 'Å¾' - this should instead be the character 'ž'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ž</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-54/unicode-test-54.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-54/unicode-test-54.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Å¾')" role="warning" id="unicode-test-54">
+        <name/> element contains 'Å¾' - this should instead be the character 'ž'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-55/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-55/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-55.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãž')
+Message:  element contains 'Ãž' - this should instead be the character 'Þ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ãž</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-55/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-55/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-55.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãž')
+Message:  element contains 'Ãž' - this should instead be the character 'Þ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Þ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-55/unicode-test-55.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-55/unicode-test-55.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ãž')" role="warning" id="unicode-test-55">
+        <name/> element contains 'Ãž' - this should instead be the character 'Þ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-56/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-56/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-56.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å¸')
+Message:  element contains 'Å¸' - this should instead be the character 'Ÿ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Å¸ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-56/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-56/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-56.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Å¸')
+Message:  element contains 'Å¸' - this should instead be the character 'Ÿ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ÿ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-56/unicode-test-56.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-56/unicode-test-56.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Å¸')" role="warning" id="unicode-test-56">
+        <name/> element contains 'Å¸' - this should instead be the character 'Ÿ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-57/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-57/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-57.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'ÃŸ')
+Message:  element contains 'ÃŸ' - this should instead be the character 'ß'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>ÃŸ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-57/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-57/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-57.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'ÃŸ')
+Message:  element contains 'ÃŸ' - this should instead be the character 'ß'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ß</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-57/unicode-test-57.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-57/unicode-test-57.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'ÃŸ')" role="warning" id="unicode-test-57">
+        <name/> element contains 'ÃŸ' - this should instead be the character 'ß'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-58/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-58/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-58.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¡')
+Message:  element contains 'Â¡' - this should instead be the character '¡'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â¡ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-58/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-58/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-58.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¡')
+Message:  element contains 'Â¡' - this should instead be the character '¡'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ¡</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-58/unicode-test-58.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-58/unicode-test-58.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â¡')" role="warning" id="unicode-test-58">
+        <name/> element contains 'Â¡' - this should instead be the character '¡'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-59/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-59/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-59.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¡')
+Message:  element contains 'Ã¡' - this should instead be the character 'á'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¡</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-59/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-59/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-59.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¡')
+Message:  element contains 'Ã¡' - this should instead be the character 'á'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test á</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-59/unicode-test-59.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-59/unicode-test-59.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¡')" role="warning" id="unicode-test-59">
+        <name/> element contains 'Ã¡' - this should instead be the character 'á'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-6/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-6/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-6.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Æ’')
+Message:  element contains 'Æ’' - this should instead be the character 'ƒ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Æ’ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-6/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-6/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-6.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Æ’')
+Message:  element contains 'Æ’' - this should instead be the character 'ƒ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ƒ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-6/unicode-test-6.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-6/unicode-test-6.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Æ’')" role="warning" id="unicode-test-6">
+        <name/> element contains 'Æ’' - this should instead be the character 'ƒ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-60/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-60/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-60.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¢')
+Message:  element contains 'Â¢' - this should instead be the character '¢'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â¢ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-60/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-60/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-60.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¢')
+Message:  element contains 'Â¢' - this should instead be the character '¢'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ¢</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-60/unicode-test-60.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-60/unicode-test-60.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â¢')" role="warning" id="unicode-test-60">
+        <name/> element contains 'Â¢' - this should instead be the character '¢'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-61/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-61/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-61.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¢')
+Message:  element contains 'Ã¢' - this should instead be the character 'â'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¢</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-61/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-61/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-61.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¢')
+Message:  element contains 'Ã¢' - this should instead be the character 'â'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test â</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-61/unicode-test-61.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-61/unicode-test-61.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¢')" role="warning" id="unicode-test-61">
+        <name/> element contains 'Ã¢' - this should instead be the character 'â'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-62/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-62/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-62.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â£')
+Message:  element contains 'Â£' - this should instead be the character '£'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â£ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-62/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-62/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-62.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â£')
+Message:  element contains 'Â£' - this should instead be the character '£'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test £</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-62/unicode-test-62.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-62/unicode-test-62.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â£')" role="warning" id="unicode-test-62">
+        <name/> element contains 'Â£' - this should instead be the character '£'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-63/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-63/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-63.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã£')
+Message:  element contains 'Ã£' - this should instead be the character 'ã'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã£</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-63/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-63/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-63.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã£')
+Message:  element contains 'Ã£' - this should instead be the character 'ã'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ã</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-63/unicode-test-63.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-63/unicode-test-63.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã£')" role="warning" id="unicode-test-63">
+        <name/> element contains 'Ã£' - this should instead be the character 'ã'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-64/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-64/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-64.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¤')
+Message:  element contains 'Â¤' - this should instead be the character '¤'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â¤ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-64/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-64/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-64.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¤')
+Message:  element contains 'Â¤' - this should instead be the character '¤'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ¤</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-64/unicode-test-64.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-64/unicode-test-64.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â¤')" role="warning" id="unicode-test-64">
+        <name/> element contains 'Â¤' - this should instead be the character '¤'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-65/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-65/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-65.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¤')
+Message:  element contains 'Ã¤' - this should instead be the character 'ä'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¤</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-65/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-65/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-65.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¤')
+Message:  element contains 'Ã¤' - this should instead be the character 'ä'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ä</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-65/unicode-test-65.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-65/unicode-test-65.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¤')" role="warning" id="unicode-test-65">
+        <name/> element contains 'Ã¤' - this should instead be the character 'ä'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-66/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-66/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-66.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¥')
+Message:  element contains 'Ã¥' - this should instead be the character 'å'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¥</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-66/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-66/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-66.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¥')
+Message:  element contains 'Ã¥' - this should instead be the character 'å'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test å</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-66/unicode-test-66.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-66/unicode-test-66.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¥')" role="warning" id="unicode-test-66">
+        <name/> element contains 'Ã¥' - this should instead be the character 'å'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-67/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-67/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-67.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¨')
+Message:  element contains 'Â¨' - this should instead be the character '¨'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â¨ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-67/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-67/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-67.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¨')
+Message:  element contains 'Â¨' - this should instead be the character '¨'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ¨</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-67/unicode-test-67.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-67/unicode-test-67.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â¨')" role="warning" id="unicode-test-67">
+        <name/> element contains 'Â¨' - this should instead be the character '¨'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-68/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-68/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-68.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¨')
+Message:  element contains 'Ã¨' - this should instead be the character 'è'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¨</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-68/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-68/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-68.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¨')
+Message:  element contains 'Ã¨' - this should instead be the character 'è'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test è</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-68/unicode-test-68.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-68/unicode-test-68.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¨')" role="warning" id="unicode-test-68">
+        <name/> element contains 'Ã¨' - this should instead be the character 'è'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-69/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-69/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-69.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Âª')
+Message:  element contains 'Âª' - this should instead be the character 'ª'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Âª </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-69/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-69/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-69.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Âª')
+Message:  element contains 'Âª' - this should instead be the character 'ª'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ª</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-69/unicode-test-69.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-69/unicode-test-69.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Âª')" role="warning" id="unicode-test-69">
+        <name/> element contains 'Âª' - this should instead be the character 'ª'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-7/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-7/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-7.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãƒ')
+Message:  element contains 'Ãƒ' - this should instead be the character 'Ã'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ãƒ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-7/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-7/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-7.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãƒ')
+Message:  element contains 'Ãƒ' - this should instead be the character 'Ã'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ã</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-7/unicode-test-7.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-7/unicode-test-7.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ãƒ')" role="warning" id="unicode-test-7">
+        <name/> element contains 'Ãƒ' - this should instead be the character 'Ã'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-70/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-70/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-70.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãª')
+Message:  element contains 'Ãª' - this should instead be the character 'ê'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ãª</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-70/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-70/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-70.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãª')
+Message:  element contains 'Ãª' - this should instead be the character 'ê'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ê</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-70/unicode-test-70.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-70/unicode-test-70.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ãª')" role="warning" id="unicode-test-70">
+        <name/> element contains 'Ãª' - this should instead be the character 'ê'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-71/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-71/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-71.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â­')
+Message:  element contains 'Â­' - this should instead be the character '­'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â­ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-71/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-71/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-71.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â­')
+Message:  element contains 'Â­' - this should instead be the character '­'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ­</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-71/unicode-test-71.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-71/unicode-test-71.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â­')" role="warning" id="unicode-test-71">
+        <name/> element contains 'Â­' - this should instead be the character '­'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-72/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-72/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-72.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã­')
+Message:  element contains 'Ã­' - this should instead be the character 'í'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã­</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-72/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-72/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-72.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã­')
+Message:  element contains 'Ã­' - this should instead be the character 'í'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test í</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-72/unicode-test-72.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-72/unicode-test-72.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã­')" role="warning" id="unicode-test-72">
+        <name/> element contains 'Ã­' - this should instead be the character 'í'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-73/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-73/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-73.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¯')
+Message:  element contains 'Â¯' - this should instead be the character '¯'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â¯ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-73/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-73/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-73.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¯')
+Message:  element contains 'Â¯' - this should instead be the character '¯'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ¯</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-73/unicode-test-73.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-73/unicode-test-73.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â¯')" role="warning" id="unicode-test-73">
+        <name/> element contains 'Â¯' - this should instead be the character '¯'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-74/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-74/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-74.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¯')
+Message:  element contains 'Ã¯' - this should instead be the character 'ï'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¯</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-74/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-74/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-74.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¯')
+Message:  element contains 'Ã¯' - this should instead be the character 'ï'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ï</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-74/unicode-test-74.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-74/unicode-test-74.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¯')" role="warning" id="unicode-test-74">
+        <name/> element contains 'Ã¯' - this should instead be the character 'ï'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-75/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-75/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-75.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â°')
+Message:  element contains 'Â°' - this should instead be the character '°'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â° </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-75/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-75/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-75.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â°')
+Message:  element contains 'Â°' - this should instead be the character '°'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test °</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-75/unicode-test-75.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-75/unicode-test-75.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â°')" role="warning" id="unicode-test-75">
+        <name/> element contains 'Â°' - this should instead be the character '°'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-76/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-76/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-76.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã°')
+Message:  element contains 'Ã°' - this should instead be the character 'ð'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã°</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-76/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-76/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-76.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã°')
+Message:  element contains 'Ã°' - this should instead be the character 'ð'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ð</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-76/unicode-test-76.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-76/unicode-test-76.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã°')" role="warning" id="unicode-test-76">
+        <name/> element contains 'Ã°' - this should instead be the character 'ð'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-77/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-77/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-77.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â±')
+Message:  element contains 'Â±' - this should instead be the character '±'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â± </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-77/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-77/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-77.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â±')
+Message:  element contains 'Â±' - this should instead be the character '±'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ±</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-77/unicode-test-77.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-77/unicode-test-77.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â±')" role="warning" id="unicode-test-77">
+        <name/> element contains 'Â±' - this should instead be the character '±'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-78/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-78/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-78.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã±')
+Message:  element contains 'Ã±' - this should instead be the character 'ñ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã±</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-78/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-78/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-78.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã±')
+Message:  element contains 'Ã±' - this should instead be the character 'ñ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ñ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-78/unicode-test-78.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-78/unicode-test-78.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã±')" role="warning" id="unicode-test-78">
+        <name/> element contains 'Ã±' - this should instead be the character 'ñ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-79/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-79/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-79.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â´')
+Message:  element contains 'Â´' - this should instead be the character '´'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â´ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-79/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-79/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-79.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â´')
+Message:  element contains 'Â´' - this should instead be the character '´'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ´</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-79/unicode-test-79.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-79/unicode-test-79.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â´')" role="warning" id="unicode-test-79">
+        <name/> element contains 'Â´' - this should instead be the character '´'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-8/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-8/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-8.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€ž')
+Message:  element contains 'â€ž' - this should instead be the character '„'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â€ž </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-8/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-8/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-8.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'â€ž')
+Message:  element contains 'â€ž' - this should instead be the character '„'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test „</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-8/unicode-test-8.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-8/unicode-test-8.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'â€ž')" role="warning" id="unicode-test-8">
+        <name/> element contains 'â€ž' - this should instead be the character '„'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-80/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-80/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-80.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã´')
+Message:  element contains 'Ã´' - this should instead be the character 'ô'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã´</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-80/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-80/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-80.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã´')
+Message:  element contains 'Ã´' - this should instead be the character 'ô'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ô</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-80/unicode-test-80.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-80/unicode-test-80.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã´')" role="warning" id="unicode-test-80">
+        <name/> element contains 'Ã´' - this should instead be the character 'ô'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-81/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-81/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-81.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Âµ')
+Message:  element contains 'Âµ' - this should instead be the character 'µ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Âµ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-81/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-81/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-81.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Âµ')
+Message:  element contains 'Âµ' - this should instead be the character 'µ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test µ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-81/unicode-test-81.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-81/unicode-test-81.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Âµ')" role="warning" id="unicode-test-81">
+        <name/> element contains 'Âµ' - this should instead be the character 'µ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-82/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-82/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-82.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãµ')
+Message:  element contains 'Ãµ' - this should instead be the character 'õ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ãµ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-82/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-82/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-82.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãµ')
+Message:  element contains 'Ãµ' - this should instead be the character 'õ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test õ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-82/unicode-test-82.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-82/unicode-test-82.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ãµ')" role="warning" id="unicode-test-82">
+        <name/> element contains 'Ãµ' - this should instead be the character 'õ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-83/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-83/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-83.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¶')
+Message:  element contains 'Â¶' - this should instead be the character '¶'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â¶ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-83/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-83/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-83.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¶')
+Message:  element contains 'Â¶' - this should instead be the character '¶'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ¶</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-83/unicode-test-83.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-83/unicode-test-83.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â¶')" role="warning" id="unicode-test-83">
+        <name/> element contains 'Â¶' - this should instead be the character '¶'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-84/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-84/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-84.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¶')
+Message:  element contains 'Ã¶' - this should instead be the character 'ö'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¶</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-84/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-84/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-84.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¶')
+Message:  element contains 'Ã¶' - this should instead be the character 'ö'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ö</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-84/unicode-test-84.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-84/unicode-test-84.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¶')" role="warning" id="unicode-test-84">
+        <name/> element contains 'Ã¶' - this should instead be the character 'ö'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-85/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-85/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-85.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â·')
+Message:  element contains 'Â·' - this should instead be the character '·'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â· </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-85/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-85/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-85.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â·')
+Message:  element contains 'Â·' - this should instead be the character '·'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ·</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-85/unicode-test-85.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-85/unicode-test-85.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â·')" role="warning" id="unicode-test-85">
+        <name/> element contains 'Â·' - this should instead be the character '·'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-86/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-86/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-86.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã·')
+Message:  element contains 'Ã·' - this should instead be the character '÷'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã·</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-86/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-86/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-86.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã·')
+Message:  element contains 'Ã·' - this should instead be the character '÷'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ÷</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-86/unicode-test-86.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-86/unicode-test-86.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã·')" role="warning" id="unicode-test-86">
+        <name/> element contains 'Ã·' - this should instead be the character '÷'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-87/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-87/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-87.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¸')
+Message:  element contains 'Â¸' - this should instead be the character '¸'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â¸ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-87/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-87/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-87.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¸')
+Message:  element contains 'Â¸' - this should instead be the character '¸'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ¸</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-87/unicode-test-87.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-87/unicode-test-87.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â¸')" role="warning" id="unicode-test-87">
+        <name/> element contains 'Â¸' - this should instead be the character '¸'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-88/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-88/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-88.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¸')
+Message:  element contains 'Ã¸' - this should instead be the character 'ø'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¸</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-88/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-88/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-88.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¸')
+Message:  element contains 'Ã¸' - this should instead be the character 'ø'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ø</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-88/unicode-test-88.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-88/unicode-test-88.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¸')" role="warning" id="unicode-test-88">
+        <name/> element contains 'Ã¸' - this should instead be the character 'ø'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-89/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-89/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-89.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¹')
+Message:  element contains 'Ã¹' - this should instead be the character 'ù'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¹</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-89/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-89/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-89.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¹')
+Message:  element contains 'Ã¹' - this should instead be the character 'ù'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ù</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-89/unicode-test-89.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-89/unicode-test-89.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¹')" role="warning" id="unicode-test-89">
+        <name/> element contains 'Ã¹' - this should instead be the character 'ù'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-9/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-9/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-9.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã„')
+Message:  element contains 'Ã„' - this should instead be the character 'Ä'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã„</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-9/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-9/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-9.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã„')
+Message:  element contains 'Ã„' - this should instead be the character 'Ä'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test Ä</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-9/unicode-test-9.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-9/unicode-test-9.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã„')" role="warning" id="unicode-test-9">
+        <name/> element contains 'Ã„' - this should instead be the character 'Ä'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-90/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-90/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-90.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Âº')
+Message:  element contains 'Âº' - this should instead be the character 'º'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Âº </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-90/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-90/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-90.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Âº')
+Message:  element contains 'Âº' - this should instead be the character 'º'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test º</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-90/unicode-test-90.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-90/unicode-test-90.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Âº')" role="warning" id="unicode-test-90">
+        <name/> element contains 'Âº' - this should instead be the character 'º'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-91/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-91/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-91.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãº')
+Message:  element contains 'Ãº' - this should instead be the character 'ú'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ãº</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-91/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-91/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-91.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ãº')
+Message:  element contains 'Ãº' - this should instead be the character 'ú'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ú</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-91/unicode-test-91.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-91/unicode-test-91.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ãº')" role="warning" id="unicode-test-91">
+        <name/> element contains 'Ãº' - this should instead be the character 'ú'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-92/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-92/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-92.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¿')
+Message:  element contains 'Â¿' - this should instead be the character '¿'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Â¿ </p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-92/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-92/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-92.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Â¿')
+Message:  element contains 'Â¿' - this should instead be the character '¿'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ¿</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-92/unicode-test-92.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-92/unicode-test-92.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Â¿')" role="warning" id="unicode-test-92">
+        <name/> element contains 'Â¿' - this should instead be the character '¿'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/unicode-tests/unicode-test-93/fail.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-93/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-93.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¿')
+Message:  element contains 'Ã¿' - this should instead be the character 'ÿ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>Ã¿</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-93/pass.xml
+++ b/test/tests/gen/unicode-tests/unicode-test-93/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="unicode-test-93.sch"?>
+<!--Context: p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]
+Test: report    contains(.,'Ã¿')
+Message:  element contains 'Ã¿' - this should instead be the character 'ÿ'. - .-->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p>â test test ÿ</p>
+  </article>
+</root>

--- a/test/tests/gen/unicode-tests/unicode-test-93/unicode-test-93.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-93/unicode-test-93.sch
@@ -1,0 +1,737 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Human Biology and Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'model'">
+        <xsl:value-of select="'Model'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|a\.\s?thaliana|arabidopsis\s?thaliana|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|h\.\s?sapiens|homo\s?sapiens|e\.\s?faecalis|enterococcus\s?faecalis|c\.\s?trachomatis|chlamydia\s?trachomatis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?plantaginis|plantago\s?lanceolata|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','') gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <pattern id="unicode-checks">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+      <report test="contains(.,'Ã¿')" role="warning" id="unicode-test-93">
+        <name/> element contains 'Ã¿' - this should instead be the character 'ÿ'. - <value-of select="."/>.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1458,11 +1458,11 @@
   <pattern id="funding-group-tests-pattern">
     <rule context="article-meta/funding-group" id="funding-group-tests">
 		
-		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
+		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1470,41 +1470,39 @@
 	  <let name="id" value="@id"/>
 	  <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
 		
-		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source.</assert>
+		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2</assert>
 		
-		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient.</assert>
+		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3</assert>
 		
-		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id.</report>
+		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4</report>
 		
-		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
+		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5</assert>
 		
-		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6</report>
 	  
-	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7</assert>
 	  
-	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
-      </report>
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8</report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
       
-      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>
-      </report>
+      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1</report>
       
-      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2</report>
       
-      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3</report>
       
-      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>.</report>
+      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4</report>
       
     </rule>
   </pattern>
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test</assert>
       
     </rule>
   </pattern>
@@ -1549,15 +1547,15 @@
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
       
-      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta.</assert>
+      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1</assert>
       
-      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2</report>
       
-      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta.</assert>
+      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3</assert>
       
-      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14</report>
       
-      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15</report>
       
     </rule>
   </pattern>
@@ -1567,28 +1565,27 @@
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
       <report test="not(child::*) and normalize-space(.)=''" role="error" id="custom-meta-test-4">The value of meta-value cannot be empty</report>
       
-      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed.</report>
+      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5</report>
       
-      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark.</assert>
+      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-6</assert>
       
-      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.</report>
+      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7</report>
       
-      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
+      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8</report>
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-custom-meta-test-9</report>
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-9</report>
       
-      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
+      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11</report>
       
-      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
+      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13</report>
       
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="warning" id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>.</report>
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="warning" id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-rep-study-custom-meta-test</report>
       
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>
-      </report>
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-rep-study-custom-meta-test</report>
     </rule>
   </pattern>
   <pattern id="meta-value-child-tests-pattern">
@@ -1596,7 +1593,7 @@
       <let name="allowed-elements" value="('italic','sup','sub')"/>
       
       <assert test="local-name() = $allowed-elements" role="error" id="custom-meta-child-test-1">
-        <name/> is not allowed in impact statement.</assert>
+        <name/> is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1</assert>
       
     </rule>
   </pattern>
@@ -4931,9 +4928,9 @@
      <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]"/>
      <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]/*)"/>
      
-     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1</assert>
      
-     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2</assert>
      
    </rule>
   </pattern>
@@ -6240,6 +6237,8 @@
       
       <report test="matches(lower-case(source[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
+      <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
+      
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
@@ -6286,11 +6285,15 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
       
       <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')" role="warning" id="data-empiar-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-empiar-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
       
@@ -6920,6 +6923,285 @@
     </rule>
   </pattern>
   
+  <pattern id="unicode-tests-pattern">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+    
+    
+    <report test="contains(.,'â‚¬')" role="warning" id="unicode-test-1">
+        <name/> element contains 'â‚¬' - this should instead be the character '€'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã€')" role="warning" id="unicode-test-2">
+        <name/> element contains 'Ã€' - this should instead be the character 'À'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-3">
+        <name/> element contains 'Ã' - this should instead be the character 'Á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€š')" role="warning" id="unicode-test-4">
+        <name/> element contains 'â€š' - this should instead be the character '‚'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‚')" role="warning" id="unicode-test-5">
+        <name/> element contains 'Ã‚' - this should instead be the character 'Â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Æ’')" role="warning" id="unicode-test-6">
+        <name/> element contains 'Æ’' - this should instead be the character 'ƒ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãƒ')" role="warning" id="unicode-test-7">
+        <name/> element contains 'Ãƒ' - this should instead be the character 'Ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€ž')" role="warning" id="unicode-test-8">
+        <name/> element contains 'â€ž' - this should instead be the character '„'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã„')" role="warning" id="unicode-test-9">
+        <name/> element contains 'Ã„' - this should instead be the character 'Ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¦')" role="warning" id="unicode-test-10">
+        <name/> element contains 'â€¦' - this should instead be the character '…'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã…')" role="warning" id="unicode-test-11">
+        <name/> element contains 'Ã…' - this should instead be the character 'Å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã†')" role="warning" id="unicode-test-13">
+        <name/> element contains 'Ã†' - this should instead be the character 'Æ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¡')" role="warning" id="unicode-test-14">
+        <name/> element contains 'â€¡' - this should instead be the character '‡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‡')" role="warning" id="unicode-test-15">
+        <name/> element contains 'Ã‡' - this should instead be the character 'Ç'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ë†')" role="warning" id="unicode-test-16">
+        <name/> element contains 'Ë†' - this should instead be the character 'ˆ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãˆ')" role="warning" id="unicode-test-17">
+        <name/> element contains 'Ãˆ' - this should instead be the character 'È'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€°')" role="warning" id="unicode-test-18">
+        <name/> element contains 'â€°' - this should instead be the character '‰'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‰')" role="warning" id="unicode-test-19">
+        <name/> element contains 'Ã‰' - this should instead be the character 'É'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŠ')" role="warning" id="unicode-test-21">
+        <name/> element contains 'ÃŠ' - this should instead be the character 'Ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¹')" role="warning" id="unicode-test-22">
+        <name/> element contains 'â€¹' - this should instead be the character '‹'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‹')" role="warning" id="unicode-test-23">
+        <name/> element contains 'Ã‹' - this should instead be the character 'Ë'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å’')" role="warning" id="unicode-test-24">
+        <name/> element contains 'Å’' - this should instead be the character 'Œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŒ')" role="warning" id="unicode-test-25">
+        <name/> element contains 'ÃŒ' - this should instead be the character 'Ì'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-26">
+        <name/> element contains 'Ã' - this should instead be the character 'Í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å½')" role="warning" id="unicode-test-27">
+        <name/> element contains 'Å½' - this should instead be the character 'Ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŽ')" role="warning" id="unicode-test-28">
+        <name/> element contains 'ÃŽ' - this should instead be the character 'Î'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-29">
+        <name/> element contains 'Ã' - this should instead be the character 'Ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-30">
+        <name/> element contains 'Ã' - this should instead be the character 'Ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€˜')" role="warning" id="unicode-test-31">
+        <name/> element contains 'â€˜' - this should instead be the character '‘'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‘')" role="warning" id="unicode-test-32">
+        <name/> element contains 'Ã‘' - this should instead be the character 'Ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€™')" role="warning" id="unicode-test-33">
+        <name/> element contains 'â€™' - this should instead be the character '’'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã’')" role="warning" id="unicode-test-34">
+        <name/> element contains 'Ã’' - this should instead be the character 'Ò'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€œ')" role="warning" id="unicode-test-35">
+        <name/> element contains 'â€œ' - this should instead be the character '“'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã“')" role="warning" id="unicode-test-36">
+        <name/> element contains 'Ã“' - this should instead be the character 'Ó'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€')" role="warning" id="unicode-test-37">
+        <name/> element contains 'â€' - this should instead be the character '”'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã”')" role="warning" id="unicode-test-38">
+        <name/> element contains 'Ã”' - this should instead be the character 'Ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã•')" role="warning" id="unicode-test-39">
+        <name/> element contains 'Ã•' - this should instead be the character 'Õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€“')" role="warning" id="unicode-test-40">
+        <name/> element contains 'â€“' - this should instead be the character '–'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã–')" role="warning" id="unicode-test-41">
+        <name/> element contains 'Ã–' - this should instead be the character 'Ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€”')" role="warning" id="unicode-test-42">
+        <name/> element contains 'â€”' - this should instead be the character '—'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã—')" role="warning" id="unicode-test-43">
+        <name/> element contains 'Ã—' - this should instead be the character '×'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ëœ')" role="warning" id="unicode-test-44">
+        <name/> element contains 'Ëœ' - this should instead be the character '˜'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã˜')" role="warning" id="unicode-test-45">
+        <name/> element contains 'Ã˜' - this should instead be the character 'Ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã™')" role="warning" id="unicode-test-46">
+        <name/> element contains 'Ã™' - this should instead be the character 'Ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¡')" role="warning" id="unicode-test-47">
+        <name/> element contains 'Å¡' - this should instead be the character 'š'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãš')" role="warning" id="unicode-test-48">
+        <name/> element contains 'Ãš' - this should instead be the character 'Ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€º')" role="warning" id="unicode-test-49">
+        <name/> element contains 'â€º' - this should instead be the character '›'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã›')" role="warning" id="unicode-test-50">
+        <name/> element contains 'Ã›' - this should instead be the character 'Û'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å“')" role="warning" id="unicode-test-51">
+        <name/> element contains 'Å“' - this should instead be the character 'œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãœ')" role="warning" id="unicode-test-52">
+        <name/> element contains 'Ãœ' - this should instead be the character 'Ü'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-53">
+        <name/> element contains 'Ã' - this should instead be the character 'Ý'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¾')" role="warning" id="unicode-test-54">
+        <name/> element contains 'Å¾' - this should instead be the character 'ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãž')" role="warning" id="unicode-test-55">
+        <name/> element contains 'Ãž' - this should instead be the character 'Þ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¸')" role="warning" id="unicode-test-56">
+        <name/> element contains 'Å¸' - this should instead be the character 'Ÿ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŸ')" role="warning" id="unicode-test-57">
+        <name/> element contains 'ÃŸ' - this should instead be the character 'ß'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¡')" role="warning" id="unicode-test-58">
+        <name/> element contains 'Â¡' - this should instead be the character '¡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¡')" role="warning" id="unicode-test-59">
+        <name/> element contains 'Ã¡' - this should instead be the character 'á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¢')" role="warning" id="unicode-test-60">
+        <name/> element contains 'Â¢' - this should instead be the character '¢'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¢')" role="warning" id="unicode-test-61">
+        <name/> element contains 'Ã¢' - this should instead be the character 'â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â£')" role="warning" id="unicode-test-62">
+        <name/> element contains 'Â£' - this should instead be the character '£'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã£')" role="warning" id="unicode-test-63">
+        <name/> element contains 'Ã£' - this should instead be the character 'ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¤')" role="warning" id="unicode-test-64">
+        <name/> element contains 'Â¤' - this should instead be the character '¤'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¤')" role="warning" id="unicode-test-65">
+        <name/> element contains 'Ã¤' - this should instead be the character 'ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¥')" role="warning" id="unicode-test-66">
+        <name/> element contains 'Ã¥' - this should instead be the character 'å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¨')" role="warning" id="unicode-test-67">
+        <name/> element contains 'Â¨' - this should instead be the character '¨'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¨')" role="warning" id="unicode-test-68">
+        <name/> element contains 'Ã¨' - this should instead be the character 'è'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âª')" role="warning" id="unicode-test-69">
+        <name/> element contains 'Âª' - this should instead be the character 'ª'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãª')" role="warning" id="unicode-test-70">
+        <name/> element contains 'Ãª' - this should instead be the character 'ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â­')" role="warning" id="unicode-test-71">
+        <name/> element contains 'Â­' - this should instead be the character '­'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã­')" role="warning" id="unicode-test-72">
+        <name/> element contains 'Ã­' - this should instead be the character 'í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¯')" role="warning" id="unicode-test-73">
+        <name/> element contains 'Â¯' - this should instead be the character '¯'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¯')" role="warning" id="unicode-test-74">
+        <name/> element contains 'Ã¯' - this should instead be the character 'ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â°')" role="warning" id="unicode-test-75">
+        <name/> element contains 'Â°' - this should instead be the character '°'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã°')" role="warning" id="unicode-test-76">
+        <name/> element contains 'Ã°' - this should instead be the character 'ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â±')" role="warning" id="unicode-test-77">
+        <name/> element contains 'Â±' - this should instead be the character '±'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã±')" role="warning" id="unicode-test-78">
+        <name/> element contains 'Ã±' - this should instead be the character 'ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â´')" role="warning" id="unicode-test-79">
+        <name/> element contains 'Â´' - this should instead be the character '´'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã´')" role="warning" id="unicode-test-80">
+        <name/> element contains 'Ã´' - this should instead be the character 'ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âµ')" role="warning" id="unicode-test-81">
+        <name/> element contains 'Âµ' - this should instead be the character 'µ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãµ')" role="warning" id="unicode-test-82">
+        <name/> element contains 'Ãµ' - this should instead be the character 'õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¶')" role="warning" id="unicode-test-83">
+        <name/> element contains 'Â¶' - this should instead be the character '¶'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¶')" role="warning" id="unicode-test-84">
+        <name/> element contains 'Ã¶' - this should instead be the character 'ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â·')" role="warning" id="unicode-test-85">
+        <name/> element contains 'Â·' - this should instead be the character '·'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã·')" role="warning" id="unicode-test-86">
+        <name/> element contains 'Ã·' - this should instead be the character '÷'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¸')" role="warning" id="unicode-test-87">
+        <name/> element contains 'Â¸' - this should instead be the character '¸'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¸')" role="warning" id="unicode-test-88">
+        <name/> element contains 'Ã¸' - this should instead be the character 'ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¹')" role="warning" id="unicode-test-89">
+        <name/> element contains 'Ã¹' - this should instead be the character 'ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âº')" role="warning" id="unicode-test-90">
+        <name/> element contains 'Âº' - this should instead be the character 'º'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãº')" role="warning" id="unicode-test-91">
+        <name/> element contains 'Ãº' - this should instead be the character 'ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¿')" role="warning" id="unicode-test-92">
+        <name/> element contains 'Â¿' - this should instead be the character '¿'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¿')" role="warning" id="unicode-test-93">
+        <name/> element contains 'Ã¿' - this should instead be the character 'ÿ'. - <value-of select="."/>.</report>
+</rule>
+  </pattern>
+  
   <pattern id="element-whitelist-pattern">
     <rule context="article//*[not(ancestor::mml:math)]" id="element-whitelist">
       <let name="allowed-elements" value="('abstract', 'ack', 'addr-line', 'aff', 'ali:free_to_read', 'ali:license_ref', 'app', 'app-group', 'article', 'article-categories', 'article-id', 'article-meta', 'article-title', 'attrib', 'author-notes', 'award-group', 'award-id', 'back', 'bio', 'body', 'bold', 'boxed-text', 'break', 'caption', 'chapter-title', 'code', 'collab', 'comment', 'conf-date', 'conf-loc', 'conf-name', 'contrib', 'contrib-group', 'contrib-id', 'copyright-holder', 'copyright-statement', 'copyright-year', 'corresp', 'country', 'custom-meta', 'custom-meta-group', 'data-title', 'date', 'date-in-citation', 'day', 'disp-formula', 'disp-quote', 'edition', 'element-citation', 'elocation-id', 'email', 'ext-link', 'fig', 'fig-group', 'fn', 'fn-group', 'fpage', 'front', 'front-stub', 'funding-group', 'funding-source', 'funding-statement', 'given-names', 'graphic', 'history', 'inline-formula', 'inline-graphic', 'institution', 'institution-id', 'institution-wrap', 'issn', 'issue', 'italic', 'journal-id', 'journal-meta', 'journal-title', 'journal-title-group', 'kwd', 'kwd-group', 'label', 'license', 'license-p', 'list', 'list-item', 'lpage', 'media', 'meta-name', 'meta-value', 'mml:math', 'monospace', 'month', 'name', 'named-content', 'on-behalf-of', 'p', 'patent', 'permissions', 'person-group', 'principal-award-recipient', 'pub-date', 'pub-id', 'publisher', 'publisher-loc', 'publisher-name', 'ref', 'ref-list', 'related-article', 'related-object', 'role', 'sc', 'sec', 'self-uri', 'source', 'strike', 'string-date', 'string-name', 'styled-content', 'sub', 'sub-article', 'subj-group', 'subject', 'suffix', 'sup', 'supplementary-material', 'surname', 'table', 'table-wrap', 'table-wrap-foot', 'tbody', 'td', 'th', 'thead', 'title', 'title-group', 'tr', 'underline', 'version', 'volume', 'xref', 'year')"/>
@@ -7281,6 +7563,7 @@
       <assert test="descendant::element-citation[(@publication-type='software') and year and source]" role="error" id="doi-software-ref-checks-xspec-assert">element-citation[(@publication-type='software') and year and source] must be present.</assert>
       <assert test="descendant::element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name]" role="error" id="doi-conf-ref-checks-xspec-assert">element-citation[(@publication-type='confproc') and not(pub-id[@pub-id-type='doi']) and year and conf-name] must be present.</assert>
       <assert test="descendant::article//ack" role="error" id="fundref-rule-xspec-assert">article//ack must be present.</assert>
+      <assert test="descendant::p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] or descendant::     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" role="error" id="unicode-tests-xspec-assert">p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')] must be present.</assert>
       <assert test="descendant::article//*[not(ancestor::mml:math)]" role="error" id="element-whitelist-xspec-assert">article//*[not(ancestor::mml:math)] must be present.</assert>
     </rule>
   </pattern>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -13213,6 +13213,16 @@
         <x:expect-report id="R-test-5" role="error"/>
         <x:expect-not-assert id="software-ref-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="R-test-6-pass">
+        <x:context href="../tests/gen/software-ref-tests/R-test-6/pass.xml"/>
+        <x:expect-not-report id="R-test-6" role="error"/>
+        <x:expect-not-assert id="software-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="R-test-6-fail">
+        <x:context href="../tests/gen/software-ref-tests/R-test-6/fail.xml"/>
+        <x:expect-report id="R-test-6" role="error"/>
+        <x:expect-not-assert id="software-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
       <x:scenario label="software-replacement-character-presence-pass">
         <x:context href="../tests/gen/software-ref-tests/software-replacement-character-presence/pass.xml"/>
         <x:expect-not-report id="software-replacement-character-presence" role="error"/>
@@ -13443,6 +13453,26 @@
       <x:scenario label="data-emdb-test-3-fail">
         <x:context href="../tests/gen/data-ref-tests/data-emdb-test-3/fail.xml"/>
         <x:expect-report id="data-emdb-test-3" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-empiar-test-1-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-empiar-test-1/pass.xml"/>
+        <x:expect-not-report id="data-empiar-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-empiar-test-1-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-empiar-test-1/fail.xml"/>
+        <x:expect-report id="data-empiar-test-1" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-empiar-test-2-pass">
+        <x:context href="../tests/gen/data-ref-tests/data-empiar-test-2/pass.xml"/>
+        <x:expect-not-report id="data-empiar-test-2" role="warning"/>
+        <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="data-empiar-test-2-fail">
+        <x:context href="../tests/gen/data-ref-tests/data-empiar-test-2/fail.xml"/>
+        <x:expect-report id="data-empiar-test-2" role="warning"/>
         <x:expect-not-assert id="data-ref-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="data-arrayexpress-test-1-pass">
@@ -15324,6 +15354,918 @@
         <x:context href="../tests/gen/fundref-rule/fundref-test-1/fail.xml"/>
         <x:expect-report id="fundref-test-1" role="warning"/>
         <x:expect-not-assert id="fundref-rule-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
+    <x:scenario label="unicode-tests">
+      <x:scenario label="unicode-test-1-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-1/pass.xml"/>
+        <x:expect-not-report id="unicode-test-1" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-1-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-1/fail.xml"/>
+        <x:expect-report id="unicode-test-1" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-2-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-2/pass.xml"/>
+        <x:expect-not-report id="unicode-test-2" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-2-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-2/fail.xml"/>
+        <x:expect-report id="unicode-test-2" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-3-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-3/pass.xml"/>
+        <x:expect-not-report id="unicode-test-3" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-3-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-3/fail.xml"/>
+        <x:expect-report id="unicode-test-3" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-4-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-4/pass.xml"/>
+        <x:expect-not-report id="unicode-test-4" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-4-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-4/fail.xml"/>
+        <x:expect-report id="unicode-test-4" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-5-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-5/pass.xml"/>
+        <x:expect-not-report id="unicode-test-5" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-5-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-5/fail.xml"/>
+        <x:expect-report id="unicode-test-5" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-6-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-6/pass.xml"/>
+        <x:expect-not-report id="unicode-test-6" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-6-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-6/fail.xml"/>
+        <x:expect-report id="unicode-test-6" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-7-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-7/pass.xml"/>
+        <x:expect-not-report id="unicode-test-7" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-7-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-7/fail.xml"/>
+        <x:expect-report id="unicode-test-7" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-8-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-8/pass.xml"/>
+        <x:expect-not-report id="unicode-test-8" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-8-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-8/fail.xml"/>
+        <x:expect-report id="unicode-test-8" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-9-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-9/pass.xml"/>
+        <x:expect-not-report id="unicode-test-9" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-9-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-9/fail.xml"/>
+        <x:expect-report id="unicode-test-9" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-10-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-10/pass.xml"/>
+        <x:expect-not-report id="unicode-test-10" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-10-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-10/fail.xml"/>
+        <x:expect-report id="unicode-test-10" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-11-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-11/pass.xml"/>
+        <x:expect-not-report id="unicode-test-11" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-11-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-11/fail.xml"/>
+        <x:expect-report id="unicode-test-11" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-13-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-13/pass.xml"/>
+        <x:expect-not-report id="unicode-test-13" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-13-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-13/fail.xml"/>
+        <x:expect-report id="unicode-test-13" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-14-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-14/pass.xml"/>
+        <x:expect-not-report id="unicode-test-14" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-14-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-14/fail.xml"/>
+        <x:expect-report id="unicode-test-14" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-15-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-15/pass.xml"/>
+        <x:expect-not-report id="unicode-test-15" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-15-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-15/fail.xml"/>
+        <x:expect-report id="unicode-test-15" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-16-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-16/pass.xml"/>
+        <x:expect-not-report id="unicode-test-16" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-16-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-16/fail.xml"/>
+        <x:expect-report id="unicode-test-16" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-17-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-17/pass.xml"/>
+        <x:expect-not-report id="unicode-test-17" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-17-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-17/fail.xml"/>
+        <x:expect-report id="unicode-test-17" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-18-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-18/pass.xml"/>
+        <x:expect-not-report id="unicode-test-18" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-18-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-18/fail.xml"/>
+        <x:expect-report id="unicode-test-18" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-19-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-19/pass.xml"/>
+        <x:expect-not-report id="unicode-test-19" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-19-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-19/fail.xml"/>
+        <x:expect-report id="unicode-test-19" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-21-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-21/pass.xml"/>
+        <x:expect-not-report id="unicode-test-21" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-21-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-21/fail.xml"/>
+        <x:expect-report id="unicode-test-21" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-22-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-22/pass.xml"/>
+        <x:expect-not-report id="unicode-test-22" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-22-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-22/fail.xml"/>
+        <x:expect-report id="unicode-test-22" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-23-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-23/pass.xml"/>
+        <x:expect-not-report id="unicode-test-23" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-23-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-23/fail.xml"/>
+        <x:expect-report id="unicode-test-23" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-24-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-24/pass.xml"/>
+        <x:expect-not-report id="unicode-test-24" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-24-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-24/fail.xml"/>
+        <x:expect-report id="unicode-test-24" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-25-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-25/pass.xml"/>
+        <x:expect-not-report id="unicode-test-25" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-25-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-25/fail.xml"/>
+        <x:expect-report id="unicode-test-25" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-26-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-26/pass.xml"/>
+        <x:expect-not-report id="unicode-test-26" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-26-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-26/fail.xml"/>
+        <x:expect-report id="unicode-test-26" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-27-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-27/pass.xml"/>
+        <x:expect-not-report id="unicode-test-27" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-27-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-27/fail.xml"/>
+        <x:expect-report id="unicode-test-27" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-28-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-28/pass.xml"/>
+        <x:expect-not-report id="unicode-test-28" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-28-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-28/fail.xml"/>
+        <x:expect-report id="unicode-test-28" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-29-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-29/pass.xml"/>
+        <x:expect-not-report id="unicode-test-29" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-29-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-29/fail.xml"/>
+        <x:expect-report id="unicode-test-29" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-30-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-30/pass.xml"/>
+        <x:expect-not-report id="unicode-test-30" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-30-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-30/fail.xml"/>
+        <x:expect-report id="unicode-test-30" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-31-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-31/pass.xml"/>
+        <x:expect-not-report id="unicode-test-31" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-31-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-31/fail.xml"/>
+        <x:expect-report id="unicode-test-31" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-32-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-32/pass.xml"/>
+        <x:expect-not-report id="unicode-test-32" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-32-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-32/fail.xml"/>
+        <x:expect-report id="unicode-test-32" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-33-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-33/pass.xml"/>
+        <x:expect-not-report id="unicode-test-33" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-33-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-33/fail.xml"/>
+        <x:expect-report id="unicode-test-33" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-34-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-34/pass.xml"/>
+        <x:expect-not-report id="unicode-test-34" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-34-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-34/fail.xml"/>
+        <x:expect-report id="unicode-test-34" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-35-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-35/pass.xml"/>
+        <x:expect-not-report id="unicode-test-35" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-35-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-35/fail.xml"/>
+        <x:expect-report id="unicode-test-35" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-36-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-36/pass.xml"/>
+        <x:expect-not-report id="unicode-test-36" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-36-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-36/fail.xml"/>
+        <x:expect-report id="unicode-test-36" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-37-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-37/pass.xml"/>
+        <x:expect-not-report id="unicode-test-37" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-37-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-37/fail.xml"/>
+        <x:expect-report id="unicode-test-37" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-38-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-38/pass.xml"/>
+        <x:expect-not-report id="unicode-test-38" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-38-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-38/fail.xml"/>
+        <x:expect-report id="unicode-test-38" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-39-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-39/pass.xml"/>
+        <x:expect-not-report id="unicode-test-39" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-39-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-39/fail.xml"/>
+        <x:expect-report id="unicode-test-39" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-40-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-40/pass.xml"/>
+        <x:expect-not-report id="unicode-test-40" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-40-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-40/fail.xml"/>
+        <x:expect-report id="unicode-test-40" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-41-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-41/pass.xml"/>
+        <x:expect-not-report id="unicode-test-41" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-41-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-41/fail.xml"/>
+        <x:expect-report id="unicode-test-41" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-42-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-42/pass.xml"/>
+        <x:expect-not-report id="unicode-test-42" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-42-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-42/fail.xml"/>
+        <x:expect-report id="unicode-test-42" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-43-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-43/pass.xml"/>
+        <x:expect-not-report id="unicode-test-43" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-43-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-43/fail.xml"/>
+        <x:expect-report id="unicode-test-43" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-44-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-44/pass.xml"/>
+        <x:expect-not-report id="unicode-test-44" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-44-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-44/fail.xml"/>
+        <x:expect-report id="unicode-test-44" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-45-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-45/pass.xml"/>
+        <x:expect-not-report id="unicode-test-45" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-45-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-45/fail.xml"/>
+        <x:expect-report id="unicode-test-45" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-46-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-46/pass.xml"/>
+        <x:expect-not-report id="unicode-test-46" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-46-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-46/fail.xml"/>
+        <x:expect-report id="unicode-test-46" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-47-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-47/pass.xml"/>
+        <x:expect-not-report id="unicode-test-47" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-47-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-47/fail.xml"/>
+        <x:expect-report id="unicode-test-47" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-48-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-48/pass.xml"/>
+        <x:expect-not-report id="unicode-test-48" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-48-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-48/fail.xml"/>
+        <x:expect-report id="unicode-test-48" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-49-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-49/pass.xml"/>
+        <x:expect-not-report id="unicode-test-49" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-49-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-49/fail.xml"/>
+        <x:expect-report id="unicode-test-49" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-50-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-50/pass.xml"/>
+        <x:expect-not-report id="unicode-test-50" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-50-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-50/fail.xml"/>
+        <x:expect-report id="unicode-test-50" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-51-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-51/pass.xml"/>
+        <x:expect-not-report id="unicode-test-51" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-51-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-51/fail.xml"/>
+        <x:expect-report id="unicode-test-51" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-52-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-52/pass.xml"/>
+        <x:expect-not-report id="unicode-test-52" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-52-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-52/fail.xml"/>
+        <x:expect-report id="unicode-test-52" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-53-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-53/pass.xml"/>
+        <x:expect-not-report id="unicode-test-53" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-53-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-53/fail.xml"/>
+        <x:expect-report id="unicode-test-53" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-54-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-54/pass.xml"/>
+        <x:expect-not-report id="unicode-test-54" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-54-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-54/fail.xml"/>
+        <x:expect-report id="unicode-test-54" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-55-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-55/pass.xml"/>
+        <x:expect-not-report id="unicode-test-55" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-55-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-55/fail.xml"/>
+        <x:expect-report id="unicode-test-55" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-56-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-56/pass.xml"/>
+        <x:expect-not-report id="unicode-test-56" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-56-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-56/fail.xml"/>
+        <x:expect-report id="unicode-test-56" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-57-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-57/pass.xml"/>
+        <x:expect-not-report id="unicode-test-57" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-57-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-57/fail.xml"/>
+        <x:expect-report id="unicode-test-57" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-58-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-58/pass.xml"/>
+        <x:expect-not-report id="unicode-test-58" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-58-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-58/fail.xml"/>
+        <x:expect-report id="unicode-test-58" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-59-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-59/pass.xml"/>
+        <x:expect-not-report id="unicode-test-59" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-59-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-59/fail.xml"/>
+        <x:expect-report id="unicode-test-59" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-60-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-60/pass.xml"/>
+        <x:expect-not-report id="unicode-test-60" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-60-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-60/fail.xml"/>
+        <x:expect-report id="unicode-test-60" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-61-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-61/pass.xml"/>
+        <x:expect-not-report id="unicode-test-61" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-61-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-61/fail.xml"/>
+        <x:expect-report id="unicode-test-61" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-62-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-62/pass.xml"/>
+        <x:expect-not-report id="unicode-test-62" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-62-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-62/fail.xml"/>
+        <x:expect-report id="unicode-test-62" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-63-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-63/pass.xml"/>
+        <x:expect-not-report id="unicode-test-63" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-63-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-63/fail.xml"/>
+        <x:expect-report id="unicode-test-63" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-64-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-64/pass.xml"/>
+        <x:expect-not-report id="unicode-test-64" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-64-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-64/fail.xml"/>
+        <x:expect-report id="unicode-test-64" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-65-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-65/pass.xml"/>
+        <x:expect-not-report id="unicode-test-65" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-65-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-65/fail.xml"/>
+        <x:expect-report id="unicode-test-65" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-66-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-66/pass.xml"/>
+        <x:expect-not-report id="unicode-test-66" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-66-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-66/fail.xml"/>
+        <x:expect-report id="unicode-test-66" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-67-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-67/pass.xml"/>
+        <x:expect-not-report id="unicode-test-67" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-67-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-67/fail.xml"/>
+        <x:expect-report id="unicode-test-67" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-68-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-68/pass.xml"/>
+        <x:expect-not-report id="unicode-test-68" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-68-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-68/fail.xml"/>
+        <x:expect-report id="unicode-test-68" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-69-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-69/pass.xml"/>
+        <x:expect-not-report id="unicode-test-69" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-69-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-69/fail.xml"/>
+        <x:expect-report id="unicode-test-69" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-70-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-70/pass.xml"/>
+        <x:expect-not-report id="unicode-test-70" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-70-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-70/fail.xml"/>
+        <x:expect-report id="unicode-test-70" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-71-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-71/pass.xml"/>
+        <x:expect-not-report id="unicode-test-71" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-71-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-71/fail.xml"/>
+        <x:expect-report id="unicode-test-71" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-72-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-72/pass.xml"/>
+        <x:expect-not-report id="unicode-test-72" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-72-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-72/fail.xml"/>
+        <x:expect-report id="unicode-test-72" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-73-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-73/pass.xml"/>
+        <x:expect-not-report id="unicode-test-73" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-73-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-73/fail.xml"/>
+        <x:expect-report id="unicode-test-73" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-74-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-74/pass.xml"/>
+        <x:expect-not-report id="unicode-test-74" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-74-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-74/fail.xml"/>
+        <x:expect-report id="unicode-test-74" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-75-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-75/pass.xml"/>
+        <x:expect-not-report id="unicode-test-75" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-75-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-75/fail.xml"/>
+        <x:expect-report id="unicode-test-75" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-76-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-76/pass.xml"/>
+        <x:expect-not-report id="unicode-test-76" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-76-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-76/fail.xml"/>
+        <x:expect-report id="unicode-test-76" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-77-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-77/pass.xml"/>
+        <x:expect-not-report id="unicode-test-77" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-77-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-77/fail.xml"/>
+        <x:expect-report id="unicode-test-77" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-78-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-78/pass.xml"/>
+        <x:expect-not-report id="unicode-test-78" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-78-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-78/fail.xml"/>
+        <x:expect-report id="unicode-test-78" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-79-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-79/pass.xml"/>
+        <x:expect-not-report id="unicode-test-79" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-79-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-79/fail.xml"/>
+        <x:expect-report id="unicode-test-79" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-80-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-80/pass.xml"/>
+        <x:expect-not-report id="unicode-test-80" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-80-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-80/fail.xml"/>
+        <x:expect-report id="unicode-test-80" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-81-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-81/pass.xml"/>
+        <x:expect-not-report id="unicode-test-81" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-81-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-81/fail.xml"/>
+        <x:expect-report id="unicode-test-81" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-82-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-82/pass.xml"/>
+        <x:expect-not-report id="unicode-test-82" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-82-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-82/fail.xml"/>
+        <x:expect-report id="unicode-test-82" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-83-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-83/pass.xml"/>
+        <x:expect-not-report id="unicode-test-83" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-83-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-83/fail.xml"/>
+        <x:expect-report id="unicode-test-83" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-84-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-84/pass.xml"/>
+        <x:expect-not-report id="unicode-test-84" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-84-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-84/fail.xml"/>
+        <x:expect-report id="unicode-test-84" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-85-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-85/pass.xml"/>
+        <x:expect-not-report id="unicode-test-85" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-85-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-85/fail.xml"/>
+        <x:expect-report id="unicode-test-85" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-86-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-86/pass.xml"/>
+        <x:expect-not-report id="unicode-test-86" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-86-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-86/fail.xml"/>
+        <x:expect-report id="unicode-test-86" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-87-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-87/pass.xml"/>
+        <x:expect-not-report id="unicode-test-87" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-87-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-87/fail.xml"/>
+        <x:expect-report id="unicode-test-87" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-88-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-88/pass.xml"/>
+        <x:expect-not-report id="unicode-test-88" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-88-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-88/fail.xml"/>
+        <x:expect-report id="unicode-test-88" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-89-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-89/pass.xml"/>
+        <x:expect-not-report id="unicode-test-89" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-89-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-89/fail.xml"/>
+        <x:expect-report id="unicode-test-89" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-90-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-90/pass.xml"/>
+        <x:expect-not-report id="unicode-test-90" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-90-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-90/fail.xml"/>
+        <x:expect-report id="unicode-test-90" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-91-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-91/pass.xml"/>
+        <x:expect-not-report id="unicode-test-91" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-91-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-91/fail.xml"/>
+        <x:expect-report id="unicode-test-91" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-92-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-92/pass.xml"/>
+        <x:expect-not-report id="unicode-test-92" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-92-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-92/fail.xml"/>
+        <x:expect-report id="unicode-test-92" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-93-pass">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-93/pass.xml"/>
+        <x:expect-not-report id="unicode-test-93" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="unicode-test-93-fail">
+        <x:context href="../tests/gen/unicode-tests/unicode-test-93/fail.xml"/>
+        <x:expect-report id="unicode-test-93" role="warning"/>
+        <x:expect-not-assert id="unicode-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
     <x:scenario label="element-whitelist">

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -1457,11 +1457,11 @@
   <pattern id="funding-group-tests-pattern">
     <rule context="article-meta/funding-group" id="funding-group-tests">
 		
-		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
+		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1469,41 +1469,39 @@
 	  <let name="id" value="@id"/>
 	  <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
 		
-		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source.</assert>
+		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2</assert>
 		
-		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient.</assert>
+		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3</assert>
 		
-		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id.</report>
+		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4</report>
 		
-		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
+		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5</assert>
 		
-		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6</report>
 	  
-	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7</assert>
 	  
-	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
-      </report>
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8</report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
       
-      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>
-      </report>
+      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1</report>
       
-      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2</report>
       
-      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3</report>
       
-      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>.</report>
+      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4</report>
       
     </rule>
   </pattern>
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test</assert>
       
     </rule>
   </pattern>
@@ -1548,15 +1546,15 @@
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
       
-      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta.</assert>
+      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1</assert>
       
-      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2</report>
       
-      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta.</assert>
+      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3</assert>
       
-      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14</report>
       
-      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15</report>
       
     </rule>
   </pattern>
@@ -1566,28 +1564,27 @@
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
       <report test="not(child::*) and normalize-space(.)=''" role="error" id="custom-meta-test-4">The value of meta-value cannot be empty</report>
       
-      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed.</report>
+      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5</report>
       
-      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark.</assert>
+      <assert test="matches(.,'[\.|\?]$')" role="error" id="final-custom-meta-test-6">Impact statement must end with a full stop or question mark. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-6</assert>
       
-      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.</report>
+      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7</report>
       
-      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
-      
-      
-      
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
-      
-      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
-      
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
-      
-      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
+      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8</report>
       
       
       
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>
-      </report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-custom-meta-test-9</report>
+      
+      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10</report>
+      
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11</report>
+      
+      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13</report>
+      
+      
+      
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="error" id="final-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#final-rep-study-custom-meta-test</report>
     </rule>
   </pattern>
   <pattern id="meta-value-child-tests-pattern">
@@ -1595,7 +1592,7 @@
       <let name="allowed-elements" value="('italic','sup','sub')"/>
       
       <assert test="local-name() = $allowed-elements" role="error" id="custom-meta-child-test-1">
-        <name/> is not allowed in impact statement.</assert>
+        <name/> is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1</assert>
       
     </rule>
   </pattern>
@@ -4917,9 +4914,9 @@
      <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]"/>
      <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]/*)"/>
      
-     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1</assert>
      
-     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2</assert>
      
    </rule>
   </pattern>
@@ -6236,6 +6233,8 @@
       
       <report test="matches(lower-case(source[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
+      <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
+      
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
@@ -6282,11 +6281,15 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
       
       <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')" role="warning" id="data-empiar-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-empiar-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
       
@@ -6897,6 +6900,285 @@
       
       <report test="some $funder in document($funders)//funder satisfies ((contains($ack,concat(' ',$funder,' ')) or contains($ack,concat(' ',$funder,'.'))) and not($funder/@fundref = $funding-group))" role="warning" id="fundref-test-1">Acknowledgements contains funder(s) in the open funder registry, but their doi is not listed in the funding section. Please check - <value-of select="string-join(for $x in document($funders)//funder[((contains($ack,concat(' ',.,' ')) or contains($ack,concat(' ',.,'.'))) and not(@fundref = $funding-group))] return concat($x,' - ',$x/@fundref),'; ')"/>.</report>
     </rule>
+  </pattern>
+  
+  <pattern id="unicode-tests-pattern">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+    
+    
+    <report test="contains(.,'â‚¬')" role="warning" id="unicode-test-1">
+        <name/> element contains 'â‚¬' - this should instead be the character '€'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã€')" role="warning" id="unicode-test-2">
+        <name/> element contains 'Ã€' - this should instead be the character 'À'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-3">
+        <name/> element contains 'Ã' - this should instead be the character 'Á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€š')" role="warning" id="unicode-test-4">
+        <name/> element contains 'â€š' - this should instead be the character '‚'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‚')" role="warning" id="unicode-test-5">
+        <name/> element contains 'Ã‚' - this should instead be the character 'Â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Æ’')" role="warning" id="unicode-test-6">
+        <name/> element contains 'Æ’' - this should instead be the character 'ƒ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãƒ')" role="warning" id="unicode-test-7">
+        <name/> element contains 'Ãƒ' - this should instead be the character 'Ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€ž')" role="warning" id="unicode-test-8">
+        <name/> element contains 'â€ž' - this should instead be the character '„'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã„')" role="warning" id="unicode-test-9">
+        <name/> element contains 'Ã„' - this should instead be the character 'Ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¦')" role="warning" id="unicode-test-10">
+        <name/> element contains 'â€¦' - this should instead be the character '…'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã…')" role="warning" id="unicode-test-11">
+        <name/> element contains 'Ã…' - this should instead be the character 'Å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã†')" role="warning" id="unicode-test-13">
+        <name/> element contains 'Ã†' - this should instead be the character 'Æ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¡')" role="warning" id="unicode-test-14">
+        <name/> element contains 'â€¡' - this should instead be the character '‡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‡')" role="warning" id="unicode-test-15">
+        <name/> element contains 'Ã‡' - this should instead be the character 'Ç'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ë†')" role="warning" id="unicode-test-16">
+        <name/> element contains 'Ë†' - this should instead be the character 'ˆ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãˆ')" role="warning" id="unicode-test-17">
+        <name/> element contains 'Ãˆ' - this should instead be the character 'È'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€°')" role="warning" id="unicode-test-18">
+        <name/> element contains 'â€°' - this should instead be the character '‰'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‰')" role="warning" id="unicode-test-19">
+        <name/> element contains 'Ã‰' - this should instead be the character 'É'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŠ')" role="warning" id="unicode-test-21">
+        <name/> element contains 'ÃŠ' - this should instead be the character 'Ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¹')" role="warning" id="unicode-test-22">
+        <name/> element contains 'â€¹' - this should instead be the character '‹'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‹')" role="warning" id="unicode-test-23">
+        <name/> element contains 'Ã‹' - this should instead be the character 'Ë'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å’')" role="warning" id="unicode-test-24">
+        <name/> element contains 'Å’' - this should instead be the character 'Œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŒ')" role="warning" id="unicode-test-25">
+        <name/> element contains 'ÃŒ' - this should instead be the character 'Ì'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-26">
+        <name/> element contains 'Ã' - this should instead be the character 'Í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å½')" role="warning" id="unicode-test-27">
+        <name/> element contains 'Å½' - this should instead be the character 'Ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŽ')" role="warning" id="unicode-test-28">
+        <name/> element contains 'ÃŽ' - this should instead be the character 'Î'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-29">
+        <name/> element contains 'Ã' - this should instead be the character 'Ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-30">
+        <name/> element contains 'Ã' - this should instead be the character 'Ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€˜')" role="warning" id="unicode-test-31">
+        <name/> element contains 'â€˜' - this should instead be the character '‘'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‘')" role="warning" id="unicode-test-32">
+        <name/> element contains 'Ã‘' - this should instead be the character 'Ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€™')" role="warning" id="unicode-test-33">
+        <name/> element contains 'â€™' - this should instead be the character '’'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã’')" role="warning" id="unicode-test-34">
+        <name/> element contains 'Ã’' - this should instead be the character 'Ò'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€œ')" role="warning" id="unicode-test-35">
+        <name/> element contains 'â€œ' - this should instead be the character '“'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã“')" role="warning" id="unicode-test-36">
+        <name/> element contains 'Ã“' - this should instead be the character 'Ó'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€')" role="warning" id="unicode-test-37">
+        <name/> element contains 'â€' - this should instead be the character '”'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã”')" role="warning" id="unicode-test-38">
+        <name/> element contains 'Ã”' - this should instead be the character 'Ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã•')" role="warning" id="unicode-test-39">
+        <name/> element contains 'Ã•' - this should instead be the character 'Õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€“')" role="warning" id="unicode-test-40">
+        <name/> element contains 'â€“' - this should instead be the character '–'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã–')" role="warning" id="unicode-test-41">
+        <name/> element contains 'Ã–' - this should instead be the character 'Ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€”')" role="warning" id="unicode-test-42">
+        <name/> element contains 'â€”' - this should instead be the character '—'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã—')" role="warning" id="unicode-test-43">
+        <name/> element contains 'Ã—' - this should instead be the character '×'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ëœ')" role="warning" id="unicode-test-44">
+        <name/> element contains 'Ëœ' - this should instead be the character '˜'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã˜')" role="warning" id="unicode-test-45">
+        <name/> element contains 'Ã˜' - this should instead be the character 'Ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã™')" role="warning" id="unicode-test-46">
+        <name/> element contains 'Ã™' - this should instead be the character 'Ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¡')" role="warning" id="unicode-test-47">
+        <name/> element contains 'Å¡' - this should instead be the character 'š'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãš')" role="warning" id="unicode-test-48">
+        <name/> element contains 'Ãš' - this should instead be the character 'Ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€º')" role="warning" id="unicode-test-49">
+        <name/> element contains 'â€º' - this should instead be the character '›'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã›')" role="warning" id="unicode-test-50">
+        <name/> element contains 'Ã›' - this should instead be the character 'Û'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å“')" role="warning" id="unicode-test-51">
+        <name/> element contains 'Å“' - this should instead be the character 'œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãœ')" role="warning" id="unicode-test-52">
+        <name/> element contains 'Ãœ' - this should instead be the character 'Ü'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-53">
+        <name/> element contains 'Ã' - this should instead be the character 'Ý'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¾')" role="warning" id="unicode-test-54">
+        <name/> element contains 'Å¾' - this should instead be the character 'ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãž')" role="warning" id="unicode-test-55">
+        <name/> element contains 'Ãž' - this should instead be the character 'Þ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¸')" role="warning" id="unicode-test-56">
+        <name/> element contains 'Å¸' - this should instead be the character 'Ÿ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŸ')" role="warning" id="unicode-test-57">
+        <name/> element contains 'ÃŸ' - this should instead be the character 'ß'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¡')" role="warning" id="unicode-test-58">
+        <name/> element contains 'Â¡' - this should instead be the character '¡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¡')" role="warning" id="unicode-test-59">
+        <name/> element contains 'Ã¡' - this should instead be the character 'á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¢')" role="warning" id="unicode-test-60">
+        <name/> element contains 'Â¢' - this should instead be the character '¢'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¢')" role="warning" id="unicode-test-61">
+        <name/> element contains 'Ã¢' - this should instead be the character 'â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â£')" role="warning" id="unicode-test-62">
+        <name/> element contains 'Â£' - this should instead be the character '£'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã£')" role="warning" id="unicode-test-63">
+        <name/> element contains 'Ã£' - this should instead be the character 'ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¤')" role="warning" id="unicode-test-64">
+        <name/> element contains 'Â¤' - this should instead be the character '¤'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¤')" role="warning" id="unicode-test-65">
+        <name/> element contains 'Ã¤' - this should instead be the character 'ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¥')" role="warning" id="unicode-test-66">
+        <name/> element contains 'Ã¥' - this should instead be the character 'å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¨')" role="warning" id="unicode-test-67">
+        <name/> element contains 'Â¨' - this should instead be the character '¨'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¨')" role="warning" id="unicode-test-68">
+        <name/> element contains 'Ã¨' - this should instead be the character 'è'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âª')" role="warning" id="unicode-test-69">
+        <name/> element contains 'Âª' - this should instead be the character 'ª'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãª')" role="warning" id="unicode-test-70">
+        <name/> element contains 'Ãª' - this should instead be the character 'ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â­')" role="warning" id="unicode-test-71">
+        <name/> element contains 'Â­' - this should instead be the character '­'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã­')" role="warning" id="unicode-test-72">
+        <name/> element contains 'Ã­' - this should instead be the character 'í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¯')" role="warning" id="unicode-test-73">
+        <name/> element contains 'Â¯' - this should instead be the character '¯'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¯')" role="warning" id="unicode-test-74">
+        <name/> element contains 'Ã¯' - this should instead be the character 'ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â°')" role="warning" id="unicode-test-75">
+        <name/> element contains 'Â°' - this should instead be the character '°'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã°')" role="warning" id="unicode-test-76">
+        <name/> element contains 'Ã°' - this should instead be the character 'ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â±')" role="warning" id="unicode-test-77">
+        <name/> element contains 'Â±' - this should instead be the character '±'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã±')" role="warning" id="unicode-test-78">
+        <name/> element contains 'Ã±' - this should instead be the character 'ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â´')" role="warning" id="unicode-test-79">
+        <name/> element contains 'Â´' - this should instead be the character '´'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã´')" role="warning" id="unicode-test-80">
+        <name/> element contains 'Ã´' - this should instead be the character 'ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âµ')" role="warning" id="unicode-test-81">
+        <name/> element contains 'Âµ' - this should instead be the character 'µ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãµ')" role="warning" id="unicode-test-82">
+        <name/> element contains 'Ãµ' - this should instead be the character 'õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¶')" role="warning" id="unicode-test-83">
+        <name/> element contains 'Â¶' - this should instead be the character '¶'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¶')" role="warning" id="unicode-test-84">
+        <name/> element contains 'Ã¶' - this should instead be the character 'ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â·')" role="warning" id="unicode-test-85">
+        <name/> element contains 'Â·' - this should instead be the character '·'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã·')" role="warning" id="unicode-test-86">
+        <name/> element contains 'Ã·' - this should instead be the character '÷'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¸')" role="warning" id="unicode-test-87">
+        <name/> element contains 'Â¸' - this should instead be the character '¸'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¸')" role="warning" id="unicode-test-88">
+        <name/> element contains 'Ã¸' - this should instead be the character 'ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¹')" role="warning" id="unicode-test-89">
+        <name/> element contains 'Ã¹' - this should instead be the character 'ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âº')" role="warning" id="unicode-test-90">
+        <name/> element contains 'Âº' - this should instead be the character 'º'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãº')" role="warning" id="unicode-test-91">
+        <name/> element contains 'Ãº' - this should instead be the character 'ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¿')" role="warning" id="unicode-test-92">
+        <name/> element contains 'Â¿' - this should instead be the character '¿'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¿')" role="warning" id="unicode-test-93">
+        <name/> element contains 'Ã¿' - this should instead be the character 'ÿ'. - <value-of select="."/>.</report>
+</rule>
   </pattern>
   
   <pattern id="element-whitelist-pattern">

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -1455,11 +1455,11 @@
   <pattern id="funding-group-tests-pattern">
     <rule context="article-meta/funding-group" id="funding-group-tests">
 		
-		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group.</assert>
+		<assert test="count(funding-statement) = 1" role="error" id="funding-group-test-1">One funding-statement should be present in funding-group. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-1</assert>
 		
-		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?</report>
+		<report test="count(award-group) = 0" role="warning" id="funding-group-test-2">There is no funding for this article. Is this correct?  More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-2</report>
 		
-	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.'</report>
+	  <report test="(count(award-group) = 0) and (funding-statement!='No external funding was received for this work.')" role="warning" id="funding-group-test-3">Is this funding-statement correct? - '<value-of select="funding-statement"/>' Usually it should be 'No external funding was received for this work.' More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#funding-group-test-3</report>
     </rule>
   </pattern>
   <pattern id="award-group-tests-pattern">
@@ -1467,41 +1467,39 @@
 	  <let name="id" value="@id"/>
 	  <let name="institution" value="funding-source[1]/institution-wrap[1]/institution[1]"/>
 		
-		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source.</assert>
+		<assert test="funding-source" role="error" id="award-group-test-2">award-group must contain a funding-source. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-2</assert>
 		
-		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient.</assert>
+		<assert test="principal-award-recipient" role="error" id="award-group-test-3">award-group must contain a principal-award-recipient. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-3</assert>
 		
-		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id.</report>
+		<report test="count(award-id) gt 1" role="error" id="award-group-test-4">award-group may contain one and only one award-id. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-4</report>
 		
-		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap.</assert>
+		<assert test="funding-source/institution-wrap" role="error" id="award-group-test-5">funding-source must contain an institution-wrap. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-5</assert>
 		
-		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one.</report>
+		<report test="count(funding-source/institution-wrap/institution) = 0" role="error" id="award-group-test-6">Every piece of funding must have an institution. &lt;award-group id="<value-of select="@id"/>"&gt; does not have one. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-6</report>
 	  
-	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;)</assert>
+	  <assert test="ancestor::article//article-meta//contrib//xref/@rid = $id" role="error" id="award-group-test-7">There is no author associated with the funding for <value-of select="$institution"/>, which is incorrect. (There is no xref from a contrib pointing to this &lt;award-group id="<value-of select="$id"/>"&gt;). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-7</assert>
 	  
-	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>
-      </report>
+	  <report test="count(funding-source/institution-wrap/institution) gt 1" role="error" id="award-group-test-8">Every piece of funding must only have 1 institution. &lt;award-group id="<value-of select="@id"/>"&gt; has <value-of select="count(funding-source/institution-wrap/institution)"/> - <value-of select="string-join(funding-source/institution-wrap/institution,', ')"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-group-test-8</report>
 	</rule>
   </pattern>
   <pattern id="award-id-tests-pattern">
     <rule context="funding-group/award-group/award-id" id="award-id-tests">
       <let name="id" value="parent::award-group/@id"/>
       
-      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>
-      </report>
+      <report test="matches(.,',|;')" role="warning" id="award-id-test-1">Funding entry with id <value-of select="$id"/> has a comma or semi-colon in the award id. Should this be separated out into several funding entries? - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-1</report>
       
-      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn][/]?[\.]?[Aa][.]?\s?$')" role="error" id="award-id-test-2">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-2</report>
       
-      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty.</report>
+      <report test="matches(.,'^\s?[Nn]one[\.]?\s?$')" role="error" id="award-id-test-3">Award id contains - <value-of select="."/> - This entry should be empty. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-3</report>
       
-      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>.</report>
+      <report test="matches(.,'&amp;#x\d')" role="warning" id="award-id-test-4">Award id contains what looks like a broken unicode - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#award-id-test-4</report>
       
     </rule>
   </pattern>
   <pattern id="institution-wrap-tests-pattern">
     <rule context="article-meta//award-group//institution-wrap" id="institution-wrap-tests">
       
-      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap).</assert>
+      <assert test="institution-id[@institution-id-type='FundRef']" role="warning" flag="pub-check" id="institution-id-test">Whenever possible, a funder should have a doi - please check whether there is an appropriate doi in the open funder registry. (institution-id[@institution-id-type="FundRef"] is not present in institution-wrap). More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#institution-id-test</assert>
       
     </rule>
   </pattern>
@@ -1546,15 +1544,15 @@
       <let name="type" value="ancestor::article-meta/article-categories/subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="pos" value="count(parent::custom-meta-group/custom-meta) - count(following-sibling::custom-meta)"/>
       
-      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta.</assert>
+      <assert test="count(meta-name) = 1" role="error" id="custom-meta-test-1">One meta-name must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-1</assert>
       
-      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $research-subj) and (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-2">The value of meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-2</report>
       
-      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta.</assert>
+      <assert test="count(meta-value) = 1" role="error" id="custom-meta-test-3">One meta-value must be present in custom-meta. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-3</assert>
       
-      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=1) and  (meta-name != 'Author impact statement')" role="error" id="custom-meta-test-14">The value of the 1st meta-name can only be 'Author impact statement'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-14</report>
       
-      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>.</report>
+      <report test="($type = $features-subj) and ($pos=2) and  (meta-name != 'Template')" role="error" id="custom-meta-test-15">The value of the 2nd meta-name can only be 'Template'. Currently it is <value-of select="meta-name"/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-15</report>
       
     </rule>
   </pattern>
@@ -1564,25 +1562,25 @@
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
       <report test="not(child::*) and normalize-space(.)=''" role="error" id="custom-meta-test-4">The value of meta-value cannot be empty</report>
       
-      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed.</report>
+      <report test="($count gt 30)" role="warning" id="custom-meta-test-5">Impact statement contains more than 30 words. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-5</report>
       
       
       
-      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed.</report>
+      <report test="matches(replace(.,' et al\. ',' et al '),'[\p{L}][\p{L}]+\. .*$|[\p{L}\p{N}][\p{L}\p{N}]+\? .*$|[\p{L}\p{N}][\p{L}\p{N}]+! .*$')" role="warning" id="custom-meta-test-7">Impact statement appears to be made up of more than one sentence. Please check, as more than one sentence is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-7</report>
       
-      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
+      <report test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-8</report>
       
-      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed</report>
+      <report test="matches(.,'[Ww]e show|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-custom-meta-test-9</report>
       
       
       
-      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
+      <report test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-10</report>
       
-      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)?</report>
+      <report test="matches(.,' [Oo]ur |^[Oo]ur ')" role="warning" id="custom-meta-test-11">Impact statement contains 'our'. Is this possessive langauge relating to the article or research itself (which should be removed)? More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-11</report>
       
-      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this.</report>
+      <report test="matches(.,' study ') and not(matches(.,'[Tt]his study'))" role="warning" id="custom-meta-test-13">Impact statement contains 'study'. Is this a third person description of this article? If so, it should be changed to not include this. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-test-13</report>
       
-      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="warning" id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>.</report>
+      <report test="($subj = 'Replication Study') and not(matches(.,'^Editors[\p{Po}] Summary: '))" role="warning" id="pre-rep-study-custom-meta-test">Impact statement in Replication studies must begin with 'Editors' summary: '. This does not - <value-of select="."/>. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#pre-rep-study-custom-meta-test</report>
       
       
     </rule>
@@ -1592,7 +1590,7 @@
       <let name="allowed-elements" value="('italic','sup','sub')"/>
       
       <assert test="local-name() = $allowed-elements" role="error" id="custom-meta-child-test-1">
-        <name/> is not allowed in impact statement.</assert>
+        <name/> is not allowed in impact statement. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#custom-meta-child-test-1</assert>
       
     </rule>
   </pattern>
@@ -4915,9 +4913,9 @@
      <let name="impact-statement" value="parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]"/>
      <let name="impact-statement-element-count" value="count(parent::article-meta//custom-meta[meta-name='Author impact statement']/meta-value[1]/*)"/>
      
-     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>".</assert>
+     <assert test=". = $impact-statement" role="warning" id="insight-asbtract-impact-test-1">In insights, abtsracts must be the same as impact statements. Here the abstract reads "<value-of select="."/>", whereas the impact statement reads "<value-of select="$impact-statement"/>". More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-1</assert>
      
-     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting.</assert>
+     <assert test="count(p/*) = $impact-statement-element-count" role="warning" id="insight-asbtract-impact-test-2">In insights, abtsracts must be the same as impact statements. Here the abstract has <value-of select="count(*)"/> child element(s), whereas the impact statement has <value-of select="$impact-statement-element-count"/> child element(s). Check for possible missing formatting. More information here - https://app.gitbook.com/@elifesciences/s/schematron/article-details/content/impact-statement#insight-asbtract-impact-test-2</assert>
      
    </rule>
   </pattern>
@@ -6234,6 +6232,8 @@
       
       <report test="matches(lower-case(source[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-5">software ref '<value-of select="ancestor::ref/@id"/>' has a source - <value-of select="source"/> - but this is the data-title.</report>
       
+      <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
+      
       <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
@@ -6280,11 +6280,15 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.rcsb.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-rcsbpbd-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a PDB 'http://www.rcsb.org' type link, but is not marked as an accession type link.</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and not(source[1]='Electron Microscopy Data Bank')" role="warning" id="data-emdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but the database name is not 'Electron Microscopy Data Bank' - <value-of select="source[1]"/>. Is that correct?</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
+      <report test="not(contains(pub-id[1]/@xlink:href,'empiar')) and matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and  pub-id[1][@assigning-authority!='EMDB' or not(@assigning-authority)]" role="warning" id="data-emdb-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked with EMDB as its assigning authority, which must be incorrect</report>
       
       <report test="matches(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb|www.ebi.ac.uk/pdbe/entry/emdb') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-emdb-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a EMDB 'http://www.ebi.ac.uk/pdbe/emdb' type link, but is not marked as an accession type link.</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and not(source[1]='Electron Microscopy Public Image Archive')" role="warning" id="data-empiar-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but the database name is not 'Electron Microscopy Public Image Archive' - <value-of select="source[1]"/>. Is that correct?</report>
+      
+      <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/pdbe/emdb/empiar/') and  pub-id[1][@assigning-authority!='EBI' or not(@assigning-authority)]" role="warning" id="data-empiar-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'http://www.ebi.ac.uk/pdbe/emdb/empiar' type link, but is not marked with EBI as its assigning authority, which must be incorrect.</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.ebi.ac.uk/arrayexpress') and not(source[1]='ArrayExpress')" role="warning" id="data-arrayexpress-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.ebi.ac.uk/arrayexpress' type link, but the database name is not 'ArrayExpress' - <value-of select="source[1]"/>. Is that correct?</report>
       
@@ -6895,6 +6899,285 @@
       
       <report test="some $funder in document($funders)//funder satisfies ((contains($ack,concat(' ',$funder,' ')) or contains($ack,concat(' ',$funder,'.'))) and not($funder/@fundref = $funding-group))" role="warning" id="fundref-test-1">Acknowledgements contains funder(s) in the open funder registry, but their doi is not listed in the funding section. Please check - <value-of select="string-join(for $x in document($funders)//funder[((contains($ack,concat(' ',.,' ')) or contains($ack,concat(' ',.,'.'))) and not(@fundref = $funding-group))] return concat($x,' - ',$x/@fundref),'; ')"/>.</report>
     </rule>
+  </pattern>
+  
+  <pattern id="unicode-tests-pattern">
+    <rule context="p[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     td[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]|     th[contains(.,'â') or contains(.,'Â') or contains(.,'Å') or contains(.,'Ã')  or contains(.,'Ë')  or contains(.,'Æ')]" id="unicode-tests">
+    
+    
+    <report test="contains(.,'â‚¬')" role="warning" id="unicode-test-1">
+        <name/> element contains 'â‚¬' - this should instead be the character '€'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã€')" role="warning" id="unicode-test-2">
+        <name/> element contains 'Ã€' - this should instead be the character 'À'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-3">
+        <name/> element contains 'Ã' - this should instead be the character 'Á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€š')" role="warning" id="unicode-test-4">
+        <name/> element contains 'â€š' - this should instead be the character '‚'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‚')" role="warning" id="unicode-test-5">
+        <name/> element contains 'Ã‚' - this should instead be the character 'Â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Æ’')" role="warning" id="unicode-test-6">
+        <name/> element contains 'Æ’' - this should instead be the character 'ƒ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãƒ')" role="warning" id="unicode-test-7">
+        <name/> element contains 'Ãƒ' - this should instead be the character 'Ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€ž')" role="warning" id="unicode-test-8">
+        <name/> element contains 'â€ž' - this should instead be the character '„'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã„')" role="warning" id="unicode-test-9">
+        <name/> element contains 'Ã„' - this should instead be the character 'Ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¦')" role="warning" id="unicode-test-10">
+        <name/> element contains 'â€¦' - this should instead be the character '…'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã…')" role="warning" id="unicode-test-11">
+        <name/> element contains 'Ã…' - this should instead be the character 'Å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã†')" role="warning" id="unicode-test-13">
+        <name/> element contains 'Ã†' - this should instead be the character 'Æ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¡')" role="warning" id="unicode-test-14">
+        <name/> element contains 'â€¡' - this should instead be the character '‡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‡')" role="warning" id="unicode-test-15">
+        <name/> element contains 'Ã‡' - this should instead be the character 'Ç'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ë†')" role="warning" id="unicode-test-16">
+        <name/> element contains 'Ë†' - this should instead be the character 'ˆ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãˆ')" role="warning" id="unicode-test-17">
+        <name/> element contains 'Ãˆ' - this should instead be the character 'È'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€°')" role="warning" id="unicode-test-18">
+        <name/> element contains 'â€°' - this should instead be the character '‰'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‰')" role="warning" id="unicode-test-19">
+        <name/> element contains 'Ã‰' - this should instead be the character 'É'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŠ')" role="warning" id="unicode-test-21">
+        <name/> element contains 'ÃŠ' - this should instead be the character 'Ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€¹')" role="warning" id="unicode-test-22">
+        <name/> element contains 'â€¹' - this should instead be the character '‹'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‹')" role="warning" id="unicode-test-23">
+        <name/> element contains 'Ã‹' - this should instead be the character 'Ë'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å’')" role="warning" id="unicode-test-24">
+        <name/> element contains 'Å’' - this should instead be the character 'Œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŒ')" role="warning" id="unicode-test-25">
+        <name/> element contains 'ÃŒ' - this should instead be the character 'Ì'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-26">
+        <name/> element contains 'Ã' - this should instead be the character 'Í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å½')" role="warning" id="unicode-test-27">
+        <name/> element contains 'Å½' - this should instead be the character 'Ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŽ')" role="warning" id="unicode-test-28">
+        <name/> element contains 'ÃŽ' - this should instead be the character 'Î'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-29">
+        <name/> element contains 'Ã' - this should instead be the character 'Ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-30">
+        <name/> element contains 'Ã' - this should instead be the character 'Ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€˜')" role="warning" id="unicode-test-31">
+        <name/> element contains 'â€˜' - this should instead be the character '‘'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã‘')" role="warning" id="unicode-test-32">
+        <name/> element contains 'Ã‘' - this should instead be the character 'Ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€™')" role="warning" id="unicode-test-33">
+        <name/> element contains 'â€™' - this should instead be the character '’'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã’')" role="warning" id="unicode-test-34">
+        <name/> element contains 'Ã’' - this should instead be the character 'Ò'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€œ')" role="warning" id="unicode-test-35">
+        <name/> element contains 'â€œ' - this should instead be the character '“'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã“')" role="warning" id="unicode-test-36">
+        <name/> element contains 'Ã“' - this should instead be the character 'Ó'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€')" role="warning" id="unicode-test-37">
+        <name/> element contains 'â€' - this should instead be the character '”'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã”')" role="warning" id="unicode-test-38">
+        <name/> element contains 'Ã”' - this should instead be the character 'Ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã•')" role="warning" id="unicode-test-39">
+        <name/> element contains 'Ã•' - this should instead be the character 'Õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€“')" role="warning" id="unicode-test-40">
+        <name/> element contains 'â€“' - this should instead be the character '–'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã–')" role="warning" id="unicode-test-41">
+        <name/> element contains 'Ã–' - this should instead be the character 'Ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€”')" role="warning" id="unicode-test-42">
+        <name/> element contains 'â€”' - this should instead be the character '—'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã—')" role="warning" id="unicode-test-43">
+        <name/> element contains 'Ã—' - this should instead be the character '×'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ëœ')" role="warning" id="unicode-test-44">
+        <name/> element contains 'Ëœ' - this should instead be the character '˜'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã˜')" role="warning" id="unicode-test-45">
+        <name/> element contains 'Ã˜' - this should instead be the character 'Ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã™')" role="warning" id="unicode-test-46">
+        <name/> element contains 'Ã™' - this should instead be the character 'Ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¡')" role="warning" id="unicode-test-47">
+        <name/> element contains 'Å¡' - this should instead be the character 'š'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãš')" role="warning" id="unicode-test-48">
+        <name/> element contains 'Ãš' - this should instead be the character 'Ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'â€º')" role="warning" id="unicode-test-49">
+        <name/> element contains 'â€º' - this should instead be the character '›'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã›')" role="warning" id="unicode-test-50">
+        <name/> element contains 'Ã›' - this should instead be the character 'Û'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å“')" role="warning" id="unicode-test-51">
+        <name/> element contains 'Å“' - this should instead be the character 'œ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãœ')" role="warning" id="unicode-test-52">
+        <name/> element contains 'Ãœ' - this should instead be the character 'Ü'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã')" role="warning" id="unicode-test-53">
+        <name/> element contains 'Ã' - this should instead be the character 'Ý'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¾')" role="warning" id="unicode-test-54">
+        <name/> element contains 'Å¾' - this should instead be the character 'ž'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãž')" role="warning" id="unicode-test-55">
+        <name/> element contains 'Ãž' - this should instead be the character 'Þ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Å¸')" role="warning" id="unicode-test-56">
+        <name/> element contains 'Å¸' - this should instead be the character 'Ÿ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'ÃŸ')" role="warning" id="unicode-test-57">
+        <name/> element contains 'ÃŸ' - this should instead be the character 'ß'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¡')" role="warning" id="unicode-test-58">
+        <name/> element contains 'Â¡' - this should instead be the character '¡'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¡')" role="warning" id="unicode-test-59">
+        <name/> element contains 'Ã¡' - this should instead be the character 'á'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¢')" role="warning" id="unicode-test-60">
+        <name/> element contains 'Â¢' - this should instead be the character '¢'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¢')" role="warning" id="unicode-test-61">
+        <name/> element contains 'Ã¢' - this should instead be the character 'â'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â£')" role="warning" id="unicode-test-62">
+        <name/> element contains 'Â£' - this should instead be the character '£'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã£')" role="warning" id="unicode-test-63">
+        <name/> element contains 'Ã£' - this should instead be the character 'ã'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¤')" role="warning" id="unicode-test-64">
+        <name/> element contains 'Â¤' - this should instead be the character '¤'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¤')" role="warning" id="unicode-test-65">
+        <name/> element contains 'Ã¤' - this should instead be the character 'ä'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¥')" role="warning" id="unicode-test-66">
+        <name/> element contains 'Ã¥' - this should instead be the character 'å'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¨')" role="warning" id="unicode-test-67">
+        <name/> element contains 'Â¨' - this should instead be the character '¨'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¨')" role="warning" id="unicode-test-68">
+        <name/> element contains 'Ã¨' - this should instead be the character 'è'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âª')" role="warning" id="unicode-test-69">
+        <name/> element contains 'Âª' - this should instead be the character 'ª'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãª')" role="warning" id="unicode-test-70">
+        <name/> element contains 'Ãª' - this should instead be the character 'ê'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â­')" role="warning" id="unicode-test-71">
+        <name/> element contains 'Â­' - this should instead be the character '­'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã­')" role="warning" id="unicode-test-72">
+        <name/> element contains 'Ã­' - this should instead be the character 'í'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¯')" role="warning" id="unicode-test-73">
+        <name/> element contains 'Â¯' - this should instead be the character '¯'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¯')" role="warning" id="unicode-test-74">
+        <name/> element contains 'Ã¯' - this should instead be the character 'ï'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â°')" role="warning" id="unicode-test-75">
+        <name/> element contains 'Â°' - this should instead be the character '°'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã°')" role="warning" id="unicode-test-76">
+        <name/> element contains 'Ã°' - this should instead be the character 'ð'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â±')" role="warning" id="unicode-test-77">
+        <name/> element contains 'Â±' - this should instead be the character '±'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã±')" role="warning" id="unicode-test-78">
+        <name/> element contains 'Ã±' - this should instead be the character 'ñ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â´')" role="warning" id="unicode-test-79">
+        <name/> element contains 'Â´' - this should instead be the character '´'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã´')" role="warning" id="unicode-test-80">
+        <name/> element contains 'Ã´' - this should instead be the character 'ô'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âµ')" role="warning" id="unicode-test-81">
+        <name/> element contains 'Âµ' - this should instead be the character 'µ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãµ')" role="warning" id="unicode-test-82">
+        <name/> element contains 'Ãµ' - this should instead be the character 'õ'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¶')" role="warning" id="unicode-test-83">
+        <name/> element contains 'Â¶' - this should instead be the character '¶'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¶')" role="warning" id="unicode-test-84">
+        <name/> element contains 'Ã¶' - this should instead be the character 'ö'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â·')" role="warning" id="unicode-test-85">
+        <name/> element contains 'Â·' - this should instead be the character '·'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã·')" role="warning" id="unicode-test-86">
+        <name/> element contains 'Ã·' - this should instead be the character '÷'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¸')" role="warning" id="unicode-test-87">
+        <name/> element contains 'Â¸' - this should instead be the character '¸'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¸')" role="warning" id="unicode-test-88">
+        <name/> element contains 'Ã¸' - this should instead be the character 'ø'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¹')" role="warning" id="unicode-test-89">
+        <name/> element contains 'Ã¹' - this should instead be the character 'ù'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Âº')" role="warning" id="unicode-test-90">
+        <name/> element contains 'Âº' - this should instead be the character 'º'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ãº')" role="warning" id="unicode-test-91">
+        <name/> element contains 'Ãº' - this should instead be the character 'ú'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Â¿')" role="warning" id="unicode-test-92">
+        <name/> element contains 'Â¿' - this should instead be the character '¿'. - <value-of select="."/>.</report>
+    
+    <report test="contains(.,'Ã¿')" role="warning" id="unicode-test-93">
+        <name/> element contains 'Ã¿' - this should instead be the character 'ÿ'. - <value-of select="."/>.</report>
+</rule>
   </pattern>
   
   <pattern id="element-whitelist-pattern">


### PR DESCRIPTION
- Add tests for unicode issues - `unicode-checks`
- Account for empiar in dataset ref checks
- Add gitbook links to impact statement tests - elifesciences/schematron-gitbook#2
- Add gitbook links to funding tests - closes elifesciences/schematron-gitbook#8