### PR TITLE
fix: allow more than 3 reviewers

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -3161,7 +3161,7 @@
       
       <report test="contrib[not(@contrib-type) or @contrib-type!='reviewer']" role="error" id="dec-letter-reviewer-test-2">Second contrib-group in decision letter contains a contrib which is not marked up as a reviewer (contrib[@contrib-type='reviewer']).</report>
       
-      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="error" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers.</report>
+      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="warning" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.</report>
     </rule>
   </pattern>
   <pattern id="dec-letter-reviewer-tests-2-pattern">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -3167,7 +3167,7 @@
       
       <report test="contrib[not(@contrib-type) or @contrib-type!='reviewer']" role="error" id="dec-letter-reviewer-test-2">Second contrib-group in decision letter contains a contrib which is not marked up as a reviewer (contrib[@contrib-type='reviewer']).</report>
       
-      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="error" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers.</report>
+      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="warning" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.</report>
     </rule>
   </pattern>
   <pattern id="dec-letter-reviewer-tests-2-pattern">

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -3160,7 +3160,7 @@
       
       <report test="contrib[not(@contrib-type) or @contrib-type!='reviewer']" role="error" id="dec-letter-reviewer-test-2">Second contrib-group in decision letter contains a contrib which is not marked up as a reviewer (contrib[@contrib-type='reviewer']).</report>
       
-      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="error" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers.</report>
+      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="warning" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.</report>
     </rule>
   </pattern>
   <pattern id="dec-letter-reviewer-tests-2-pattern">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -4388,8 +4388,8 @@
         id="dec-letter-reviewer-test-2">Second contrib-group in decision letter contains a contrib which is not marked up as a reviewer (contrib[@contrib-type='reviewer']).</report>
       
       <report test="count(contrib[@contrib-type='reviewer']) gt 3"
-        role="error"
-        id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers.</report>
+        role="warning"
+        id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.</report>
     </rule>
     
     <rule context="sub-article[@article-type='decision-letter']/front-stub/contrib-group[2]/contrib[@contrib-type='reviewer']"

--- a/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/dec-letter-reviewer-test-6.sch
+++ b/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/dec-letter-reviewer-test-6.sch
@@ -725,7 +725,7 @@
   </xsl:function>
   <pattern id="dec-letter-auth-response">
     <rule context="sub-article[@article-type='decision-letter']/front-stub/contrib-group[2]" id="dec-letter-reviewer-tests">
-      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="error" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers.</report>
+      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="warning" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/fail.xml
+++ b/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="dec-letter-reviewer-test-6.sch"?>
 <!--Context: sub-article[@article-type='decision-letter']/front-stub/contrib-group[2]
 Test: report    count(contrib[@contrib-type='reviewer']) gt 3
-Message: Second contrib-group in decision letter contains more than three reviewers.-->
+Message: Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/pass.xml
+++ b/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="dec-letter-reviewer-test-6.sch"?>
 <!--Context: sub-article[@article-type='decision-letter']/front-stub/contrib-group[2]
 Test: report    count(contrib[@contrib-type='reviewer']) gt 3
-Message: Second contrib-group in decision letter contains more than three reviewers.-->
+Message: Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -3174,7 +3174,7 @@
       
       <report test="contrib[not(@contrib-type) or @contrib-type!='reviewer']" role="error" id="dec-letter-reviewer-test-2">Second contrib-group in decision letter contains a contrib which is not marked up as a reviewer (contrib[@contrib-type='reviewer']).</report>
       
-      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="error" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers.</report>
+      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="warning" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.</report>
     </rule>
   </pattern>
   <pattern id="dec-letter-reviewer-tests-2-pattern">

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -6249,12 +6249,12 @@
       </x:scenario>
       <x:scenario label="dec-letter-reviewer-test-6-pass">
         <x:context href="../tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/pass.xml"/>
-        <x:expect-not-report id="dec-letter-reviewer-test-6" role="error"/>
+        <x:expect-not-report id="dec-letter-reviewer-test-6" role="warning"/>
         <x:expect-not-assert id="dec-letter-reviewer-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="dec-letter-reviewer-test-6-fail">
         <x:context href="../tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/fail.xml"/>
-        <x:expect-report id="dec-letter-reviewer-test-6" role="error"/>
+        <x:expect-report id="dec-letter-reviewer-test-6" role="warning"/>
         <x:expect-not-assert id="dec-letter-reviewer-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -3161,7 +3161,7 @@
       
       <report test="contrib[not(@contrib-type) or @contrib-type!='reviewer']" role="error" id="dec-letter-reviewer-test-2">Second contrib-group in decision letter contains a contrib which is not marked up as a reviewer (contrib[@contrib-type='reviewer']).</report>
       
-      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="error" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers.</report>
+      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="warning" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.</report>
     </rule>
   </pattern>
   <pattern id="dec-letter-reviewer-tests-2-pattern">

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -3160,7 +3160,7 @@
       
       <report test="contrib[not(@contrib-type) or @contrib-type!='reviewer']" role="error" id="dec-letter-reviewer-test-2">Second contrib-group in decision letter contains a contrib which is not marked up as a reviewer (contrib[@contrib-type='reviewer']).</report>
       
-      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="error" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers.</report>
+      <report test="count(contrib[@contrib-type='reviewer']) gt 3" role="warning" id="dec-letter-reviewer-test-6">Second contrib-group in decision letter contains more than three reviewers. Is this correct? Exeter: Please check with eLife. eLife: check eJP to ensure this is correct.</report>
     </rule>
   </pattern>
   <pattern id="dec-letter-reviewer-tests-2-pattern">


### PR DESCRIPTION
- Downgrade `dec-letter-reviewer-test-6` to warning. In exceptional cases more than 3 reviewers are allowed.