### PR TITLE
improvement: Add more checks

### DIFF
--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1485,6 +1485,14 @@
       
     </rule>
   </pattern>
+  <pattern id="abstract-word-count-pattern">
+    <rule context="front//abstract[not(@abstract-type) and not(sec)]" id="abstract-word-count">
+      <let name="p-words" value="string-join(child::p[not(starts-with(.,'DOI:') or starts-with(.,'Editorial note:'))],' ')"/>
+	    <let name="count" value="count(tokenize(normalize-space(replace($p-words,'\p{P}','')),' '))"/>
+	     
+      <report test="($count gt 150)" role="warning" id="abstract-word-count-restriction">The abstract contains <value-of select="$count"/> words, when the limit is 150. Please either ensure that the abstract is made up of 150 or fewer words, or add an author query asking the authors to do so.</report>
+	   </rule>
+  </pattern>
   <pattern id="aff-tests-pattern">
     <rule context="article-meta/contrib-group/aff" id="aff-tests">
       
@@ -1880,7 +1888,7 @@
       
       <assert test="count(child::fig[not(@specific-use='child-fig')]) = 1" role="error" id="fig-group-test-1">fig-group must have one and only one main figure.</assert>
       
-      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::supplementary-material) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">fig-group does not contain a figure supplement, figure-level course data or code file, or a figure-level video, which must be incorrect.</report>
+      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">fig-group does not contain a figure supplement or a figure-level video, which must be incorrect.</report>
       
     </rule>
   </pattern>
@@ -1962,6 +1970,8 @@
         <name/> must have an @xlink:href which contains a file reference.</assert>
       
       <report test="preceding::graphic/@xlink:href = $link" role="error" id="graphic-test-6">Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
+      
+      <report test="contains($link,'&amp;')" role="error" id="graphic-test-8">Image file-name for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> contains an ampersand - <value-of select="tokenize($link,'/')[last()]"/>. Please rename the file so that this ampersand is removed.</report>
     </rule>
   </pattern>
   <pattern id="media-tests-pattern">
@@ -1989,6 +1999,8 @@
       <report test="matches(lower-case(@xlink:href),'\.xml$|\.html$|\.json$')" role="error" id="media-test-9">media points to an xml, html or json file. This cannot be handled by Kriya currently. Please download the file, place it in a zip and replace the file with this zip (otherwise the file will be erroenously overwritten before publication).</report>
       
       <report test="preceding::media/@xlink:href = $link" role="error" id="media-test-10">Media file for <value-of select="if (@mimetype='video') then replace(label,'\.','') else replace(parent::*/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="if (preceding::media[@xlink:href=$link][1]/@mimetype='video') then replace(preceding::media[@xlink:href=$link][1]/label,'\.','')           else replace(preceding::media[@xlink:href=$link][1]/parent::*/label,'\.','')"/>.</report>
+      
+      <report test="contains($link,'&amp;')" role="error" id="media-test-11">Media filename for <value-of select="if (@mimetype='video') then replace(label,'\.','') else replace(parent::*/label,'\.','')"/> contains an ampersand - <value-of select="tokenize($link,'/')[last()]"/>. Please rename the file so that this ampersand is removed.</report>
     </rule>
   </pattern>
   <pattern id="video-test-pattern">
@@ -6392,6 +6404,8 @@
       <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|medrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct? More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#not-rxiv-test</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test</report>
+      
+      <report test="matches($lc,'biorxiv') and not(starts-with(parent::element-citation/pub-id[@pub-id-type='doi'][1],'10.1101/'))" role="error" id="biorxiv-test-2">ref '<value-of select="ancestor::ref/@id"/>' is captured as a <value-of select="."/> preprint, but it does not have a doi starting with the bioRxiv prefix, '10.1101/'. <value-of select="if (parent::element-citation/pub-id[@pub-id-type='doi']) then concat('The doi does not point to bioRxiv - https://doi.org/',parent::element-citation/pub-id[@pub-id-type='doi'][1]) else 'The doi is missing'"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test-2</report>
       
       <report test="matches($lc,'^arxiv$') and not(. = 'arXiv')" role="error" id="arxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'arXiv'. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#arxiv-test</report>
       

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1454,6 +1454,14 @@
       
     </rule>
   </pattern>
+  <pattern id="abstract-word-count-pattern">
+    <rule context="front//abstract[not(@abstract-type) and not(sec)]" id="abstract-word-count">
+      <let name="p-words" value="string-join(child::p[not(starts-with(.,'DOI:') or starts-with(.,'Editorial note:'))],' ')"/>
+	    <let name="count" value="count(tokenize(normalize-space(replace($p-words,'\p{P}','')),' '))"/>
+	     
+      <report test="($count gt 150)" role="warning" id="abstract-word-count-restriction">[abstract-word-count-restriction] The abstract contains <value-of select="$count"/> words, when the limit is 150. Please either ensure that the abstract is made up of 150 or fewer words, or add an author query asking the authors to do so.</report>
+	   </rule>
+  </pattern>
   <pattern id="aff-tests-pattern">
     <rule context="article-meta/contrib-group/aff" id="aff-tests">
       
@@ -1835,7 +1843,7 @@
       
       <assert test="count(child::fig[not(@specific-use='child-fig')]) = 1" role="error" id="fig-group-test-1">[fig-group-test-1] fig-group must have one and only one main figure.</assert>
       
-      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::supplementary-material) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">[fig-group-test-2] fig-group does not contain a figure supplement, figure-level course data or code file, or a figure-level video, which must be incorrect.</report>
+      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">[fig-group-test-2] fig-group does not contain a figure supplement or a figure-level video, which must be incorrect.</report>
       
     </rule>
   </pattern>
@@ -1908,6 +1916,8 @@
       <assert test="matches(@xlink:href,'\.[\p{L}\p{N}]{1,6}$')" role="error" id="graphic-test-5">[graphic-test-5] <name/> must have an @xlink:href which contains a file reference.</assert>
       
       <report test="preceding::graphic/@xlink:href = $link" role="error" id="graphic-test-6">[graphic-test-6] Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
+      
+      <report test="contains($link,'&amp;')" role="error" id="graphic-test-8">[graphic-test-8] Image file-name for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> contains an ampersand - <value-of select="tokenize($link,'/')[last()]"/>. Please rename the file so that this ampersand is removed.</report>
     </rule>
   </pattern>
   <pattern id="media-tests-pattern">
@@ -1934,6 +1944,8 @@
       <report test="matches(lower-case(@xlink:href),'\.xml$|\.html$|\.json$')" role="error" id="media-test-9">[media-test-9] media points to an xml, html or json file. This cannot be handled by Kriya currently. Please download the file, place it in a zip and replace the file with this zip (otherwise the file will be erroenously overwritten before publication).</report>
       
       <report test="preceding::media/@xlink:href = $link" role="error" id="media-test-10">[media-test-10] Media file for <value-of select="if (@mimetype='video') then replace(label,'\.','') else replace(parent::*/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="if (preceding::media[@xlink:href=$link][1]/@mimetype='video') then replace(preceding::media[@xlink:href=$link][1]/label,'\.','')           else replace(preceding::media[@xlink:href=$link][1]/parent::*/label,'\.','')"/>.</report>
+      
+      <report test="contains($link,'&amp;')" role="error" id="media-test-11">[media-test-11] Media filename for <value-of select="if (@mimetype='video') then replace(label,'\.','') else replace(parent::*/label,'\.','')"/> contains an ampersand - <value-of select="tokenize($link,'/')[last()]"/>. Please rename the file so that this ampersand is removed.</report>
     </rule>
   </pattern>
   <pattern id="video-test-pattern">
@@ -6081,6 +6093,8 @@
       <assert test="matches($lc,'biorxiv|arxiv|chemrxiv|medrxiv|peerj preprints|psyarxiv|paleorxiv|preprints')" role="warning" id="not-rxiv-test">[not-rxiv-test] ref '<value-of select="ancestor::ref/@id"/>' is tagged as a preprint, but has a source <value-of select="."/>, which doesn't look like a preprint. Is it correct? More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#not-rxiv-test</assert>
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">[biorxiv-test] ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test</report>
+      
+      <report test="matches($lc,'biorxiv') and not(starts-with(parent::element-citation/pub-id[@pub-id-type='doi'][1],'10.1101/'))" role="error" id="biorxiv-test-2">[biorxiv-test-2] ref '<value-of select="ancestor::ref/@id"/>' is captured as a <value-of select="."/> preprint, but it does not have a doi starting with the bioRxiv prefix, '10.1101/'. <value-of select="if (parent::element-citation/pub-id[@pub-id-type='doi']) then concat('The doi does not point to bioRxiv - https://doi.org/',parent::element-citation/pub-id[@pub-id-type='doi'][1]) else 'The doi is missing'"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test-2</report>
       
       <report test="matches($lc,'^arxiv$') and not(. = 'arXiv')" role="error" id="arxiv-test">[arxiv-test] ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'arXiv'. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#arxiv-test</report>
       

--- a/test/tests/gen/abstract-word-count/abstract-word-count-restriction/abstract-word-count-restriction.sch
+++ b/test/tests/gen/abstract-word-count/abstract-word-count-restriction/abstract-word-count-restriction.sch
@@ -785,14 +785,16 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="content-containers">
-    <rule context="fig-group" id="fig-group-tests">
-      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">fig-group does not contain a figure supplement or a figure-level video, which must be incorrect.</report>
+  <pattern id="article-metadata">
+    <rule context="front//abstract[not(@abstract-type) and not(sec)]" id="abstract-word-count">
+      <let name="p-words" value="string-join(child::p[not(starts-with(.,'DOI:') or starts-with(.,'Editorial note:'))],' ')"/>
+      <let name="count" value="count(tokenize(normalize-space(replace($p-words,'\p{P}','')),' '))"/>
+      <report test="($count gt 150)" role="warning" id="abstract-word-count-restriction">The abstract contains <value-of select="$count"/> words, when the limit is 150. Please either ensure that the abstract is made up of 150 or fewer words, or add an author query asking the authors to do so.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::fig-group" role="error" id="fig-group-tests-xspec-assert">fig-group must be present.</assert>
+      <assert test="descendant::front//abstract[not(@abstract-type) and not(sec)]" role="error" id="abstract-word-count-xspec-assert">front//abstract[not(@abstract-type) and not(sec)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/abstract-word-count/abstract-word-count-restriction/fail.xml
+++ b/test/tests/gen/abstract-word-count/abstract-word-count-restriction/fail.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="abstract-word-count-restriction.sch"?>
+<!--Context: front//abstract[not(@abstract-type) and not(sec)]
+Test: report    ($count gt 150)
+Message: The abstract contains  words, when the limit is 150. Please either ensure that the abstract is made up of 150 or fewer words, or add an author query asking the authors to do so. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+      <abstract>
+        <p>erat vel vitae scelerisque volutpat ullamcorper dis nec morbi viverra voluptatum posuere phasellus felis donec sed conubia pharetra fames ullamcorper pellentesque rutrum nec suspendisse donec id mi malesuada quis vulputate mi integer vivamus a dolor distinctio hendrerit ut suspendisse mi lacus at leo lacus nunc sociis ut quis aliquet placerat vel magnis vitae luctus sed praesent commodo eget luctus integer suspendisse eros lorem quam vivamus fusce erat hendrerit mauris ornare sed ut lacinia suspendisse nulla sem tincidunt nunc consequat morbi in nibh magna dui nam luctus sit eget inceptos mi tincidunt omnis a adipiscing et ac posuere class nec turpis lacus vivamus metus tellus purus proin donec nam vel amet posuere diamlorem vitae beatae sed tortor laoreet purus in pretium proin auctor diam volutpat pulvinar in nec cras mattis ipsum volutpat blandit ac nullam sagittis magna inceptos purus vitae nisl sed pretium magna dolor eget nibh integer eros vel in iaculis.</p>
+        <p><bold>Editorial note:</bold> This article has been through an editorial process in which the authors decide how to respond to the issues raised during peer review. The Reviewing Editor's assessment is that all the issues have been addressed (<xref ref-type="decision-letter" rid="SA1">see decision letter</xref>).</p>
+      </abstract>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/abstract-word-count/abstract-word-count-restriction/pass.xml
+++ b/test/tests/gen/abstract-word-count/abstract-word-count-restriction/pass.xml
@@ -1,0 +1,14 @@
+<?oxygen SCHSchema="abstract-word-count-restriction.sch"?>
+<!--Context: front//abstract[not(@abstract-type) and not(sec)]
+Test: report    ($count gt 150)
+Message: The abstract contains  words, when the limit is 150. Please either ensure that the abstract is made up of 150 or fewer words, or add an author query asking the authors to do so. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <front>
+    <abstract>
+      <p>erat vel vitae scelerisque volutpat ullamcorper dis nec morbi viverra voluptatum posuere phasellus felis donec sed conubia pharetra fames ullamcorper pellentesque rutrum nec suspendisse donec id mi malesuada quis vulputate mi integer vivamus a dolor distinctio hendrerit ut suspendisse mi lacus at leo lacus nunc sociis ut quis aliquet placerat vel magnis vitae luctus sed praesent commodo eget luctus integer suspendisse eros lorem quam vivamus fusce erat hendrerit mauris ornare sed ut lacinia suspendisse nulla sem tincidunt nunc consequat morbi in nibh magna dui nam luctus sit eget inceptos mi tincidunt omnis a adipiscing et ac posuere class nec turpis lacus vivamus metus tellus purus proin donec nam vel amet posuere diamlorem vitae beatae sed tortor laoreet purus in pretium proin auctor diam volutpat pulvinar in nec cras mattis ipsum volutpat blandit ac nullam sagittis magna inceptos purus vitae nisl sed pretium magna dolor eget nibh integer eros vel in.</p>
+      <p><bold>Editorial note:</bold> This article has been through an editorial process in which the authors decide how to respond to the issues raised during peer review. The Reviewing Editor's assessment is that all the issues have been addressed (<xref ref-type="decision-letter" rid="SA1">see decision letter</xref>).</p>
+    </abstract>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/fig-group-tests/fig-group-test-2/fail.xml
+++ b/test/tests/gen/fig-group-tests/fig-group-test-2/fail.xml
@@ -1,11 +1,18 @@
 <?oxygen SCHSchema="fig-group-test-2.sch"?>
 <!--Context: fig-group
-Test: report    not(child::fig[@specific-use='child-fig']) and not(descendant::supplementary-material) and not(descendant::media[@mimetype='video'])
-Message: fig-group does not contain a figure supplement, figure-level course data or code file, or a figure-level video, which must be incorrect. -->
+Test: report    not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])
+Message: fig-group does not contain a figure supplement or a figure-level video, which must be incorrect. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <fig-group>
       <fig/>
+    </fig-group>
+    <fig-group>
+      <fig>
+        <caption>
+          <supplementary-material/>
+        </caption>
+      </fig>
     </fig-group>
   </article>
 </root>

--- a/test/tests/gen/fig-group-tests/fig-group-test-2/pass.xml
+++ b/test/tests/gen/fig-group-tests/fig-group-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="fig-group-test-2.sch"?>
 <!--Context: fig-group
-Test: report    not(child::fig[@specific-use='child-fig']) and not(descendant::supplementary-material) and not(descendant::media[@mimetype='video'])
-Message: fig-group does not contain a figure supplement, figure-level course data or code file, or a figure-level video, which must be incorrect. -->
+Test: report    not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])
+Message: fig-group does not contain a figure supplement or a figure-level video, which must be incorrect. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <fig-group>
@@ -14,6 +14,8 @@ Message: fig-group does not contain a figure supplement, figure-level course dat
           <supplementary-material/>
         </caption>
       </fig>
+      <fig specific-use="child-fig"/>
+      <media mimetype="video"/>
     </fig-group>
     <fig-group>
       <fig/>

--- a/test/tests/gen/graphic-tests/graphic-test-8/fail.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-8/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="graphic-test-8.sch"?>
+<!--Context: graphic|inline-graphic
+Test: report    contains($link,'&')
+Message: Image file-name for  contains an ampersand - . Please rename the file so that this ampersand is removed. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <graphic mime-subtype="tif" mimetype="image" xlink:href="Figure4FGH&amp;I.tiff"/>
+  </article>
+</root>

--- a/test/tests/gen/graphic-tests/graphic-test-8/graphic-test-8.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-8/graphic-test-8.sch
@@ -786,13 +786,15 @@
     
   </xsl:function>
   <pattern id="content-containers">
-    <rule context="fig-group" id="fig-group-tests">
-      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">fig-group does not contain a figure supplement or a figure-level video, which must be incorrect.</report>
+    <rule context="graphic|inline-graphic" id="graphic-tests">
+      <let name="link" value="@xlink:href"/>
+      <let name="file" value="lower-case($link)"/>
+      <report test="contains($link,'&amp;')" role="error" id="graphic-test-8">Image file-name for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> contains an ampersand - <value-of select="tokenize($link,'/')[last()]"/>. Please rename the file so that this ampersand is removed.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::fig-group" role="error" id="fig-group-tests-xspec-assert">fig-group must be present.</assert>
+      <assert test="descendant::graphic or descendant::inline-graphic" role="error" id="graphic-tests-xspec-assert">graphic|inline-graphic must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/graphic-tests/graphic-test-8/pass.xml
+++ b/test/tests/gen/graphic-tests/graphic-test-8/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="graphic-test-8.sch"?>
+<!--Context: graphic|inline-graphic
+Test: report    contains($link,'&')
+Message: Image file-name for  contains an ampersand - . Please rename the file so that this ampersand is removed. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <graphic mime-subtype="tif" mimetype="image" xlink:href="Figure4FGH-I.tiff"/>
+  </article>
+</root>

--- a/test/tests/gen/media-tests/media-test-11/fail.xml
+++ b/test/tests/gen/media-tests/media-test-11/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="media-test-11.sch"?>
+<!--Context: media
+Test: report    contains($link,'&')
+Message: Media filename for  contains an ampersand - . Please rename the file so that this ampersand is removed. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <media mime-subtype="xlsx" mimetype="application" xlink:href="sourcedataFigure4FGH&amp;I.xlsx"/>
+  </article>
+</root>

--- a/test/tests/gen/media-tests/media-test-11/media-test-11.sch
+++ b/test/tests/gen/media-tests/media-test-11/media-test-11.sch
@@ -786,13 +786,15 @@
     
   </xsl:function>
   <pattern id="content-containers">
-    <rule context="fig-group" id="fig-group-tests">
-      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">fig-group does not contain a figure supplement or a figure-level video, which must be incorrect.</report>
+    <rule context="media" id="media-tests">
+      <let name="file" value="@mime-subtype"/>
+      <let name="link" value="@xlink:href"/>
+      <report test="contains($link,'&amp;')" role="error" id="media-test-11">Media filename for <value-of select="if (@mimetype='video') then replace(label,'\.','') else replace(parent::*/label,'\.','')"/> contains an ampersand - <value-of select="tokenize($link,'/')[last()]"/>. Please rename the file so that this ampersand is removed.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::fig-group" role="error" id="fig-group-tests-xspec-assert">fig-group must be present.</assert>
+      <assert test="descendant::media" role="error" id="media-tests-xspec-assert">media must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/media-tests/media-test-11/pass.xml
+++ b/test/tests/gen/media-tests/media-test-11/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="media-test-11.sch"?>
+<!--Context: media
+Test: report    contains($link,'&')
+Message: Media filename for  contains an ampersand - . Please rename the file so that this ampersand is removed. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <media mime-subtype="xlsx" mimetype="application" xlink:href="sourcedataFigure4FG-I.xlsx"/>
+  </article>
+</root>

--- a/test/tests/gen/preprint-title-tests/biorxiv-test-2/biorxiv-test-2.sch
+++ b/test/tests/gen/preprint-title-tests/biorxiv-test-2/biorxiv-test-2.sch
@@ -785,14 +785,15 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="content-containers">
-    <rule context="fig-group" id="fig-group-tests">
-      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">fig-group does not contain a figure supplement or a figure-level video, which must be incorrect.</report>
+  <pattern id="house-style">
+    <rule context="element-citation[@publication-type='preprint']/source" id="preprint-title-tests">
+      <let name="lc" value="lower-case(.)"/>
+      <report test="matches($lc,'biorxiv') and not(starts-with(parent::element-citation/pub-id[@pub-id-type='doi'][1],'10.1101/'))" role="error" id="biorxiv-test-2">ref '<value-of select="ancestor::ref/@id"/>' is captured as a <value-of select="."/> preprint, but it does not have a doi starting with the bioRxiv prefix, '10.1101/'. <value-of select="if (parent::element-citation/pub-id[@pub-id-type='doi']) then concat('The doi does not point to bioRxiv - https://doi.org/',parent::element-citation/pub-id[@pub-id-type='doi'][1]) else 'The doi is missing'"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test-2</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::fig-group" role="error" id="fig-group-tests-xspec-assert">fig-group must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='preprint']/source" role="error" id="preprint-title-tests-xspec-assert">element-citation[@publication-type='preprint']/source must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/preprint-title-tests/biorxiv-test-2/fail.xml
+++ b/test/tests/gen/preprint-title-tests/biorxiv-test-2/fail.xml
@@ -1,0 +1,51 @@
+<?oxygen SCHSchema="biorxiv-test-2.sch"?>
+<!--Context: element-citation[@publication-type='preprint']/source
+Test: report    matches($lc,'biorxiv') and not(starts-with(parent::element-citation/pub-id[@pub-id-type='doi'][1],'10.1101/'))
+Message: ref '' is captured as a  preprint, but it does not have a doi starting with the bioRxiv prefix, '10.1101/'. . More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test-2 -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref id="bib22">
+      <element-citation publication-type="preprint">
+        <person-group person-group-type="author">
+          <name>
+            <surname>Rambaut</surname>
+            <given-names>A</given-names>
+          </name>
+          <name>
+            <surname>Holmes</surname>
+            <given-names>EC</given-names>
+          </name>
+          <name>
+            <surname>Hill</surname>
+            <given-names>V</given-names>
+          </name>
+        </person-group>
+        <year iso-8601-date="2020">2020</year>
+        <article-title>A dynamic nomenclature proposal for SARS-CoV-2 to assist genomic epidemiology</article-title>
+        <source>bioRxiv</source>
+        <pub-id pub-id-type="doi">10.1038/s41467-019-12002-1</pub-id>
+      </element-citation>
+    </ref>
+    <ref id="bib22">
+      <element-citation publication-type="preprint">
+        <person-group person-group-type="author">
+          <name>
+            <surname>Rambaut</surname>
+            <given-names>A</given-names>
+          </name>
+          <name>
+            <surname>Holmes</surname>
+            <given-names>EC</given-names>
+          </name>
+          <name>
+            <surname>Hill</surname>
+            <given-names>V</given-names>
+          </name>
+        </person-group>
+        <year iso-8601-date="2020">2020</year>
+        <article-title>A dynamic nomenclature proposal for SARS-CoV-2 to assist genomic epidemiology</article-title>
+        <source>bioRxiv</source>
+      </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/preprint-title-tests/biorxiv-test-2/pass.xml
+++ b/test/tests/gen/preprint-title-tests/biorxiv-test-2/pass.xml
@@ -1,0 +1,30 @@
+<?oxygen SCHSchema="biorxiv-test-2.sch"?>
+<!--Context: element-citation[@publication-type='preprint']/source
+Test: report    matches($lc,'biorxiv') and not(starts-with(parent::element-citation/pub-id[@pub-id-type='doi'][1],'10.1101/'))
+Message: ref '' is captured as a  preprint, but it does not have a doi starting with the bioRxiv prefix, '10.1101/'. . More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test-2 -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref id="bib22">
+      <element-citation publication-type="preprint">
+        <person-group person-group-type="author">
+          <name>
+            <surname>Rambaut</surname>
+            <given-names>A</given-names>
+          </name>
+          <name>
+            <surname>Holmes</surname>
+            <given-names>EC</given-names>
+          </name>
+          <name>
+            <surname>Hill</surname>
+            <given-names>V</given-names>
+          </name>
+        </person-group>
+        <year iso-8601-date="2020">2020</year>
+        <article-title>A dynamic nomenclature proposal for SARS-CoV-2 to assist genomic epidemiology</article-title>
+        <source>bioRxiv</source>
+        <pub-id pub-id-type="doi">10.1101/2020.04.17.046086</pub-id>
+      </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/software-ref-tests/ref-software-test-1/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-1/fail.xml
@@ -118,9 +118,19 @@ Message: software ref '' has both a source (Software name) -  - and a publisher-
 
 
 
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    source and publisher-name
 Message: software ref '' has both a source (Software name) -  - and a publisher-name (Software host) -  - which is incorrect. It should have either one or the other. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-1 -->
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-1/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-1/pass.xml
@@ -117,9 +117,19 @@ Message: software ref '' has both a source (Software name) -  - and a publisher-
 
 
 
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    source and publisher-name
 Message: software ref '' has both a source (Software name) -  - and a publisher-name (Software host) -  - which is incorrect. It should have either one or the other. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-1 -->
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-2/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-2/fail.xml
@@ -117,9 +117,19 @@ Message: software ref '' with the title -  - must contain either one source elem
 
 
 
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: assert    source or publisher-name
 Message: software ref '' with the title -  - must contain either one source element (Software name) or one publisher-name element (Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-2 -->
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-2/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-2/pass.xml
@@ -117,9 +117,19 @@ Message: software ref '' with the title -  - must contain either one source elem
 
 
 
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: assert    source or publisher-name
 Message: software ref '' with the title -  - must contain either one source element (Software name) or one publisher-name element (Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-2 -->
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-3/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-3/fail.xml
@@ -117,9 +117,19 @@ Message: software ref '' has a publisher-name (Software host) - . Since this is 
 
 
 
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(publisher-name[1]),'github|gitlab|bitbucket|sourceforge|figshare|^osf$|open science framework|zenodo|matlab')
 Message: software ref '' has a publisher-name (Software host) - . Since this is a software source, it should be captured in a source element. Please move into the Software name field (rather than Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-3 -->
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-3/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-3/pass.xml
@@ -117,9 +117,19 @@ Message: software ref '' has a publisher-name (Software host) - . Since this is 
 
 
 
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(publisher-name[1]),'github|gitlab|bitbucket|sourceforge|figshare|^osf$|open science framework|zenodo|matlab')
 Message: software ref '' has a publisher-name (Software host) - . Since this is a software source, it should be captured in a source element. Please move into the Software name field (rather than Software host). More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-3 -->
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-4/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-4/fail.xml
@@ -117,9 +117,19 @@ Message: software ref '' has a source (Software name) - . Since this is a softwa
 
 
 
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(source[1]),'schr[öo]dinger|r foundation|rstudio ,? inc|mathworks| llc| ltd')
 Message: software ref '' has a source (Software name) - . Since this is a software publisher, it should be captured in a publisher-name element. Please move into the Software host field. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-4 -->
+
+
+
+
+
 
 
 

--- a/test/tests/gen/software-ref-tests/ref-software-test-4/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-4/pass.xml
@@ -117,9 +117,19 @@ Message: software ref '' has a source (Software name) - . Since this is a softwa
 
 
 
+
+
+
+
+
 <!--Context: element-citation[@publication-type='software']
 Test: report    matches(lower-case(source[1]),'schr[öo]dinger|r foundation|rstudio ,? inc|mathworks| llc| ltd')
 Message: software ref '' has a source (Software name) - . Since this is a software publisher, it should be captured in a publisher-name element. Please move into the Software host field. More information here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#ref-software-test-4 -->
+
+
+
+
+
 
 
 

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1480,6 +1480,14 @@
       
     </rule>
   </pattern>
+  <pattern id="abstract-word-count-pattern">
+    <rule context="front//abstract[not(@abstract-type) and not(sec)]" id="abstract-word-count">
+      <let name="p-words" value="string-join(child::p[not(starts-with(.,'DOI:') or starts-with(.,'Editorial note:'))],' ')"/>
+	    <let name="count" value="count(tokenize(normalize-space(replace($p-words,'\p{P}','')),' '))"/>
+	     
+      <report test="($count gt 150)" role="warning" id="abstract-word-count-restriction">The abstract contains <value-of select="$count"/> words, when the limit is 150. Please either ensure that the abstract is made up of 150 or fewer words, or add an author query asking the authors to do so.</report>
+	   </rule>
+  </pattern>
   <pattern id="aff-tests-pattern">
     <rule context="article-meta/contrib-group/aff" id="aff-tests">
       
@@ -1875,7 +1883,7 @@
       
       <assert test="count(child::fig[not(@specific-use='child-fig')]) = 1" role="error" id="fig-group-test-1">fig-group must have one and only one main figure.</assert>
       
-      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::supplementary-material) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">fig-group does not contain a figure supplement, figure-level course data or code file, or a figure-level video, which must be incorrect.</report>
+      <report test="not(child::fig[@specific-use='child-fig']) and not(descendant::media[@mimetype='video'])" role="error" id="fig-group-test-2">fig-group does not contain a figure supplement or a figure-level video, which must be incorrect.</report>
       
     </rule>
   </pattern>
@@ -1960,6 +1968,8 @@
         <name/> must have an @xlink:href which contains a file reference.</assert>
       
       <report test="preceding::graphic/@xlink:href = $link" role="error" id="graphic-test-6">Image file for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="replace(preceding::graphic[@xlink:href=$link][1]/parent::fig/label,'\.','')"/>.</report>
+      
+      <report test="contains($link,'&amp;')" role="error" id="graphic-test-8">Image file-name for <value-of select="if (name()='inline-graphic') then 'inline-graphic' else replace(parent::fig/label,'\.','')"/> contains an ampersand - <value-of select="tokenize($link,'/')[last()]"/>. Please rename the file so that this ampersand is removed.</report>
     </rule>
   </pattern>
   <pattern id="media-tests-pattern">
@@ -1987,6 +1997,8 @@
       <report test="matches(lower-case(@xlink:href),'\.xml$|\.html$|\.json$')" role="error" id="media-test-9">media points to an xml, html or json file. This cannot be handled by Kriya currently. Please download the file, place it in a zip and replace the file with this zip (otherwise the file will be erroenously overwritten before publication).</report>
       
       <report test="preceding::media/@xlink:href = $link" role="error" id="media-test-10">Media file for <value-of select="if (@mimetype='video') then replace(label,'\.','') else replace(parent::*/label,'\.','')"/> (<value-of select="$link"/>) is the same as the one used for <value-of select="if (preceding::media[@xlink:href=$link][1]/@mimetype='video') then replace(preceding::media[@xlink:href=$link][1]/label,'\.','')           else replace(preceding::media[@xlink:href=$link][1]/parent::*/label,'\.','')"/>.</report>
+      
+      <report test="contains($link,'&amp;')" role="error" id="media-test-11">Media filename for <value-of select="if (@mimetype='video') then replace(label,'\.','') else replace(parent::*/label,'\.','')"/> contains an ampersand - <value-of select="tokenize($link,'/')[last()]"/>. Please rename the file so that this ampersand is removed.</report>
     </rule>
   </pattern>
   <pattern id="video-test-pattern">
@@ -6393,6 +6405,8 @@
       
       <report test="matches($lc,'biorxiv') and not(. = 'bioRxiv')" role="error" id="biorxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'bioRxiv'. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test</report>
       
+      <report test="matches($lc,'biorxiv') and not(starts-with(parent::element-citation/pub-id[@pub-id-type='doi'][1],'10.1101/'))" role="error" id="biorxiv-test-2">ref '<value-of select="ancestor::ref/@id"/>' is captured as a <value-of select="."/> preprint, but it does not have a doi starting with the bioRxiv prefix, '10.1101/'. <value-of select="if (parent::element-citation/pub-id[@pub-id-type='doi']) then concat('The doi does not point to bioRxiv - https://doi.org/',parent::element-citation/pub-id[@pub-id-type='doi'][1]) else 'The doi is missing'"/>. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#biorxiv-test-2</report>
+      
       <report test="matches($lc,'^arxiv$') and not(. = 'arXiv')" role="error" id="arxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'arXiv'. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#arxiv-test</report>
       
       <report test="matches($lc,'chemrxiv') and not(. = 'ChemRxiv')" role="error" id="chemrxiv-test">ref '<value-of select="ancestor::ref/@id"/>' has a source <value-of select="."/>, which is not the correct proprietary capitalisation - 'ChemRxiv'. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/preprint-references#chemrxiv-test</report>
@@ -7539,6 +7553,7 @@
       <assert test="descendant::front//abstract/*" role="error" id="abstract-children-tests-xspec-assert">front//abstract/* must be present.</assert>
       <assert test="descendant::abstract[not(@abstract-type)]/sec" role="error" id="abstract-sec-titles-xspec-assert">abstract[not(@abstract-type)]/sec must be present.</assert>
       <assert test="descendant::abstract[not(@abstract-type) and sec]//related-object" role="error" id="clintrial-related-object-xspec-assert">abstract[not(@abstract-type) and sec]//related-object must be present.</assert>
+      <assert test="descendant::front//abstract[not(@abstract-type) and not(sec)]" role="error" id="abstract-word-count-xspec-assert">front//abstract[not(@abstract-type) and not(sec)] must be present.</assert>
       <assert test="descendant::article-meta/contrib-group/aff" role="error" id="aff-tests-xspec-assert">article-meta/contrib-group/aff must be present.</assert>
       <assert test="descendant::article-meta/contrib-group[not(@*)]/aff" role="error" id="author-aff-tests-xspec-assert">article-meta/contrib-group[not(@*)]/aff must be present.</assert>
       <assert test="descendant::aff" role="error" id="gen-aff-tests-xspec-assert">aff must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -1850,6 +1850,18 @@
         <x:expect-not-assert id="clintrial-related-object-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="abstract-word-count">
+      <x:scenario label="abstract-word-count-restriction-pass">
+        <x:context href="../tests/gen/abstract-word-count/abstract-word-count-restriction/pass.xml"/>
+        <x:expect-not-report id="abstract-word-count-restriction" role="warning"/>
+        <x:expect-not-assert id="abstract-word-count-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="abstract-word-count-restriction-fail">
+        <x:context href="../tests/gen/abstract-word-count/abstract-word-count-restriction/fail.xml"/>
+        <x:expect-report id="abstract-word-count-restriction" role="warning"/>
+        <x:expect-not-assert id="abstract-word-count-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
     <x:scenario label="aff-tests">
       <x:scenario label="aff-test-1-pass">
         <x:context href="../tests/gen/aff-tests/aff-test-1/pass.xml"/>
@@ -3235,6 +3247,16 @@
         <x:expect-report id="graphic-test-6" role="error"/>
         <x:expect-not-assert id="graphic-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="graphic-test-8-pass">
+        <x:context href="../tests/gen/graphic-tests/graphic-test-8/pass.xml"/>
+        <x:expect-not-report id="graphic-test-8" role="error"/>
+        <x:expect-not-assert id="graphic-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="graphic-test-8-fail">
+        <x:context href="../tests/gen/graphic-tests/graphic-test-8/fail.xml"/>
+        <x:expect-report id="graphic-test-8" role="error"/>
+        <x:expect-not-assert id="graphic-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="media-tests">
       <x:scenario label="media-test-1-pass">
@@ -3335,6 +3357,16 @@
       <x:scenario label="media-test-10-fail">
         <x:context href="../tests/gen/media-tests/media-test-10/fail.xml"/>
         <x:expect-report id="media-test-10" role="error"/>
+        <x:expect-not-assert id="media-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="media-test-11-pass">
+        <x:context href="../tests/gen/media-tests/media-test-11/pass.xml"/>
+        <x:expect-not-report id="media-test-11" role="error"/>
+        <x:expect-not-assert id="media-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="media-test-11-fail">
+        <x:context href="../tests/gen/media-tests/media-test-11/fail.xml"/>
+        <x:expect-report id="media-test-11" role="error"/>
         <x:expect-not-assert id="media-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
@@ -13441,6 +13473,16 @@
       <x:scenario label="biorxiv-test-fail">
         <x:context href="../tests/gen/preprint-title-tests/biorxiv-test/fail.xml"/>
         <x:expect-report id="biorxiv-test" role="error"/>
+        <x:expect-not-assert id="preprint-title-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="biorxiv-test-2-pass">
+        <x:context href="../tests/gen/preprint-title-tests/biorxiv-test-2/pass.xml"/>
+        <x:expect-not-report id="biorxiv-test-2" role="error"/>
+        <x:expect-not-assert id="preprint-title-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="biorxiv-test-2-fail">
+        <x:context href="../tests/gen/preprint-title-tests/biorxiv-test-2/fail.xml"/>
+        <x:expect-report id="biorxiv-test-2" role="error"/>
         <x:expect-not-assert id="preprint-title-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="arxiv-test-pass">


### PR DESCRIPTION
- warning for abstracts with 151+ words - `abstract-word-count-restriction`
- Minor change to `fig-group-test-2`
- Do not allow ampersands in filenames for images or files - `graphic-test-8`, `media-test-11`.
- Add test for bioRxiv doi conformance - `biorxiv-test-2`.