### PR TITLE
fix: Less sensitivity for surname-test-5

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1115,7 +1115,7 @@
 		
 	  <assert test="matches(.,&quot;^[\p{L}\p{M}\s'-]*$&quot;)" role="error" id="surname-test-4">[surname-test-4] surname should usually only contain letters, spaces, or hyphens. <value-of select="."/> contains other characters.</assert>
 		
-	  <assert test="matches(.,'^\p{Lu}')" role="warning" id="surname-test-5">[surname-test-5] surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</assert>
+	  <report test="matches(.,'^\p{Ll}') and not(matches(.,'^de[rn]? |^van |^von |^el |^te[rn] '))" role="warning" id="surname-test-5">[surname-test-5] surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</report>
 	  
 	  <report test="matches(.,'^\s')" role="error" id="surname-test-6">[surname-test-6] surname starts with a space, which cannot be correct - '<value-of select="."/>'.</report>
 	  

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1127,7 +1127,7 @@
 		
 	  <assert test="matches(.,&quot;^[\p{L}\p{M}\s'-]*$&quot;)" role="error" id="surname-test-4">surname should usually only contain letters, spaces, or hyphens. <value-of select="."/> contains other characters.</assert>
 		
-	  <assert test="matches(.,'^\p{Lu}')" role="warning" id="surname-test-5">surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</assert>
+	  <report test="matches(.,'^\p{Ll}') and not(matches(.,'^de[rn]? |^van |^von |^el |^te[rn] '))" role="warning" id="surname-test-5">surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</report>
 	  
 	  <report test="matches(.,'^\s')" role="error" id="surname-test-6">surname starts with a space, which cannot be correct - '<value-of select="."/>'.</report>
 	  

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1115,7 +1115,7 @@
 		
 	  <assert test="matches(.,&quot;^[\p{L}\p{M}\s'-]*$&quot;)" role="error" id="surname-test-4">[surname-test-4] surname should usually only contain letters, spaces, or hyphens. <value-of select="."/> contains other characters.</assert>
 		
-	  <assert test="matches(.,'^\p{Lu}')" role="warning" id="surname-test-5">[surname-test-5] surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</assert>
+	  <report test="matches(.,'^\p{Ll}') and not(matches(.,'^de[rn]? |^van |^von |^el |^te[rn] '))" role="warning" id="surname-test-5">[surname-test-5] surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</report>
 	  
 	  <report test="matches(.,'^\s')" role="error" id="surname-test-6">[surname-test-6] surname starts with a space, which cannot be correct - '<value-of select="."/>'.</report>
 	  

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1304,9 +1304,9 @@
       	role="error" 
       	id="surname-test-4">surname should usually only contain letters, spaces, or hyphens. <value-of select="."/> contains other characters.</assert>
 		
-	  <assert test="matches(.,'^\p{Lu}')"
-      	role="warning" 
-      	id="surname-test-5">surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</assert>
+	  <report test="matches(.,'^\p{Ll}') and not(matches(.,'^de[rn]? |^van |^von |^el |^te[rn] '))"
+      role="warning" 
+      id="surname-test-5">surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</report>
 	  
 	  <report test="matches(.,'^\s')"
 	    role="error" 

--- a/test/tests/gen/software-ref-tests/ref-software-test-1/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-1/fail.xml
@@ -92,9 +92,11 @@ Message: software ref '' has both a source (Software name) -  - and a publisher-
 
 
 
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    source and publisher-name
 Message: software ref '' has both a source (Software name) -  - and a publisher-name (Software host) -  - which is incorrect. It should have either one or the other. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-1-->
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-1/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-1/pass.xml
@@ -91,9 +91,11 @@ Message: software ref '' has both a source (Software name) -  - and a publisher-
 
 
 
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    source and publisher-name
 Message: software ref '' has both a source (Software name) -  - and a publisher-name (Software host) -  - which is incorrect. It should have either one or the other. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-1-->
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-2/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-2/fail.xml
@@ -91,9 +91,11 @@ Message: software ref '' with the title -  - must contain either one source elem
 
 
 
+
 <!--Context: element-citation[@publication-type='software']
 Test: assert    source or publisher-name
 Message: software ref '' with the title -  - must contain either one source element (Software name) or one publisher-name element (Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-2-->
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-2/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-2/pass.xml
@@ -91,9 +91,11 @@ Message: software ref '' with the title -  - must contain either one source elem
 
 
 
+
 <!--Context: element-citation[@publication-type='software']
 Test: assert    source or publisher-name
 Message: software ref '' with the title -  - must contain either one source element (Software name) or one publisher-name element (Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-2-->
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-3/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-3/fail.xml
@@ -91,9 +91,11 @@ Message: software ref '' has a publisher-name (Software host) - . Since this is 
 
 
 
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(publisher-name[1]),'github|gitlab|bitbucket|sourceforge|figshare|^osf$|open science framework|zenodo|matlab')
 Message: software ref '' has a publisher-name (Software host) - . Since this is a software source, it should be captured in a source element. Please move into the Software name field (rather than Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-3-->
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-3/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-3/pass.xml
@@ -91,9 +91,11 @@ Message: software ref '' has a publisher-name (Software host) - . Since this is 
 
 
 
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(publisher-name[1]),'github|gitlab|bitbucket|sourceforge|figshare|^osf$|open science framework|zenodo|matlab')
 Message: software ref '' has a publisher-name (Software host) - . Since this is a software source, it should be captured in a source element. Please move into the Software name field (rather than Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-3-->
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-4/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-4/fail.xml
@@ -91,9 +91,11 @@ Message: software ref '' has a source (Software name) - . Since this is a softwa
 
 
 
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(source[1]),'schr[öo]dinger|r foundation|rstudio ,? inc|mathworks| llc| ltd')
 Message: software ref '' has a source (Software name) - . Since this is a software publisher, it should be captured in a publisher-name element. Please move into the Software host field. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-4-->
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-4/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-4/pass.xml
@@ -91,9 +91,11 @@ Message: software ref '' has a source (Software name) - . Since this is a softwa
 
 
 
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(source[1]),'schr[öo]dinger|r foundation|rstudio ,? inc|mathworks| llc| ltd')
 Message: software ref '' has a source (Software name) - . Since this is a software publisher, it should be captured in a publisher-name element. Please move into the Software host field. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-4-->
+
 
 
 

--- a/test/tests/gen/surname-tests/surname-test-5/fail.xml
+++ b/test/tests/gen/surname-tests/surname-test-5/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="surname-test-5.sch"?>
 <!--Context: contrib-group//name/surname
-Test: assert    matches(.,'^\p{Lu}')
+Test: report    matches(.,'^\p{Ll}') and not(matches(.,'^de[rn]? |^van |^von |^el |^te[rn] '))
 Message: surname doesn't begin with a capital letter - . Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/surname-tests/surname-test-5/pass.xml
+++ b/test/tests/gen/surname-tests/surname-test-5/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="surname-test-5.sch"?>
 <!--Context: contrib-group//name/surname
-Test: assert    matches(.,'^\p{Lu}')
+Test: report    matches(.,'^\p{Ll}') and not(matches(.,'^de[rn]? |^van |^von |^el |^te[rn] '))
 Message: surname doesn't begin with a capital letter - . Is this correct?-->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/surname-tests/surname-test-5/surname-test-5.sch
+++ b/test/tests/gen/surname-tests/surname-test-5/surname-test-5.sch
@@ -781,7 +781,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="contrib-group//name/surname" id="surname-tests">
-      <assert test="matches(.,'^\p{Lu}')" role="warning" id="surname-test-5">surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</assert>
+      <report test="matches(.,'^\p{Ll}') and not(matches(.,'^de[rn]? |^van |^von |^el |^te[rn] '))" role="warning" id="surname-test-5">surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1121,7 +1121,7 @@
 		
 	  <assert test="matches(.,&quot;^[\p{L}\p{M}\s'-]*$&quot;)" role="error" id="surname-test-4">surname should usually only contain letters, spaces, or hyphens. <value-of select="."/> contains other characters.</assert>
 		
-	  <assert test="matches(.,'^\p{Lu}')" role="warning" id="surname-test-5">surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</assert>
+	  <report test="matches(.,'^\p{Ll}') and not(matches(.,'^de[rn]? |^van |^von |^el |^te[rn] '))" role="warning" id="surname-test-5">surname doesn't begin with a capital letter - <value-of select="."/>. Is this correct?</report>
 	  
 	  <report test="matches(.,'^\s')" role="error" id="surname-test-6">surname starts with a space, which cannot be correct - '<value-of select="."/>'.</report>
 	  

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -889,12 +889,12 @@
       </x:scenario>
       <x:scenario label="surname-test-5-pass">
         <x:context href="../tests/gen/surname-tests/surname-test-5/pass.xml"/>
-        <x:expect-not-assert id="surname-test-5" role="warning"/>
+        <x:expect-not-report id="surname-test-5" role="warning"/>
         <x:expect-not-assert id="surname-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="surname-test-5-fail">
         <x:context href="../tests/gen/surname-tests/surname-test-5/fail.xml"/>
-        <x:expect-assert id="surname-test-5" role="warning"/>
+        <x:expect-report id="surname-test-5" role="warning"/>
         <x:expect-not-assert id="surname-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="surname-test-6-pass">


### PR DESCRIPTION
- Only fire `surname-test-5` in cases where the surname does not start with common lower case words, such as 'van', or 'de'.