### PR TITLE
improvement: Refinements and new checks

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -2272,10 +2272,9 @@
     </rule>
   </pattern>
   <pattern id="table-fn-label-tests-pattern">
-    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
-      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+    <rule context="table-wrap-foot//fn/p" id="table-fn-label-tests"> 
       
-      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">[table-fn-label-test-1] Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
+      <report test="not(matches(.,'^\s?[*†‡§¶]')) and matches(.,'^\s?[\p{Ps}]?[\da-z][\p{Pe}]?\s+[\p{Lu}\d]')" role="warning" id="table-fn-label-test-1">[table-fn-label-test-1] Footnote starts with what might be a label which is not in line with house style - <value-of select="."/>. If it is a label, then it should changed to one of the allowed symbols, so that the order of labels in the footnotes follows this sequence *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -2515,7 +2514,7 @@
       
       
       
-      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="final-fig-specific-test-4">[final-fig-specific-test-4] There is no citation to <value-of select="$lab"/> Ensure this is added.</report>
+      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="final-fig-specific-test-4">[final-fig-specific-test-4] There is no citation to <value-of select="$lab"/> Ensure this is added.</report>
       
       <report test="if ($article-type = $features-article-types) then (not(ancestor::article//xref[@rid = $id]))         else ()" role="warning" id="feat-fig-specific-test-4">[feat-fig-specific-test-4] There is no citation to <value-of select="if (label) then label else 'figure.'"/> Is this correct?</report>
       
@@ -3961,9 +3960,9 @@
   <pattern id="elem-citation-data-pub-id-pattern">
     <rule context="ref/element-citation[@publication-type='data']/pub-id" id="elem-citation-data-pub-id">
       
-      <assert test="@pub-id-type=('accession', 'archive', 'ark', 'doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
-        Each pub-id element must have one of these types: accession, archive, ark, assigning-authority or doi. 
-        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with types 
+      <assert test="@pub-id-type=('accession','doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
+        Each pub-id element must have a pub-id-type which is either accession or doi. 
+        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with the type 
         '<value-of select="@pub-id-type"/>'.</assert>
       
       <report test="if (@pub-id-type != 'doi') then not(@xlink:href) else ()" role="error" id="err-elem-cit-data-14-1">[err-elem-cit-data-14-1]
@@ -4881,7 +4880,7 @@
   <pattern id="das-elem-citation-data-pub-id-pattern">
     <rule context="sec[@sec-type='data-availability']//element-citation[@publication-type='data']/pub-id" id="das-elem-citation-data-pub-id">
       
-      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'archive', 'doi'))" role="error" id="das-pub-id-1">[das-pub-id-1] Each pub-id element must have an @pub-id-type with one of these types: accession, archive, or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
+      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'doi'))" role="error" id="das-pub-id-1">[das-pub-id-1] Each pub-id element must have an @pub-id-type which is either accession or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
       
       <report test="@pub-id-type!='doi' and normalize-space(.)!='' and (not(@xlink:href) or (normalize-space(@xlink:href)=''))" role="error" id="das-pub-id-2">[das-pub-id-2] Each pub-id element which is not a doi must have an @xlink-href (which is not empty). More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-2</report>
       
@@ -4909,13 +4908,19 @@
   <pattern id="pub-id-tests-pattern">
     <rule context="element-citation/pub-id" id="pub-id-tests">
       
-      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">[pub-id-test-1] @xlink:href must start with an http:// or ftp:// protocol. - <value-of select="."/> does not.</report>
+      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">[pub-id-test-1] @xlink:href must start with an http:// or ftp:// protocol. - <value-of select="@xlink:href"/> does not.</report>
       
       <report test="(@pub-id-type='doi') and not(matches(.,'^10\.\d{4,9}/[-._;\+()#/:A-Za-z0-9&lt;&gt;\[\]]+$'))" role="error" id="pub-id-test-2">[pub-id-test-2] pub-id is tagged as a doi, but it is not one - <value-of select="."/>
       </report>
       
       <report test="(@pub-id-type='pmid') and matches(.,'\D')" role="error" id="pub-id-test-3">[pub-id-test-3] pub-id is tagged as a pmid, but it contains a character(s) which is not a digit - <value-of select="."/>
       </report>
+      
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://doi.org/\d')" role="error" id="pub-id-doi-test-1">[pub-id-doi-test-1] pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      
+      <report test="matches(@xlink:href,'https?://doi.org/\d') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">[pub-id-doi-test-2] pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. If the dataset has a doi link, the identifier must be the the doi, which is the string after 'doi.org/' in the link - <value-of select="substring-after(@xlink:href,'doi.org/')"/>.</report>
+      
+      <report test="contains(.,' ')" role="warning" id="pub-id-test-4">[pub-id-test-4] pub id contains whitespace - <value-of select="."/> - which is very likely to be incorrect.</report>
       
     </rule>
   </pattern>
@@ -6235,7 +6240,7 @@
       
       <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">[data-osf-test-2] Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-2</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">[data-osf-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">[data-osf-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">[data-osf-test-4] Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-4</report>
       
@@ -6311,7 +6316,7 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">[data-neurovault-test-2] Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-2</report>
       
-      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">[data-neurovault-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">[data-neurovault-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">[data-wwpdb-test-1] Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-wwpdb-test-1</report>
       
@@ -6335,7 +6340,7 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">[data-encode-test-2] Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-2</report>
       
-      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">[data-encode-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">[data-encode-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">[data-emdr-test-1] Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct? More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-emdr-test-1</report>
       

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -2343,10 +2343,9 @@
     </rule>
   </pattern>
   <pattern id="table-fn-label-tests-pattern">
-    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
-      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+    <rule context="table-wrap-foot//fn/p" id="table-fn-label-tests"> 
       
-      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
+      <report test="not(matches(.,'^\s?[*†‡§¶]')) and matches(.,'^\s?[\p{Ps}]?[\da-z][\p{Pe}]?\s+[\p{Lu}\d]')" role="warning" id="table-fn-label-test-1">Footnote starts with what might be a label which is not in line with house style - <value-of select="."/>. If it is a label, then it should changed to one of the allowed symbols, so that the order of labels in the footnotes follows this sequence *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -2601,7 +2600,7 @@
       
       
       
-      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="final-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure this is added.</report>
+      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="final-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure this is added.</report>
       
       <report test="if ($article-type = $features-article-types) then (not(ancestor::article//xref[@rid = $id]))         else ()" role="warning" id="feat-fig-specific-test-4">There is no citation to <value-of select="if (label) then label else 'figure.'"/> Is this correct?</report>
       
@@ -4062,9 +4061,9 @@
   <pattern id="elem-citation-data-pub-id-pattern">
     <rule context="ref/element-citation[@publication-type='data']/pub-id" id="elem-citation-data-pub-id">
       
-      <assert test="@pub-id-type=('accession', 'archive', 'ark', 'doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
-        Each pub-id element must have one of these types: accession, archive, ark, assigning-authority or doi. 
-        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with types 
+      <assert test="@pub-id-type=('accession','doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
+        Each pub-id element must have a pub-id-type which is either accession or doi. 
+        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with the type 
         '<value-of select="@pub-id-type"/>'.</assert>
       
       <report test="if (@pub-id-type != 'doi') then not(@xlink:href) else ()" role="error" id="err-elem-cit-data-14-1">[err-elem-cit-data-14-1]
@@ -4982,7 +4981,7 @@
   <pattern id="das-elem-citation-data-pub-id-pattern">
     <rule context="sec[@sec-type='data-availability']//element-citation[@publication-type='data']/pub-id" id="das-elem-citation-data-pub-id">
       
-      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'archive', 'doi'))" role="error" id="das-pub-id-1">Each pub-id element must have an @pub-id-type with one of these types: accession, archive, or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
+      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'doi'))" role="error" id="das-pub-id-1">Each pub-id element must have an @pub-id-type which is either accession or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
       
       <report test="@pub-id-type!='doi' and normalize-space(.)!='' and (not(@xlink:href) or (normalize-space(@xlink:href)=''))" role="error" id="das-pub-id-2">Each pub-id element which is not a doi must have an @xlink-href (which is not empty). More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-2</report>
       
@@ -5010,13 +5009,19 @@
   <pattern id="pub-id-tests-pattern">
     <rule context="element-citation/pub-id" id="pub-id-tests">
       
-      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">@xlink:href must start with an http:// or ftp:// protocol. - <value-of select="."/> does not.</report>
+      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">@xlink:href must start with an http:// or ftp:// protocol. - <value-of select="@xlink:href"/> does not.</report>
       
       <report test="(@pub-id-type='doi') and not(matches(.,'^10\.\d{4,9}/[-._;\+()#/:A-Za-z0-9&lt;&gt;\[\]]+$'))" role="error" id="pub-id-test-2">pub-id is tagged as a doi, but it is not one - <value-of select="."/>
       </report>
       
       <report test="(@pub-id-type='pmid') and matches(.,'\D')" role="error" id="pub-id-test-3">pub-id is tagged as a pmid, but it contains a character(s) which is not a digit - <value-of select="."/>
       </report>
+      
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://doi.org/\d')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      
+      <report test="matches(@xlink:href,'https?://doi.org/\d') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. If the dataset has a doi link, the identifier must be the the doi, which is the string after 'doi.org/' in the link - <value-of select="substring-after(@xlink:href,'doi.org/')"/>.</report>
+      
+      <report test="contains(.,' ')" role="warning" id="pub-id-test-4">pub id contains whitespace - <value-of select="."/> - which is very likely to be incorrect.</report>
       
     </rule>
   </pattern>
@@ -6547,7 +6552,7 @@
       
       <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-2</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-4</report>
       
@@ -6623,7 +6628,7 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-2</report>
       
-      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-wwpdb-test-1</report>
       
@@ -6647,7 +6652,7 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-2</report>
       
-      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct? More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-emdr-test-1</report>
       

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -2270,10 +2270,9 @@
     </rule>
   </pattern>
   <pattern id="table-fn-label-tests-pattern">
-    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
-      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+    <rule context="table-wrap-foot//fn/p" id="table-fn-label-tests"> 
       
-      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">[table-fn-label-test-1] Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
+      <report test="not(matches(.,'^\s?[*†‡§¶]')) and matches(.,'^\s?[\p{Ps}]?[\da-z][\p{Pe}]?\s+[\p{Lu}\d]')" role="warning" id="table-fn-label-test-1">[table-fn-label-test-1] Footnote starts with what might be a label which is not in line with house style - <value-of select="."/>. If it is a label, then it should changed to one of the allowed symbols, so that the order of labels in the footnotes follows this sequence *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -2511,7 +2510,7 @@
       
       <report test="if ($article-type = ('correction','retraction')) then ()          else not(                $first-cite-parent/following-sibling::*[1][@id=$id] or                ($first-cite-parent/following-sibling::*[1][local-name()='fig-group'] and $first-cite-parent/following-sibling::*[1]/*[1][@id=$id])                or                (                ($first-cite-parent/following-sibling::*[1]/local-name()=('fig-group','fig','media','table-wrap')) and  ($first-cite-parent/following-sibling::*[2][@id=$id] or                ($first-cite-parent/following-sibling::*[2][local-name()='fig-group'] and $first-cite-parent/following-sibling::*[2]/*[1][@id=$id])))                or                (($first-cite-parent/following-sibling::*[1]/local-name()=('fig-group','fig','media','table-wrap')) and ($first-cite-parent/following-sibling::*[2]/local-name()=('fig-group','fig','media','table-wrap')) and ($first-cite-parent/following-sibling::*[3][@id=$id] or                ($first-cite-parent/following-sibling::*[3][local-name()='fig-group'] and $first-cite-parent/following-sibling::*[3]/*[1][@id=$id])))                or                (($first-cite-parent/following-sibling::*[1]/local-name()=('fig-group','fig','media','table-wrap')) and ($first-cite-parent/following-sibling::*[2]/local-name()=('fig-group','fig','media','table-wrap')) and                ($first-cite-parent/following-sibling::*[3]/local-name()=('fig-group','fig','media','table-wrap')) and ($first-cite-parent/following-sibling::*[4][@id=$id] or ($first-cite-parent/following-sibling::*[4][local-name()='fig-group'] and $first-cite-parent/following-sibling::*[4]/*[1][@id=$id])))                 )" role="warning" id="fig-specific-test-3">[fig-specific-test-3] <value-of select="$lab"/> does not appear directly after a paragraph citing it. Is that correct?</report>
       
-      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="pre-fig-specific-test-4">[pre-fig-specific-test-4] There is no citation to <value-of select="$lab"/> Ensure to query the author asking for a citation.</report>
+      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="pre-fig-specific-test-4">[pre-fig-specific-test-4] There is no citation to <value-of select="$lab"/> Ensure to query the author asking for a citation.</report>
       
       
       
@@ -3959,9 +3958,9 @@
   <pattern id="elem-citation-data-pub-id-pattern">
     <rule context="ref/element-citation[@publication-type='data']/pub-id" id="elem-citation-data-pub-id">
       
-      <assert test="@pub-id-type=('accession', 'archive', 'ark', 'doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
-        Each pub-id element must have one of these types: accession, archive, ark, assigning-authority or doi. 
-        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with types 
+      <assert test="@pub-id-type=('accession','doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
+        Each pub-id element must have a pub-id-type which is either accession or doi. 
+        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with the type 
         '<value-of select="@pub-id-type"/>'.</assert>
       
       <report test="if (@pub-id-type != 'doi') then not(@xlink:href) else ()" role="error" id="err-elem-cit-data-14-1">[err-elem-cit-data-14-1]
@@ -4879,7 +4878,7 @@
   <pattern id="das-elem-citation-data-pub-id-pattern">
     <rule context="sec[@sec-type='data-availability']//element-citation[@publication-type='data']/pub-id" id="das-elem-citation-data-pub-id">
       
-      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'archive', 'doi'))" role="error" id="das-pub-id-1">[das-pub-id-1] Each pub-id element must have an @pub-id-type with one of these types: accession, archive, or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
+      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'doi'))" role="error" id="das-pub-id-1">[das-pub-id-1] Each pub-id element must have an @pub-id-type which is either accession or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
       
       <report test="@pub-id-type!='doi' and normalize-space(.)!='' and (not(@xlink:href) or (normalize-space(@xlink:href)=''))" role="error" id="das-pub-id-2">[das-pub-id-2] Each pub-id element which is not a doi must have an @xlink-href (which is not empty). More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-2</report>
       
@@ -4907,13 +4906,19 @@
   <pattern id="pub-id-tests-pattern">
     <rule context="element-citation/pub-id" id="pub-id-tests">
       
-      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">[pub-id-test-1] @xlink:href must start with an http:// or ftp:// protocol. - <value-of select="."/> does not.</report>
+      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">[pub-id-test-1] @xlink:href must start with an http:// or ftp:// protocol. - <value-of select="@xlink:href"/> does not.</report>
       
       <report test="(@pub-id-type='doi') and not(matches(.,'^10\.\d{4,9}/[-._;\+()#/:A-Za-z0-9&lt;&gt;\[\]]+$'))" role="error" id="pub-id-test-2">[pub-id-test-2] pub-id is tagged as a doi, but it is not one - <value-of select="."/>
       </report>
       
       <report test="(@pub-id-type='pmid') and matches(.,'\D')" role="error" id="pub-id-test-3">[pub-id-test-3] pub-id is tagged as a pmid, but it contains a character(s) which is not a digit - <value-of select="."/>
       </report>
+      
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://doi.org/\d')" role="error" id="pub-id-doi-test-1">[pub-id-doi-test-1] pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      
+      <report test="matches(@xlink:href,'https?://doi.org/\d') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">[pub-id-doi-test-2] pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. If the dataset has a doi link, the identifier must be the the doi, which is the string after 'doi.org/' in the link - <value-of select="substring-after(@xlink:href,'doi.org/')"/>.</report>
+      
+      <report test="contains(.,' ')" role="warning" id="pub-id-test-4">[pub-id-test-4] pub id contains whitespace - <value-of select="."/> - which is very likely to be incorrect.</report>
       
     </rule>
   </pattern>
@@ -6233,7 +6238,7 @@
       
       <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">[data-osf-test-2] Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-2</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">[data-osf-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">[data-osf-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">[data-osf-test-4] Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-4</report>
       
@@ -6309,7 +6314,7 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">[data-neurovault-test-2] Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-2</report>
       
-      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">[data-neurovault-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">[data-neurovault-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">[data-wwpdb-test-1] Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-wwpdb-test-1</report>
       
@@ -6333,7 +6338,7 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">[data-encode-test-2] Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-2</report>
       
-      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">[data-encode-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">[data-encode-test-3] Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">[data-emdr-test-1] Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct? More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-emdr-test-1</report>
       

--- a/test/tests/gen/das-elem-citation-data-pub-id/das-pub-id-1/das-pub-id-1.sch
+++ b/test/tests/gen/das-elem-citation-data-pub-id/das-pub-id-1/das-pub-id-1.sch
@@ -787,7 +787,7 @@
   </xsl:function>
   <pattern id="das-element-citation-tests">
     <rule context="sec[@sec-type='data-availability']//element-citation[@publication-type='data']/pub-id" id="das-elem-citation-data-pub-id">
-      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'archive', 'doi'))" role="error" id="das-pub-id-1">Each pub-id element must have an @pub-id-type with one of these types: accession, archive, or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
+      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'doi'))" role="error" id="das-pub-id-1">Each pub-id element must have an @pub-id-type which is either accession or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/das-elem-citation-data-pub-id/das-pub-id-1/fail.xml
+++ b/test/tests/gen/das-elem-citation-data-pub-id/das-pub-id-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="das-pub-id-1.sch"?>
 <!--Context: sec[@sec-type='data-availability']//element-citation[@publication-type='data']/pub-id
-Test: report    normalize-space(.)!='' and not(@pub-id-type=('accession', 'archive', 'doi'))
-Message: Each pub-id element must have an @pub-id-type with one of these types: accession, archive, or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1 -->
+Test: report    normalize-space(.)!='' and not(@pub-id-type=('accession', 'doi'))
+Message: Each pub-id element must have an @pub-id-type which is either accession or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <back>

--- a/test/tests/gen/das-elem-citation-data-pub-id/das-pub-id-1/pass.xml
+++ b/test/tests/gen/das-elem-citation-data-pub-id/das-pub-id-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="das-pub-id-1.sch"?>
 <!--Context: sec[@sec-type='data-availability']//element-citation[@publication-type='data']/pub-id
-Test: report    normalize-space(.)!='' and not(@pub-id-type=('accession', 'archive', 'doi'))
-Message: Each pub-id element must have an @pub-id-type with one of these types: accession, archive, or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1 -->
+Test: report    normalize-space(.)!='' and not(@pub-id-type=('accession', 'doi'))
+Message: Each pub-id element must have an @pub-id-type which is either accession or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <back>

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/data-encode-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/data-encode-test-3.sch
@@ -787,7 +787,7 @@
   </xsl:function>
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
-      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="data-encode-test-3.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
-Message: Data reference with the title '' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3 -->
+Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation id="dataset7" publication-type="data" specific-use="references">

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/fail.xml
@@ -14,7 +14,7 @@ Message: Data reference with the title '' has an ENCODE 'www.encodeproject.org' 
       <year iso-8601-date="2012">2012</year>
       <data-title>DNase-seq and DGF on 8 week adult mouse heart</data-title>
       <source>ENCODE</source>
-      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
+      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
     </element-citation>
   </article>
 </root>

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="data-encode-test-3.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
-Message: Data reference with the title '' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3 -->
+Test: report    contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation id="dataset7" publication-type="data" specific-use="references">

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/pass.xml
@@ -14,7 +14,7 @@ Message: Data reference with the title '' has an ENCODE 'www.encodeproject.org' 
       <year iso-8601-date="2012">2012</year>
       <data-title>DNase-seq and DGF on 8 week adult mouse heart</data-title>
       <source>ENCODE</source>
-      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://www.encodeproject.org/experiments/ENCSR000CNE/">ENCSR000CNE</pub-id>
     </element-citation>
   </article>
 </root>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/data-neurovault-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/data-neurovault-test-3.sch
@@ -787,7 +787,7 @@
   </xsl:function>
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
-      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/fail.xml
@@ -8,7 +8,7 @@ Message: Data reference with the title '' has a NeuroVault 'neurovault.org/colle
       <year iso-8601-date="2019">2019</year>
       <data-title>Differential Fear Conditioning Paradigm at 7T with Cerebellar Focus</data-title>
       <source>NeuroVault</source>
-      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
+      <pub-id assigning-authority="other" pub-id-type="other" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
     </element-citation>
   </article>
 </root>

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="data-neurovault-test-3.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
-Message: Data reference with the title '' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3 -->
+Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="data-neurovault-test-3.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
-Message: Data reference with the title '' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3 -->
+Test: report    contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/pass.xml
@@ -8,7 +8,7 @@ Message: Data reference with the title '' has a NeuroVault 'neurovault.org/colle
       <year iso-8601-date="2019">2019</year>
       <data-title>Differential Fear Conditioning Paradigm at 7T with Cerebellar Focus</data-title>
       <source>NeuroVault</source>
-      <pub-id assigning-authority="other" pub-id-type="archive" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://neurovault.org/collections/OMLBHQAA/">OMLBHQAA</pub-id>
     </element-citation>
   </article>
 </root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/data-osf-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/data-osf-test-3.sch
@@ -787,7 +787,7 @@
   </xsl:function>
   <pattern id="house-style">
     <rule context="element-citation[@publication-type='data']" id="data-ref-tests">
-      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/fail.xml
@@ -14,7 +14,7 @@ Message: Data reference with the title '' has an OSF 'https://osf.io' type link,
       <year iso-8601-date="2019">2019</year>
       <data-title>RealNoi</data-title>
       <source>Open Science Framework</source>
-      <pub-id assigning-authority="Open Science Framework" pub-id-type="accession" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="other" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
     </element-citation>
   </article>
 </root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/fail.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="data-osf-test-3.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
-Message: Data reference with the title '' has an OSF 'https://osf.io' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3 -->
+Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has an OSF 'https://osf.io' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/pass.xml
@@ -14,7 +14,7 @@ Message: Data reference with the title '' has an OSF 'https://osf.io' type link,
       <year iso-8601-date="2019">2019</year>
       <data-title>RealNoi</data-title>
       <source>Open Science Framework</source>
-      <pub-id assigning-authority="Open Science Framework" pub-id-type="archive" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
+      <pub-id assigning-authority="Open Science Framework" pub-id-type="accession" xlink:href="https://osf.io/f9kzs/">f9kzs</pub-id>
     </element-citation>
   </article>
 </root>

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/pass.xml
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="data-osf-test-3.sch"?>
 <!--Context: element-citation[@publication-type='data']
-Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]
-Message: Data reference with the title '' has an OSF 'https://osf.io' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3 -->
+Test: report    matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]
+Message: Data reference with the title '' has an OSF 'https://osf.io' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation id="dataset1" publication-type="data" specific-use="isSupplementedBy">

--- a/test/tests/gen/elem-citation-data-pub-id/err-elem-cit-data-13-2/fail.xml
+++ b/test/tests/gen/elem-citation-data-pub-id/err-elem-cit-data-13-2/fail.xml
@@ -1,9 +1,9 @@
 <?oxygen SCHSchema="err-elem-cit-data-13-2.sch"?>
 <!--Context: ref/element-citation[@publication-type='data']/pub-id
-Test: assert    @pub-id-type=('accession', 'archive', 'ark', 'doi')
+Test: assert    @pub-id-type=('accession','doi')
 Message: [err-elem-cit-data-13-2]
-        Each pub-id element must have one of these types: accession, archive, ark, assigning-authority or doi. 
-        Reference '' has a <pub-id element with types 
+        Each pub-id element must have a pub-id-type which is either accession or doi. 
+        Reference '' has a <pub-id element with the type 
         ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/elem-citation-data-pub-id/err-elem-cit-data-13-2/pass.xml
+++ b/test/tests/gen/elem-citation-data-pub-id/err-elem-cit-data-13-2/pass.xml
@@ -1,9 +1,9 @@
 <?oxygen SCHSchema="err-elem-cit-data-13-2.sch"?>
 <!--Context: ref/element-citation[@publication-type='data']/pub-id
-Test: assert    @pub-id-type=('accession', 'archive', 'ark', 'doi')
+Test: assert    @pub-id-type=('accession','doi')
 Message: [err-elem-cit-data-13-2]
-        Each pub-id element must have one of these types: accession, archive, ark, assigning-authority or doi. 
-        Reference '' has a <pub-id element with types 
+        Each pub-id element must have a pub-id-type which is either accession or doi. 
+        Reference '' has a <pub-id element with the type 
         ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/fig-specific-tests/final-fig-specific-test-4/fail.xml
+++ b/test/tests/gen/fig-specific-tests/final-fig-specific-test-4/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="final-fig-specific-test-4.sch"?>
 <!--Context: article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]
-Test: report    if ($article-type = ($features-article-types,'correction','retraction')) then () else not(ancestor::article//xref[@rid = $id])
+Test: report    if ($article-type = ($features-article-types,'correction','retraction')) then () else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then () else not(ancestor::article//xref[@rid = $id])
 Message: There is no citation to  Ensure this is added. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">

--- a/test/tests/gen/fig-specific-tests/final-fig-specific-test-4/final-fig-specific-test-4.sch
+++ b/test/tests/gen/fig-specific-tests/final-fig-specific-test-4/final-fig-specific-test-4.sch
@@ -797,7 +797,7 @@
       <let name="lab" value="replace(label[1],'\.','')"/>
       <let name="first-cite" value="ancestor::article/body/descendant::xref[parent::p and not(ancestor::caption) and (@rid = $id)][1]"/>
       <let name="first-cite-parent" value="$first-cite/parent::p"/>
-      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="final-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure this is added.</report>
+      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="final-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure this is added.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/fig-specific-tests/final-fig-specific-test-4/pass.xml
+++ b/test/tests/gen/fig-specific-tests/final-fig-specific-test-4/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="final-fig-specific-test-4.sch"?>
 <!--Context: article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]
-Test: report    if ($article-type = ($features-article-types,'correction','retraction')) then () else not(ancestor::article//xref[@rid = $id])
+Test: report    if ($article-type = ($features-article-types,'correction','retraction')) then () else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then () else not(ancestor::article//xref[@rid = $id])
 Message: There is no citation to  Ensure this is added. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">

--- a/test/tests/gen/fig-specific-tests/pre-fig-specific-test-4/fail.xml
+++ b/test/tests/gen/fig-specific-tests/pre-fig-specific-test-4/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="pre-fig-specific-test-4.sch"?>
 <!--Context: article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]
-Test: report    if ($article-type = ($features-article-types,'correction','retraction')) then () else not(ancestor::article//xref[@rid = $id])
+Test: report    if ($article-type = ($features-article-types,'correction','retraction')) then () else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then () else not(ancestor::article//xref[@rid = $id])
 Message: There is no citation to  Ensure to query the author asking for a citation. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">

--- a/test/tests/gen/fig-specific-tests/pre-fig-specific-test-4/pass.xml
+++ b/test/tests/gen/fig-specific-tests/pre-fig-specific-test-4/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="pre-fig-specific-test-4.sch"?>
 <!--Context: article/body//fig[not(@specific-use='child-fig')][not(ancestor::boxed-text)]
-Test: report    if ($article-type = ($features-article-types,'correction','retraction')) then () else not(ancestor::article//xref[@rid = $id])
+Test: report    if ($article-type = ($features-article-types,'correction','retraction')) then () else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then () else not(ancestor::article//xref[@rid = $id])
 Message: There is no citation to  Ensure to query the author asking for a citation. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">

--- a/test/tests/gen/fig-specific-tests/pre-fig-specific-test-4/pre-fig-specific-test-4.sch
+++ b/test/tests/gen/fig-specific-tests/pre-fig-specific-test-4/pre-fig-specific-test-4.sch
@@ -797,7 +797,7 @@
       <let name="lab" value="replace(label[1],'\.','')"/>
       <let name="first-cite" value="ancestor::article/body/descendant::xref[parent::p and not(ancestor::caption) and (@rid = $id)][1]"/>
       <let name="first-cite-parent" value="$first-cite/parent::p"/>
-      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="pre-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure to query the author asking for a citation.</report>
+      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="pre-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure to query the author asking for a citation.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-1/fail.xml
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-1/fail.xml
@@ -1,0 +1,34 @@
+<?oxygen SCHSchema="pub-id-doi-test-1.sch"?>
+<!--Context: element-citation/pub-id
+Test: report    (@pub-id-type != 'doi') and matches(@xlink:href,'https?://doi.org/\d')
+Message: pub-id has a doi link -  - but it's pub-id-type is  instead of doi. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Keesey</surname>
+          <given-names>IW</given-names>
+        </name>
+        <name>
+          <surname>Grabe</surname>
+          <given-names>V</given-names>
+        </name>
+        <name>
+          <surname>Knaden</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Hansson</surname>
+          <given-names>BS</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Divergent sensory investment mirrors potential speciation via niche partitioning
+        across Drosophila</data-title>
+      <source>EDMOND</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://doi.org/10.17617/3.3v">the open access data repository of the Max Planck
+        Society</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pass.xml
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pass.xml
@@ -1,0 +1,33 @@
+<?oxygen SCHSchema="pub-id-doi-test-1.sch"?>
+<!--Context: element-citation/pub-id
+Test: report    (@pub-id-type != 'doi') and matches(@xlink:href,'https?://doi.org/\d')
+Message: pub-id has a doi link -  - but it's pub-id-type is  instead of doi. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Keesey</surname>
+          <given-names>IW</given-names>
+        </name>
+        <name>
+          <surname>Grabe</surname>
+          <given-names>V</given-names>
+        </name>
+        <name>
+          <surname>Knaden</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Hansson</surname>
+          <given-names>BS</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Divergent sensory investment mirrors potential speciation via niche partitioning
+        across Drosophila</data-title>
+      <source>EDMOND</source>
+      <pub-id assigning-authority="other" pub-id-type="doi" xlink:href="https://doi.org/10.17617/3.3v">10.17617/3.3v</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pub-id-doi-test-1.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pub-id-doi-test-1.sch
@@ -785,17 +785,14 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="element-citation-data-tests">
-    <rule context="ref/element-citation[@publication-type='data']/pub-id" id="elem-citation-data-pub-id">
-      <assert test="@pub-id-type=('accession','doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
-        Each pub-id element must have a pub-id-type which is either accession or doi. 
-        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with the type 
-        '<value-of select="@pub-id-type"/>'.</assert>
+  <pattern id="pub-id-pattern">
+    <rule context="element-citation/pub-id" id="pub-id-tests">
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://doi.org/\d')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::ref/element-citation[@publication-type='data']/pub-id" role="error" id="elem-citation-data-pub-id-xspec-assert">ref/element-citation[@publication-type='data']/pub-id must be present.</assert>
+      <assert test="descendant::element-citation/pub-id" role="error" id="pub-id-tests-xspec-assert">element-citation/pub-id must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-2/fail.xml
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-2/fail.xml
@@ -1,0 +1,34 @@
+<?oxygen SCHSchema="pub-id-doi-test-2.sch"?>
+<!--Context: element-citation/pub-id
+Test: report    matches(@xlink:href,'https?://doi.org/\d') and not(contains(.,substring-after(@xlink:href,'doi.org/')))
+Message: pub id has a doi link -  - but the identifier is not the doi - '', which is incorrect. If the dataset has a doi link, the identifier must be the the doi, which is the string after 'doi.org/' in the link - . -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Keesey</surname>
+          <given-names>IW</given-names>
+        </name>
+        <name>
+          <surname>Grabe</surname>
+          <given-names>V</given-names>
+        </name>
+        <name>
+          <surname>Knaden</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Hansson</surname>
+          <given-names>BS</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Divergent sensory investment mirrors potential speciation via niche partitioning
+        across Drosophila</data-title>
+      <source>EDMOND</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://doi.org/10.17617/3.3v">the open access data repository of the Max Planck
+        Society</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-2/pass.xml
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-2/pass.xml
@@ -1,0 +1,33 @@
+<?oxygen SCHSchema="pub-id-doi-test-2.sch"?>
+<!--Context: element-citation/pub-id
+Test: report    matches(@xlink:href,'https?://doi.org/\d') and not(contains(.,substring-after(@xlink:href,'doi.org/')))
+Message: pub id has a doi link -  - but the identifier is not the doi - '', which is incorrect. If the dataset has a doi link, the identifier must be the the doi, which is the string after 'doi.org/' in the link - . -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Keesey</surname>
+          <given-names>IW</given-names>
+        </name>
+        <name>
+          <surname>Grabe</surname>
+          <given-names>V</given-names>
+        </name>
+        <name>
+          <surname>Knaden</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Hansson</surname>
+          <given-names>BS</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Divergent sensory investment mirrors potential speciation via niche partitioning
+        across Drosophila</data-title>
+      <source>EDMOND</source>
+      <pub-id assigning-authority="other" pub-id-type="doi" xlink:href="https://doi.org/10.17617/3.3v">10.17617/3.3v</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-2/pub-id-doi-test-2.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-2/pub-id-doi-test-2.sch
@@ -785,17 +785,14 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="element-citation-data-tests">
-    <rule context="ref/element-citation[@publication-type='data']/pub-id" id="elem-citation-data-pub-id">
-      <assert test="@pub-id-type=('accession','doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
-        Each pub-id element must have a pub-id-type which is either accession or doi. 
-        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with the type 
-        '<value-of select="@pub-id-type"/>'.</assert>
+  <pattern id="pub-id-pattern">
+    <rule context="element-citation/pub-id" id="pub-id-tests">
+      <report test="matches(@xlink:href,'https?://doi.org/\d') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. If the dataset has a doi link, the identifier must be the the doi, which is the string after 'doi.org/' in the link - <value-of select="substring-after(@xlink:href,'doi.org/')"/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::ref/element-citation[@publication-type='data']/pub-id" role="error" id="elem-citation-data-pub-id-xspec-assert">ref/element-citation[@publication-type='data']/pub-id must be present.</assert>
+      <assert test="descendant::element-citation/pub-id" role="error" id="pub-id-tests-xspec-assert">element-citation/pub-id must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/pub-id-tests/pub-id-test-1/pub-id-test-1.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-test-1/pub-id-test-1.sch
@@ -787,7 +787,7 @@
   </xsl:function>
   <pattern id="pub-id-pattern">
     <rule context="element-citation/pub-id" id="pub-id-tests">
-      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">@xlink:href must start with an http:// or ftp:// protocol. - <value-of select="."/> does not.</report>
+      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">@xlink:href must start with an http:// or ftp:// protocol. - <value-of select="@xlink:href"/> does not.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/pub-id-tests/pub-id-test-4/fail.xml
+++ b/test/tests/gen/pub-id-tests/pub-id-test-4/fail.xml
@@ -1,0 +1,34 @@
+<?oxygen SCHSchema="pub-id-test-4.sch"?>
+<!--Context: element-citation/pub-id
+Test: report    contains(.,' ')
+Message: pub id contains whitespace -  - which is very likely to be incorrect. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Keesey</surname>
+          <given-names>IW</given-names>
+        </name>
+        <name>
+          <surname>Grabe</surname>
+          <given-names>V</given-names>
+        </name>
+        <name>
+          <surname>Knaden</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Hansson</surname>
+          <given-names>BS</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Divergent sensory investment mirrors potential speciation via niche partitioning
+        across Drosophila</data-title>
+      <source>EDMOND</source>
+      <pub-id assigning-authority="other" pub-id-type="accession" xlink:href="https://doi.org/10.17617/3.3v">the open access data repository of the Max Planck
+        Society</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/pub-id-tests/pub-id-test-4/pass.xml
+++ b/test/tests/gen/pub-id-tests/pub-id-test-4/pass.xml
@@ -1,0 +1,33 @@
+<?oxygen SCHSchema="pub-id-test-4.sch"?>
+<!--Context: element-citation/pub-id
+Test: report    contains(.,' ')
+Message: pub id contains whitespace -  - which is very likely to be incorrect. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+      <person-group person-group-type="author">
+        <name>
+          <surname>Keesey</surname>
+          <given-names>IW</given-names>
+        </name>
+        <name>
+          <surname>Grabe</surname>
+          <given-names>V</given-names>
+        </name>
+        <name>
+          <surname>Knaden</surname>
+          <given-names>M</given-names>
+        </name>
+        <name>
+          <surname>Hansson</surname>
+          <given-names>BS</given-names>
+        </name>
+      </person-group>
+      <year iso-8601-date="2020">2020</year>
+      <data-title>Divergent sensory investment mirrors potential speciation via niche partitioning
+        across Drosophila</data-title>
+      <source>EDMOND</source>
+      <pub-id assigning-authority="other" pub-id-type="doi" xlink:href="https://doi.org/10.17617/3.3v">10.17617/3.3v</pub-id>
+    </element-citation>
+  </article>
+</root>

--- a/test/tests/gen/pub-id-tests/pub-id-test-4/pub-id-test-4.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-test-4/pub-id-test-4.sch
@@ -785,17 +785,14 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="element-citation-data-tests">
-    <rule context="ref/element-citation[@publication-type='data']/pub-id" id="elem-citation-data-pub-id">
-      <assert test="@pub-id-type=('accession','doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
-        Each pub-id element must have a pub-id-type which is either accession or doi. 
-        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with the type 
-        '<value-of select="@pub-id-type"/>'.</assert>
+  <pattern id="pub-id-pattern">
+    <rule context="element-citation/pub-id" id="pub-id-tests">
+      <report test="contains(.,' ')" role="warning" id="pub-id-test-4">pub id contains whitespace - <value-of select="."/> - which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::ref/element-citation[@publication-type='data']/pub-id" role="error" id="elem-citation-data-pub-id-xspec-assert">ref/element-citation[@publication-type='data']/pub-id must be present.</assert>
+      <assert test="descendant::element-citation/pub-id" role="error" id="pub-id-tests-xspec-assert">element-citation/pub-id must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/software-ref-tests/ref-software-test-1/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-1/fail.xml
@@ -103,9 +103,23 @@ Message: software ref '' has both a source (Software name) -  - and a publisher-
 
 
 
+
+
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    source and publisher-name
 Message: software ref '' has both a source (Software name) -  - and a publisher-name (Software host) -  - which is incorrect. It should have either one or the other. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-1 -->
+
+
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-1/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-1/pass.xml
@@ -102,9 +102,23 @@ Message: software ref '' has both a source (Software name) -  - and a publisher-
 
 
 
+
+
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    source and publisher-name
 Message: software ref '' has both a source (Software name) -  - and a publisher-name (Software host) -  - which is incorrect. It should have either one or the other. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-1 -->
+
+
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-2/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-2/fail.xml
@@ -102,9 +102,23 @@ Message: software ref '' with the title -  - must contain either one source elem
 
 
 
+
+
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: assert    source or publisher-name
 Message: software ref '' with the title -  - must contain either one source element (Software name) or one publisher-name element (Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-2 -->
+
+
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-2/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-2/pass.xml
@@ -102,9 +102,23 @@ Message: software ref '' with the title -  - must contain either one source elem
 
 
 
+
+
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: assert    source or publisher-name
 Message: software ref '' with the title -  - must contain either one source element (Software name) or one publisher-name element (Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-2 -->
+
+
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-3/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-3/fail.xml
@@ -102,9 +102,23 @@ Message: software ref '' has a publisher-name (Software host) - . Since this is 
 
 
 
+
+
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(publisher-name[1]),'github|gitlab|bitbucket|sourceforge|figshare|^osf$|open science framework|zenodo|matlab')
 Message: software ref '' has a publisher-name (Software host) - . Since this is a software source, it should be captured in a source element. Please move into the Software name field (rather than Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-3 -->
+
+
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-3/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-3/pass.xml
@@ -102,9 +102,23 @@ Message: software ref '' has a publisher-name (Software host) - . Since this is 
 
 
 
+
+
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(publisher-name[1]),'github|gitlab|bitbucket|sourceforge|figshare|^osf$|open science framework|zenodo|matlab')
 Message: software ref '' has a publisher-name (Software host) - . Since this is a software source, it should be captured in a source element. Please move into the Software name field (rather than Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-3 -->
+
+
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-4/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-4/fail.xml
@@ -102,9 +102,23 @@ Message: software ref '' has a source (Software name) - . Since this is a softwa
 
 
 
+
+
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(source[1]),'schr[öo]dinger|r foundation|rstudio ,? inc|mathworks| llc| ltd')
 Message: software ref '' has a source (Software name) - . Since this is a software publisher, it should be captured in a publisher-name element. Please move into the Software host field. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-4 -->
+
+
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-4/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-4/pass.xml
@@ -102,9 +102,23 @@ Message: software ref '' has a source (Software name) - . Since this is a softwa
 
 
 
+
+
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(source[1]),'schr[öo]dinger|r foundation|rstudio ,? inc|mathworks| llc| ltd')
 Message: software ref '' has a source (Software name) - . Since this is a software publisher, it should be captured in a publisher-name element. Please move into the Software host field. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-4 -->
+
+
+
+
+
+
+
 
 
 

--- a/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/fail.xml
+++ b/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/fail.xml
@@ -1,15 +1,15 @@
 <?oxygen SCHSchema="table-fn-label-test-1.sch"?>
-<!--Context: table-wrap-foot//fn/p/*[1]
-Test: report    not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)
-Message: Footnote starts with label which is not in line with house style - . Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1 -->
+<!--Context: table-wrap-foot//fn/p
+Test: report    not(matches(.,'^\s?[*†‡§¶]')) and matches(.,'^\s?[\p{Ps}]?[\da-z][\p{Pe}]?\s+[\p{Lu}\d]')
+Message: Footnote starts with what might be a label which is not in line with house style - . If it is a label, then it should changed to one of the allowed symbols, so that the order of labels in the footnotes follows this sequence *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <table-wrap-foot>
       <fn>
-        <p><sup>1</sup> ‘BP’ indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
+        <p><sup>1</sup> BP indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
       </fn>
       <fn>
-        <p><sup>2</sup> ‘BP’ indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
+        <p><sup>2</sup> BP indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
       </fn>
     </table-wrap-foot>
   </article>

--- a/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/pass.xml
+++ b/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/pass.xml
@@ -1,15 +1,15 @@
 <?oxygen SCHSchema="table-fn-label-test-1.sch"?>
-<!--Context: table-wrap-foot//fn/p/*[1]
-Test: report    not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)
-Message: Footnote starts with label which is not in line with house style - . Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1 -->
+<!--Context: table-wrap-foot//fn/p
+Test: report    not(matches(.,'^\s?[*†‡§¶]')) and matches(.,'^\s?[\p{Ps}]?[\da-z][\p{Pe}]?\s+[\p{Lu}\d]')
+Message: Footnote starts with what might be a label which is not in line with house style - . If it is a label, then it should changed to one of the allowed symbols, so that the order of labels in the footnotes follows this sequence *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <table-wrap-foot>
       <fn>
-        <p><sup>*</sup> ‘BP’ indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
+        <p><sup>*</sup> BP indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
       </fn>
       <fn>
-        <p><sup>†</sup> ‘BP’ indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
+        <p><sup>†</sup> BP indicates the presence of a gene synt<sup>a</sup> ‘BP’ indicates the presence of a gene synteny break. ‘Inactivated’ indicates centromere inactivation resulting from sequence divergence and erosion of AT-richness.</p>
       </fn>
     </table-wrap-foot>
   </article>

--- a/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/table-fn-label-test-1.sch
+++ b/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/table-fn-label-test-1.sch
@@ -786,14 +786,13 @@
     
   </xsl:function>
   <pattern id="content-containers">
-    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests">
-      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
-      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
+    <rule context="table-wrap-foot//fn/p" id="table-fn-label-tests">
+      <report test="not(matches(.,'^\s?[*†‡§¶]')) and matches(.,'^\s?[\p{Ps}]?[\da-z][\p{Pe}]?\s+[\p{Lu}\d]')" role="warning" id="table-fn-label-test-1">Footnote starts with what might be a label which is not in line with house style - <value-of select="."/>. If it is a label, then it should changed to one of the allowed symbols, so that the order of labels in the footnotes follows this sequence *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::table-wrap-foot//fn/p/*[1]" role="error" id="table-fn-label-tests-xspec-assert">table-wrap-foot//fn/p/*[1] must be present.</assert>
+      <assert test="descendant::table-wrap-foot//fn/p" role="error" id="table-fn-label-tests-xspec-assert">table-wrap-foot//fn/p must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -2344,10 +2344,9 @@
     </rule>
   </pattern>
   <pattern id="table-fn-label-tests-pattern">
-    <rule context="table-wrap-foot//fn/p/*[1]" id="table-fn-label-tests"> 
-      <let name="house-labels" value="('*', '†', '‡', '§', '¶','**', '††', '‡‡', '§§', '¶¶','***', '†††', '‡‡‡', '§§§', '¶¶¶','****', '††††', '‡‡‡‡', '§§§§', '¶¶¶¶')"/>
+    <rule context="table-wrap-foot//fn/p" id="table-fn-label-tests"> 
       
-      <report test="not(preceding-sibling::text()) and (name(.)='sup') and not(.=$house-labels)" role="warning" id="table-fn-label-test-1">Footnote starts with label which is not in line with house style - <value-of select="parent::p"/>. Footnote symbols should be in the order: *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
+      <report test="not(matches(.,'^\s?[*†‡§¶]')) and matches(.,'^\s?[\p{Ps}]?[\da-z][\p{Pe}]?\s+[\p{Lu}\d]')" role="warning" id="table-fn-label-test-1">Footnote starts with what might be a label which is not in line with house style - <value-of select="."/>. If it is a label, then it should changed to one of the allowed symbols, so that the order of labels in the footnotes follows this sequence *, †, ‡, §, ¶, **, ††, ‡‡, §§, ¶¶, etc. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/tables#table-fn-label-test-1</report>
     </rule>
   </pattern>
   <pattern id="fn-tests-pattern">
@@ -2606,9 +2605,9 @@
       <report test="if ($article-type = ('correction','retraction')) then ()          else not(                $first-cite-parent/following-sibling::*[1][@id=$id] or                ($first-cite-parent/following-sibling::*[1][local-name()='fig-group'] and $first-cite-parent/following-sibling::*[1]/*[1][@id=$id])                or                (                ($first-cite-parent/following-sibling::*[1]/local-name()=('fig-group','fig','media','table-wrap')) and  ($first-cite-parent/following-sibling::*[2][@id=$id] or                ($first-cite-parent/following-sibling::*[2][local-name()='fig-group'] and $first-cite-parent/following-sibling::*[2]/*[1][@id=$id])))                or                (($first-cite-parent/following-sibling::*[1]/local-name()=('fig-group','fig','media','table-wrap')) and ($first-cite-parent/following-sibling::*[2]/local-name()=('fig-group','fig','media','table-wrap')) and ($first-cite-parent/following-sibling::*[3][@id=$id] or                ($first-cite-parent/following-sibling::*[3][local-name()='fig-group'] and $first-cite-parent/following-sibling::*[3]/*[1][@id=$id])))                or                (($first-cite-parent/following-sibling::*[1]/local-name()=('fig-group','fig','media','table-wrap')) and ($first-cite-parent/following-sibling::*[2]/local-name()=('fig-group','fig','media','table-wrap')) and                ($first-cite-parent/following-sibling::*[3]/local-name()=('fig-group','fig','media','table-wrap')) and ($first-cite-parent/following-sibling::*[4][@id=$id] or ($first-cite-parent/following-sibling::*[4][local-name()='fig-group'] and $first-cite-parent/following-sibling::*[4]/*[1][@id=$id])))                 )" role="warning" id="fig-specific-test-3">
         <value-of select="$lab"/> does not appear directly after a paragraph citing it. Is that correct?</report>
       
-      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="pre-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure to query the author asking for a citation.</report>
+      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="pre-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure to query the author asking for a citation.</report>
       
-      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="final-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure this is added.</report>
+      <report test="if ($article-type = ($features-article-types,'correction','retraction')) then ()         else if (contains($lab,'Chemical') or contains($lab,'Scheme')) then ()         else not(ancestor::article//xref[@rid = $id])" role="warning" id="final-fig-specific-test-4">There is no citation to <value-of select="$lab"/> Ensure this is added.</report>
       
       <report test="if ($article-type = $features-article-types) then (not(ancestor::article//xref[@rid = $id]))         else ()" role="warning" id="feat-fig-specific-test-4">There is no citation to <value-of select="if (label) then label else 'figure.'"/> Is this correct?</report>
       
@@ -4070,9 +4069,9 @@
   <pattern id="elem-citation-data-pub-id-pattern">
     <rule context="ref/element-citation[@publication-type='data']/pub-id" id="elem-citation-data-pub-id">
       
-      <assert test="@pub-id-type=('accession', 'archive', 'ark', 'doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
-        Each pub-id element must have one of these types: accession, archive, ark, assigning-authority or doi. 
-        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with types 
+      <assert test="@pub-id-type=('accession','doi')" role="error" id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
+        Each pub-id element must have a pub-id-type which is either accession or doi. 
+        Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with the type 
         '<value-of select="@pub-id-type"/>'.</assert>
       
       <report test="if (@pub-id-type != 'doi') then not(@xlink:href) else ()" role="error" id="err-elem-cit-data-14-1">[err-elem-cit-data-14-1]
@@ -4991,7 +4990,7 @@
   <pattern id="das-elem-citation-data-pub-id-pattern">
     <rule context="sec[@sec-type='data-availability']//element-citation[@publication-type='data']/pub-id" id="das-elem-citation-data-pub-id">
       
-      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'archive', 'doi'))" role="error" id="das-pub-id-1">Each pub-id element must have an @pub-id-type with one of these types: accession, archive, or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
+      <report test="normalize-space(.)!='' and not(@pub-id-type=('accession', 'doi'))" role="error" id="das-pub-id-1">Each pub-id element must have an @pub-id-type which is either accession or doi. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-1</report>
       
       <report test="@pub-id-type!='doi' and normalize-space(.)!='' and (not(@xlink:href) or (normalize-space(@xlink:href)=''))" role="error" id="das-pub-id-2">Each pub-id element which is not a doi must have an @xlink-href (which is not empty). More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-pub-id-2</report>
       
@@ -5019,13 +5018,19 @@
   <pattern id="pub-id-tests-pattern">
     <rule context="element-citation/pub-id" id="pub-id-tests">
       
-      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">@xlink:href must start with an http:// or ftp:// protocol. - <value-of select="."/> does not.</report>
+      <report test="(@xlink:href) and not(matches(@xlink:href,'^http[s]?://|^ftp://'))" role="error" id="pub-id-test-1">@xlink:href must start with an http:// or ftp:// protocol. - <value-of select="@xlink:href"/> does not.</report>
       
       <report test="(@pub-id-type='doi') and not(matches(.,'^10\.\d{4,9}/[-._;\+()#/:A-Za-z0-9&lt;&gt;\[\]]+$'))" role="error" id="pub-id-test-2">pub-id is tagged as a doi, but it is not one - <value-of select="."/>
       </report>
       
       <report test="(@pub-id-type='pmid') and matches(.,'\D')" role="error" id="pub-id-test-3">pub-id is tagged as a pmid, but it contains a character(s) which is not a digit - <value-of select="."/>
       </report>
+      
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://doi.org/\d')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      
+      <report test="matches(@xlink:href,'https?://doi.org/\d') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. If the dataset has a doi link, the identifier must be the the doi, which is the string after 'doi.org/' in the link - <value-of select="substring-after(@xlink:href,'doi.org/')"/>.</report>
+      
+      <report test="contains(.,' ')" role="warning" id="pub-id-test-4">pub id contains whitespace - <value-of select="."/> - which is very likely to be incorrect.</report>
       
     </rule>
   </pattern>
@@ -6547,7 +6552,7 @@
       
       <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@assigning-authority!='Open Science Framework' or not(@assigning-authority)]" role="warning" id="data-osf-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'https://osf.io' type link, but is not marked with Open Science Framework as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-2</report>
       
-      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
+      <report test="matches(pub-id[1]/@xlink:href,'^http[s]?://osf.io') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-osf-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an OSF 'https://osf.io' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-3</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.17605/OSF') and (source[1]!='Open Science Framework')" role="warning" id="data-osf-test-4">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.17605/OSF' but the database name is not 'Open Science Framework' - <value-of select="source[1]"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-osf-test-4</report>
       
@@ -6623,7 +6628,7 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-neurovault-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'neurovault.org/collections' type link, but is not marked with 'other' as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-2</report>
       
-      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'neurovault.org/collections') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-neurovault-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has a NeuroVault 'neurovault.org/collections' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-neurovault-test-3</report>
       
       <report test="starts-with(pub-id[1][@pub-id-type='doi'],'10.2210') and (source[1]!='Worldwide Protein Data Bank')" role="warning" id="data-wwpdb-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a doi starting with '10.2210' but the database name is not 'Worldwide Protein Data Bank' - <value-of select="source[1]"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-wwpdb-test-1</report>
       
@@ -6647,7 +6652,7 @@
       
       <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and  pub-id[1][@assigning-authority!='other' or not(@assigning-authority)]" role="warning" id="data-encode-test-2">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.encodeproject.org' type link, but is not marked with 'other' as its assigning authority, which must be incorrect. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-2</report>
       
-      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='archive' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an archive type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
+      <report test="contains(pub-id[1]/@xlink:href,'www.encodeproject.org') and pub-id[1][@pub-id-type!='accession' or not(@pub-id-type)]" role="warning" id="data-encode-test-3">Data reference with the title '<value-of select="data-title[1]"/>' has an ENCODE 'www.encodeproject.org' type link, but is not marked as an accession type link. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-encode-test-3</report>
       
       <report test="contains(pub-id[1]/@xlink:href,'www.emdataresource.org') and not(source[1]='EMDataResource')" role="warning" id="data-emdr-test-1">Data reference with the title '<value-of select="data-title[1]"/>' has a 'www.emdataresource.org' type link, but the database name is not 'EMDataResource' - <value-of select="source[1]"/>. Is that correct? More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#data-emdr-test-1</report>
       
@@ -7598,7 +7603,7 @@
       <assert test="descendant::td/*" role="error" id="td-child-tests-xspec-assert">td/* must be present.</assert>
       <assert test="descendant::th/*" role="error" id="th-child-tests-xspec-assert">th/* must be present.</assert>
       <assert test="descendant::th" role="error" id="th-tests-xspec-assert">th must be present.</assert>
-      <assert test="descendant::table-wrap-foot//fn/p/*[1]" role="error" id="table-fn-label-tests-xspec-assert">table-wrap-foot//fn/p/*[1] must be present.</assert>
+      <assert test="descendant::table-wrap-foot//fn/p" role="error" id="table-fn-label-tests-xspec-assert">table-wrap-foot//fn/p must be present.</assert>
       <assert test="descendant::fn[@id][not(@fn-type='other')]" role="error" id="fn-tests-xspec-assert">fn[@id][not(@fn-type='other')] must be present.</assert>
       <assert test="descendant::list-item" role="error" id="list-item-tests-xspec-assert">list-item must be present.</assert>
       <assert test="descendant::media[@mimetype='video'][matches(@id,'^video[0-9]{1,3}$')]" role="error" id="general-video-xspec-assert">media[@mimetype='video'][matches(@id,'^video[0-9]{1,3}$')] must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -9135,6 +9135,36 @@
         <x:expect-report id="pub-id-test-3" role="error"/>
         <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="pub-id-doi-test-1-pass">
+        <x:context href="../tests/gen/pub-id-tests/pub-id-doi-test-1/pass.xml"/>
+        <x:expect-not-report id="pub-id-doi-test-1" role="error"/>
+        <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="pub-id-doi-test-1-fail">
+        <x:context href="../tests/gen/pub-id-tests/pub-id-doi-test-1/fail.xml"/>
+        <x:expect-report id="pub-id-doi-test-1" role="error"/>
+        <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="pub-id-doi-test-2-pass">
+        <x:context href="../tests/gen/pub-id-tests/pub-id-doi-test-2/pass.xml"/>
+        <x:expect-not-report id="pub-id-doi-test-2" role="error"/>
+        <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="pub-id-doi-test-2-fail">
+        <x:context href="../tests/gen/pub-id-tests/pub-id-doi-test-2/fail.xml"/>
+        <x:expect-report id="pub-id-doi-test-2" role="error"/>
+        <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="pub-id-test-4-pass">
+        <x:context href="../tests/gen/pub-id-tests/pub-id-test-4/pass.xml"/>
+        <x:expect-not-report id="pub-id-test-4" role="warning"/>
+        <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="pub-id-test-4-fail">
+        <x:context href="../tests/gen/pub-id-tests/pub-id-test-4/fail.xml"/>
+        <x:expect-report id="pub-id-test-4" role="warning"/>
+        <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="feature-title-tests">
       <x:scenario label="feature-title-test-1-pass">


### PR DESCRIPTION
- Make `table-fn-label-test-1` more sensitive
- Ignore Chemical structures and Schemes in `pre-fig-specific-test-4` and `final-fig-specific-test-4`
- Only allow `accession` or `doi` for `pub-id-type`.
- Conformance for `pub-id` values - `pub-id-doi-test-1`, `pub-id-doi-test-2`, `pub-id-test-4`.