### PR TITLE
fix: app-table-wrap-ids

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -2129,15 +2129,15 @@
       
       <report test="count(tr) lt 1" role="warning" id="kr-table-header-3">Key resources table has no rows in its header, which is incorrect.</report>
       
-      <assert test="normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</assert>
+      <report test="tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[2]) = 'Designation'" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</assert>
+      <report test="tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[3]) = 'Source or reference'" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</assert>
+      <report test="tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[4]) = 'Identifiers'" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</assert>
+      <report test="tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[5]) = 'Additional information'" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</assert>
+      <report test="tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</report>
       
     </rule>
   </pattern>
@@ -2903,7 +2903,7 @@
     </rule>
   </pattern>
   <pattern id="app-table-wrap-ids-pattern">
-    <rule context="app/table-wrap" id="app-table-wrap-ids">
+    <rule context="app//table-wrap[label]" id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
     
       <assert test="matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')" role="error" id="app-table-wrap-id-test-1">table-wrap @id in appendix must be in the format 'app0table0'. <value-of select="@id"/> does not conform to this.</assert>
@@ -6204,7 +6204,7 @@
       
       <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
       
-      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
+      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software reference contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
     </rule>
@@ -6873,7 +6873,7 @@
         <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.5281/zenodo'. Should it have a link in the format 'http://doi.org/10.5281/zenodo...'?</report>
       
       <report test="$host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))" role="warning" id="software-doi-test-2">
-        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>)known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
+        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
       
     </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -2135,15 +2135,15 @@
       
       <report test="count(tr) lt 1" role="warning" id="kr-table-header-3">Key resources table has no rows in its header, which is incorrect.</report>
       
-      <assert test="normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</assert>
+      <report test="tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[2]) = 'Designation'" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</assert>
+      <report test="tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[3]) = 'Source or reference'" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</assert>
+      <report test="tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[4]) = 'Identifiers'" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</assert>
+      <report test="tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[5]) = 'Additional information'" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</assert>
+      <report test="tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</report>
       
     </rule>
   </pattern>
@@ -2909,7 +2909,7 @@
     </rule>
   </pattern>
   <pattern id="app-table-wrap-ids-pattern">
-    <rule context="app/table-wrap" id="app-table-wrap-ids">
+    <rule context="app//table-wrap[label]" id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
     
       <assert test="matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')" role="error" id="app-table-wrap-id-test-1">table-wrap @id in appendix must be in the format 'app0table0'. <value-of select="@id"/> does not conform to this.</assert>
@@ -6210,7 +6210,7 @@
       
       <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
       
-      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
+      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software reference contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
     </rule>
@@ -6879,7 +6879,7 @@
         <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.5281/zenodo'. Should it have a link in the format 'http://doi.org/10.5281/zenodo...'?</report>
       
       <report test="$host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))" role="warning" id="software-doi-test-2">
-        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>)known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
+        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -2128,15 +2128,15 @@
       
       <report test="count(tr) lt 1" role="warning" id="kr-table-header-3">Key resources table has no rows in its header, which is incorrect.</report>
       
-      <assert test="normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</assert>
+      <report test="tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[2]) = 'Designation'" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</assert>
+      <report test="tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[3]) = 'Source or reference'" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</assert>
+      <report test="tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[4]) = 'Identifiers'" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</assert>
+      <report test="tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[5]) = 'Additional information'" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</assert>
+      <report test="tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</report>
       
     </rule>
   </pattern>
@@ -2902,7 +2902,7 @@
     </rule>
   </pattern>
   <pattern id="app-table-wrap-ids-pattern">
-    <rule context="app/table-wrap" id="app-table-wrap-ids">
+    <rule context="app//table-wrap[label]" id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
     
       <assert test="matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')" role="error" id="app-table-wrap-id-test-1">table-wrap @id in appendix must be in the format 'app0table0'. <value-of select="@id"/> does not conform to this.</assert>
@@ -6203,7 +6203,7 @@
       
       <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
       
-      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
+      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software reference contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
     </rule>
@@ -6872,7 +6872,7 @@
         <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.5281/zenodo'. Should it have a link in the format 'http://doi.org/10.5281/zenodo...'?</report>
       
       <report test="$host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))" role="warning" id="software-doi-test-2">
-        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>)known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
+        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
       
     </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2880,25 +2880,25 @@
         role="warning"
         id="kr-table-header-3">Key resources table has no rows in its header, which is incorrect.</report>
       
-      <assert test="normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'" 
+      <report test="tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')" 
         role="warning"
-        id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</assert>
+        id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[2]) = 'Designation'" 
+      <report test="tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')" 
         role="warning"
-        id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</assert>
+        id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[3]) = 'Source or reference'" 
+      <report test="tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')" 
         role="warning"
-        id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</assert>
+        id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[4]) = 'Identifiers'" 
+      <report test="tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')" 
         role="warning"
-        id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</assert>
+        id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[5]) = 'Additional information'" 
+      <report test="tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')" 
         role="warning"
-        id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</assert>
+        id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</report>
       
     </rule>
     
@@ -4000,7 +4000,7 @@
         id="sub-mml-math-id-test">mml:math @id in disp-formula must be in the format 'sa0m0'.  <value-of select="@id"/> does not conform to this.</report>
     </rule>
     
-    <rule context="app/table-wrap" 
+    <rule context="app//table-wrap[label]" 
     id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
     
@@ -8356,7 +8356,7 @@
       
       <report test="matches(.,'�')"
         role="error"
-        id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/></report>
+        id="software-replacement-character-presence">software reference contains the replacement character '�' which is unallowed - <value-of select="."/></report>
       
     </rule>
     
@@ -9417,7 +9417,7 @@
       
       <report test="$host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))"
         role="warning" 
-        id="software-doi-test-2"><value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>)known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
+        id="software-doi-test-2"><value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
       
     </rule>
     

--- a/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-1/app-table-wrap-id-test-1.sch
+++ b/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-1/app-table-wrap-id-test-1.sch
@@ -725,14 +725,14 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="id-conformance">
-    <rule context="app/table-wrap" id="app-table-wrap-ids">
+    <rule context="app//table-wrap[label]" id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
       <assert test="matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')" role="error" id="app-table-wrap-id-test-1">table-wrap @id in appendix must be in the format 'app0table0'. <value-of select="@id"/> does not conform to this.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::app/table-wrap" role="error" id="app-table-wrap-ids-xspec-assert">app/table-wrap must be present.</assert>
+      <assert test="descendant::app//table-wrap[label]" role="error" id="app-table-wrap-ids-xspec-assert">app//table-wrap[label] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-1/fail.xml
+++ b/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-1/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="app-table-wrap-id-test-1.sch"?>
-<!--Context: app/table-wrap
+<!--Context: app//table-wrap[label]
 Test: assert    matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')
 Message: table-wrap @id in appendix must be in the format 'app0table0'.  does not conform to this.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-1/pass.xml
+++ b/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-1/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="app-table-wrap-id-test-1.sch"?>
-<!--Context: app/table-wrap
+<!--Context: app//table-wrap[label]
 Test: assert    matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')
 Message: table-wrap @id in appendix must be in the format 'app0table0'.  does not conform to this.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-2/app-table-wrap-id-test-2.sch
+++ b/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-2/app-table-wrap-id-test-2.sch
@@ -725,14 +725,14 @@
     </xsl:choose>
   </xsl:function>
   <pattern id="id-conformance">
-    <rule context="app/table-wrap" id="app-table-wrap-ids">
+    <rule context="app//table-wrap[label]" id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
       <assert test="starts-with(@id, concat('app' , $app-no))" role="error" id="app-table-wrap-id-test-2">table-wrap @id must start with <value-of select="concat('app' , $app-no)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::app/table-wrap" role="error" id="app-table-wrap-ids-xspec-assert">app/table-wrap must be present.</assert>
+      <assert test="descendant::app//table-wrap[label]" role="error" id="app-table-wrap-ids-xspec-assert">app//table-wrap[label] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-2/fail.xml
+++ b/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-2/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="app-table-wrap-id-test-2.sch"?>
-<!--Context: app/table-wrap
+<!--Context: app//table-wrap[label]
 Test: assert    starts-with(@id, concat('app' , $app-no))
 Message: table-wrap @id must start with .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-2/pass.xml
+++ b/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-2/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="app-table-wrap-id-test-2.sch"?>
-<!--Context: app/table-wrap
+<!--Context: app//table-wrap[label]
 Test: assert    starts-with(@id, concat('app' , $app-no))
 Message: table-wrap @id must start with .-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/doi-software-ref-checks/software-doi-test-2/fail.xml
+++ b/test/tests/gen/doi-software-ref-checks/software-doi-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="software-doi-test-2.sch"?>
 <!--Context: element-citation[(@publication-type='software') and year and source]
 Test: report    $host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))
-Message:  is a software ref with a host ()known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?-->
+Message:  is a software ref with a host () known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation publication-type="software">

--- a/test/tests/gen/doi-software-ref-checks/software-doi-test-2/pass.xml
+++ b/test/tests/gen/doi-software-ref-checks/software-doi-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="software-doi-test-2.sch"?>
 <!--Context: element-citation[(@publication-type='software') and year and source]
 Test: report    $host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))
-Message:  is a software ref with a host ()known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?-->
+Message:  is a software ref with a host () known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation publication-type="software">

--- a/test/tests/gen/doi-software-ref-checks/software-doi-test-2/software-doi-test-2.sch
+++ b/test/tests/gen/doi-software-ref-checks/software-doi-test-2/software-doi-test-2.sch
@@ -729,7 +729,7 @@
       <let name="cite" value="e:citation-format1(year[1])"/>
       <let name="host" value="lower-case(source[1])"/>
       <report test="$host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))" role="warning" id="software-doi-test-2">
-        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>)known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
+        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-4/fail.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-4/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-4.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'
+Test: report    tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')
 Message: The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-4/kr-table-header-4.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-4/kr-table-header-4.sch
@@ -726,7 +726,7 @@
   </xsl:function>
   <pattern id="content-containers">
     <rule context="table-wrap[@id='keyresource']/table/thead[1]" id="kr-table-heading-tests">
-      <assert test="normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</assert>
+      <report test="tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-4/pass.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-4/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-4.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'
+Test: report    tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')
 Message: The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-5/fail.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-5/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-5.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[2]) = 'Designation'
+Test: report    tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')
 Message: The second column header in a Key resources table is usually 'Designation' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-5/kr-table-header-5.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-5/kr-table-header-5.sch
@@ -726,7 +726,7 @@
   </xsl:function>
   <pattern id="content-containers">
     <rule context="table-wrap[@id='keyresource']/table/thead[1]" id="kr-table-heading-tests">
-      <assert test="normalize-space(tr[1]/th[2]) = 'Designation'" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</assert>
+      <report test="tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-5/pass.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-5/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-5.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[2]) = 'Designation'
+Test: report    tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')
 Message: The second column header in a Key resources table is usually 'Designation' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-6/fail.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-6/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-6.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[3]) = 'Source or reference'
+Test: report    tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')
 Message: The third column header in a Key resources table is usually 'Source or reference' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-6/kr-table-header-6.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-6/kr-table-header-6.sch
@@ -726,7 +726,7 @@
   </xsl:function>
   <pattern id="content-containers">
     <rule context="table-wrap[@id='keyresource']/table/thead[1]" id="kr-table-heading-tests">
-      <assert test="normalize-space(tr[1]/th[3]) = 'Source or reference'" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</assert>
+      <report test="tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-6/pass.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-6/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-6.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[3]) = 'Source or reference'
+Test: report    tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')
 Message: The third column header in a Key resources table is usually 'Source or reference' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-7/fail.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-7/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-7.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[4]) = 'Identifiers'
+Test: report    tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')
 Message: The fourth column header in a Key resources table is usually 'Identifiers' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-7/kr-table-header-7.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-7/kr-table-header-7.sch
@@ -726,7 +726,7 @@
   </xsl:function>
   <pattern id="content-containers">
     <rule context="table-wrap[@id='keyresource']/table/thead[1]" id="kr-table-heading-tests">
-      <assert test="normalize-space(tr[1]/th[4]) = 'Identifiers'" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</assert>
+      <report test="tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-7/pass.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-7/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-7.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[4]) = 'Identifiers'
+Test: report    tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')
 Message: The fourth column header in a Key resources table is usually 'Identifiers' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-8/fail.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-8/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-8.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[5]) = 'Additional information'
+Test: report    tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')
 Message: The fifth column header in a Key resources table is usually 'Additional information' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-8/kr-table-header-8.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-8/kr-table-header-8.sch
@@ -726,7 +726,7 @@
   </xsl:function>
   <pattern id="content-containers">
     <rule context="table-wrap[@id='keyresource']/table/thead[1]" id="kr-table-heading-tests">
-      <assert test="normalize-space(tr[1]/th[5]) = 'Additional information'" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</assert>
+      <report test="tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-8/pass.xml
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-8/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="kr-table-header-8.sch"?>
 <!--Context: table-wrap[@id='keyresource']/table/thead[1]
-Test: assert    normalize-space(tr[1]/th[5]) = 'Additional information'
+Test: report    tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')
 Message: The fifth column header in a Key resources table is usually 'Additional information' but this one has ''.-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/software-ref-tests/software-replacement-character-presence/fail.xml
+++ b/test/tests/gen/software-ref-tests/software-replacement-character-presence/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="software-replacement-character-presence.sch"?>
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(.,'�')
-Message: software citation contains the replacement character '�' which is unallowed - -->
+Message: software reference contains the replacement character '�' which is unallowed - -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <ref id="bib33"><element-citation publication-type="software">

--- a/test/tests/gen/software-ref-tests/software-replacement-character-presence/pass.xml
+++ b/test/tests/gen/software-ref-tests/software-replacement-character-presence/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="software-replacement-character-presence.sch"?>
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(.,'�')
-Message: software citation contains the replacement character '�' which is unallowed - -->
+Message: software reference contains the replacement character '�' which is unallowed - -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <ref id="bib33"><element-citation publication-type="software">

--- a/test/tests/gen/software-ref-tests/software-replacement-character-presence/software-replacement-character-presence.sch
+++ b/test/tests/gen/software-ref-tests/software-replacement-character-presence/software-replacement-character-presence.sch
@@ -727,7 +727,7 @@
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='software']" id="software-ref-tests">
       <let name="lc" value="lower-case(data-title[1])"/>
-      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
+      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software reference contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
     </rule>
   </pattern>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -2136,15 +2136,15 @@
       
       <report test="count(tr) lt 1" role="warning" id="kr-table-header-3">Key resources table has no rows in its header, which is incorrect.</report>
       
-      <assert test="normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</assert>
+      <report test="tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[2]) = 'Designation'" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</assert>
+      <report test="tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[3]) = 'Source or reference'" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</assert>
+      <report test="tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[4]) = 'Identifiers'" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</assert>
+      <report test="tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[5]) = 'Additional information'" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</assert>
+      <report test="tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</report>
       
     </rule>
   </pattern>
@@ -2916,7 +2916,7 @@
     </rule>
   </pattern>
   <pattern id="app-table-wrap-ids-pattern">
-    <rule context="app/table-wrap" id="app-table-wrap-ids">
+    <rule context="app//table-wrap[label]" id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
     
       <assert test="matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')" role="error" id="app-table-wrap-id-test-1">table-wrap @id in appendix must be in the format 'app0table0'. <value-of select="@id"/> does not conform to this.</assert>
@@ -6209,7 +6209,7 @@
       
       <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
       
-      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
+      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software reference contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
     </rule>
@@ -6896,7 +6896,7 @@
         <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.5281/zenodo'. Should it have a link in the format 'http://doi.org/10.5281/zenodo...'?</report>
       
       <report test="$host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))" role="warning" id="software-doi-test-2">
-        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>)known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
+        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
       
     </rule>
   </pattern>
@@ -7371,7 +7371,7 @@
       <assert test="descendant::fn" role="error" id="fn-ids-xspec-assert">fn must be present.</assert>
       <assert test="descendant::disp-formula" role="error" id="disp-formula-ids-xspec-assert">disp-formula must be present.</assert>
       <assert test="descendant::disp-formula/mml:math" role="error" id="mml-math-ids-xspec-assert">disp-formula/mml:math must be present.</assert>
-      <assert test="descendant::app/table-wrap" role="error" id="app-table-wrap-ids-xspec-assert">app/table-wrap must be present.</assert>
+      <assert test="descendant::app//table-wrap[label]" role="error" id="app-table-wrap-ids-xspec-assert">app//table-wrap[label] must be present.</assert>
       <assert test="descendant::sub-article//table-wrap" role="error" id="resp-table-wrap-ids-xspec-assert">sub-article//table-wrap must be present.</assert>
       <assert test="descendant::article//table-wrap[not(ancestor::app) and not(ancestor::sub-article[@article-type='reply'])]" role="error" id="table-wrap-ids-xspec-assert">article//table-wrap[not(ancestor::app) and not(ancestor::sub-article[@article-type='reply'])] must be present.</assert>
       <assert test="descendant::article/body/sec" role="error" id="body-top-level-sec-ids-xspec-assert">article/body/sec must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -3827,52 +3827,52 @@
       </x:scenario>
       <x:scenario label="kr-table-header-4-pass">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-4/pass.xml"/>
-        <x:expect-not-assert id="kr-table-header-4" role="warning"/>
+        <x:expect-not-report id="kr-table-header-4" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-4-fail">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-4/fail.xml"/>
-        <x:expect-assert id="kr-table-header-4" role="warning"/>
+        <x:expect-report id="kr-table-header-4" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-5-pass">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-5/pass.xml"/>
-        <x:expect-not-assert id="kr-table-header-5" role="warning"/>
+        <x:expect-not-report id="kr-table-header-5" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-5-fail">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-5/fail.xml"/>
-        <x:expect-assert id="kr-table-header-5" role="warning"/>
+        <x:expect-report id="kr-table-header-5" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-6-pass">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-6/pass.xml"/>
-        <x:expect-not-assert id="kr-table-header-6" role="warning"/>
+        <x:expect-not-report id="kr-table-header-6" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-6-fail">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-6/fail.xml"/>
-        <x:expect-assert id="kr-table-header-6" role="warning"/>
+        <x:expect-report id="kr-table-header-6" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-7-pass">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-7/pass.xml"/>
-        <x:expect-not-assert id="kr-table-header-7" role="warning"/>
+        <x:expect-not-report id="kr-table-header-7" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-7-fail">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-7/fail.xml"/>
-        <x:expect-assert id="kr-table-header-7" role="warning"/>
+        <x:expect-report id="kr-table-header-7" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-8-pass">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-8/pass.xml"/>
-        <x:expect-not-assert id="kr-table-header-8" role="warning"/>
+        <x:expect-not-report id="kr-table-header-8" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="kr-table-header-8-fail">
         <x:context href="../tests/gen/kr-table-heading-tests/kr-table-header-8/fail.xml"/>
-        <x:expect-assert id="kr-table-header-8" role="warning"/>
+        <x:expect-report id="kr-table-header-8" role="warning"/>
         <x:expect-not-assert id="kr-table-heading-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>

--- a/validator/webapp/schematron/final-JATS-schematron.sch
+++ b/validator/webapp/schematron/final-JATS-schematron.sch
@@ -2129,15 +2129,15 @@
       
       <report test="count(tr) lt 1" role="warning" id="kr-table-header-3">Key resources table has no rows in its header, which is incorrect.</report>
       
-      <assert test="normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</assert>
+      <report test="tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[2]) = 'Designation'" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</assert>
+      <report test="tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[3]) = 'Source or reference'" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</assert>
+      <report test="tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[4]) = 'Identifiers'" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</assert>
+      <report test="tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[5]) = 'Additional information'" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</assert>
+      <report test="tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</report>
       
     </rule>
   </pattern>
@@ -2903,7 +2903,7 @@
     </rule>
   </pattern>
   <pattern id="app-table-wrap-ids-pattern">
-    <rule context="app/table-wrap" id="app-table-wrap-ids">
+    <rule context="app//table-wrap[label]" id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
     
       <assert test="matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')" role="error" id="app-table-wrap-id-test-1">table-wrap @id in appendix must be in the format 'app0table0'. <value-of select="@id"/> does not conform to this.</assert>
@@ -6204,7 +6204,7 @@
       
       <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
       
-      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
+      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software reference contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
     </rule>
@@ -6873,7 +6873,7 @@
         <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.5281/zenodo'. Should it have a link in the format 'http://doi.org/10.5281/zenodo...'?</report>
       
       <report test="$host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))" role="warning" id="software-doi-test-2">
-        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>)known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
+        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
       
     </rule>
   </pattern>

--- a/validator/webapp/schematron/pre-JATS-schematron.sch
+++ b/validator/webapp/schematron/pre-JATS-schematron.sch
@@ -2128,15 +2128,15 @@
       
       <report test="count(tr) lt 1" role="warning" id="kr-table-header-3">Key resources table has no rows in its header, which is incorrect.</report>
       
-      <assert test="normalize-space(tr[1]/th[1]) = 'Reagent type (species) or resource'" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</assert>
+      <report test="tr[1]/th[1] and (normalize-space(tr[1]/th[1]) != 'Reagent type (species) or resource')" role="warning" id="kr-table-header-4">The first column header in a Key resources table is usually 'Reagent type (species) or resource' but this one has '<value-of select="tr[1]/th[1]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[2]) = 'Designation'" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</assert>
+      <report test="tr[1]/th[2] and (normalize-space(tr[1]/th[2]) != 'Designation')" role="warning" id="kr-table-header-5">The second column header in a Key resources table is usually 'Designation' but this one has '<value-of select="tr[1]/th[2]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[3]) = 'Source or reference'" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</assert>
+      <report test="tr[1]/th[3] and (normalize-space(tr[1]/th[3]) != 'Source or reference')" role="warning" id="kr-table-header-6">The third column header in a Key resources table is usually 'Source or reference' but this one has '<value-of select="tr[1]/th[3]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[4]) = 'Identifiers'" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</assert>
+      <report test="tr[1]/th[4] and (normalize-space(tr[1]/th[4]) != 'Identifiers')" role="warning" id="kr-table-header-7">The fourth column header in a Key resources table is usually 'Identifiers' but this one has '<value-of select="tr[1]/th[4]"/>'.</report>
       
-      <assert test="normalize-space(tr[1]/th[5]) = 'Additional information'" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</assert>
+      <report test="tr[1]/th[5] and (normalize-space(tr[1]/th[5]) != 'Additional information')" role="warning" id="kr-table-header-8">The fifth column header in a Key resources table is usually 'Additional information' but this one has '<value-of select="tr[1]/th[5]"/>'.</report>
       
     </rule>
   </pattern>
@@ -2902,7 +2902,7 @@
     </rule>
   </pattern>
   <pattern id="app-table-wrap-ids-pattern">
-    <rule context="app/table-wrap" id="app-table-wrap-ids">
+    <rule context="app//table-wrap[label]" id="app-table-wrap-ids">
       <let name="app-no" value="substring-after(ancestor::app[1]/@id,'-')"/>
     
       <assert test="matches(@id, '^app[0-9]{1,3}table[0-9]{1,3}$')" role="error" id="app-table-wrap-id-test-1">table-wrap @id in appendix must be in the format 'app0table0'. <value-of select="@id"/> does not conform to this.</assert>
@@ -6203,7 +6203,7 @@
       
       <report test="matches(lower-case(publisher-name[1]),'r: a language and environment for statistical computing')" role="error" id="R-test-6">software ref '<value-of select="ancestor::ref/@id"/>' has a publisher-name - <value-of select="source"/> - but this is the data-title.</report>
       
-      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software citation contains the replacement character '�' which is unallowed - <value-of select="."/>
+      <report test="matches(.,'�')" role="error" id="software-replacement-character-presence">software reference contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
       
     </rule>
@@ -6872,7 +6872,7 @@
         <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.5281/zenodo'. Should it have a link in the format 'http://doi.org/10.5281/zenodo...'?</report>
       
       <report test="$host='figshare' and not(contains(ext-link,'10.6084/m9.figshare'))" role="warning" id="software-doi-test-2">
-        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>)known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
+        <value-of select="$cite"/> is a software ref with a host (<value-of select="source[1]"/>) known to register dois starting with '10.6084/m9.figshare'. Should it have a link in the format 'http://doi.org/10.6084/m9.figshare...'?</report>
       
     </rule>
   </pattern>


### PR DESCRIPTION
- fix: context `app-table-wrap-ids` - table descendants of app instead of child.
- Only fire certain kr-table-header tests when the header is present.
- Typos and message text fixes