### PR TITLE
fix: message text edits

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1714,7 +1714,7 @@
     <rule context="article-meta/elocation-id" id="elocation-id-tests">
       <let name="article-id" value="parent::article-meta/article-id[@pub-id-type='publisher-id'][1]"/>
       
-      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">[test-elocation-conformance] elocation-id is incorrect. It's value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
+      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">[test-elocation-conformance] elocation-id is incorrect. Its value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="related-object-tests-pattern">
@@ -1812,7 +1812,7 @@
   <pattern id="body-xref-tests-pattern">
     <rule context="body//xref" id="body-xref-tests">
       
-      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">[empty-xref-test] Empty xref in the body is not allowed. It's position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
+      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">[empty-xref-test] Empty xref in the body is not allowed. Its position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
       
       <report test="ends-with(.,';') or ends-with(.,'; ')" role="warning" id="semi-colon-xref-test">[semi-colon-xref-test] xref ends with semi-colon - '<value-of select="."/>' - which is almost definitely incorrect. The semi-colon should very likely be placed after the link as 'normal' text.</report>
       
@@ -2378,7 +2378,7 @@
       
       <report test="($xrefs//*:match) and ($sec-id != $sec1/@id)" role="error" id="video-placement-1">[video-placement-1] <value-of select="$label"/> does not appear in the same section as where it is first cited (sec with title '<value-of select="$sec1/title"/>'), which is incorrect.</report>
       
-      <report test="($xref-sib = 'p') and ($xref1//following::media/@id = $id)" role="warning" id="video-placement-2">[video-placement-2] <value-of select="$label"/> appears after it's first citation but not directly after it's first citation. Is this correct?</report>
+      <report test="($xref-sib = 'p') and ($xref1//following::media/@id = $id)" role="warning" id="video-placement-2">[video-placement-2] <value-of select="$label"/> appears after its first citation but not directly after its first citation. Is this correct?</report>
       
     </rule>
   </pattern>
@@ -2585,7 +2585,7 @@
       
       <assert test="parent::fig-group" role="error" id="fig-sup-test-1">[fig-sup-test-1] fig supplement is not a child of fig-group. This cannot be correct.</assert>
       
-      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">[fig-sup-test-2] fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure X—figure supplement X.' (where X is one or more digits).</assert>
+      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">[fig-sup-test-2] fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure 0—figure supplement 0.' (where 0 is one or more digits).</assert>
       
       <assert test="starts-with(label[1],concat('Figure ',$parent-fig-no))" role="error" id="fig-sup-test-3">[fig-sup-test-3] <value-of select="label"/> does not start with the main figure number it is associated with - <value-of select="concat('Figure ',$parent-fig-no)"/>.</assert>
       
@@ -2801,7 +2801,7 @@
       
       <assert test="title = 'References'" role="warning" id="ref-list-title-test">[ref-list-title-test] reference list usually has a title that is 'References', but currently it is '<value-of select="title"/>' - is that correct?</assert>
       
-      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">[ref-list-distinct-1] In the reference list, each reference must be unique in it's citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
+      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">[ref-list-distinct-1] In the reference list, each reference must be unique in its citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
       
     </rule>
   </pattern>
@@ -3024,7 +3024,7 @@
     <rule context="article/body/sec" id="body-top-level-sec-ids">
       <let name="pos" value="count(parent::body/sec) - count(following-sibling::sec)"/>
     
-      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">[body-top-level-sec-id-test] This sec id must be a concatenation of 's' and this element's position relative to it's siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
+      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">[body-top-level-sec-id-test] This sec id must be a concatenation of 's' and this element's position relative to its siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
       </rule>
   </pattern>
   <pattern id="back-top-level-sec-ids-pattern">
@@ -3039,7 +3039,7 @@
       <let name="parent-sec" value="parent::sec/@id"/>
       <let name="pos" value="count(parent::sec/sec) - count(following-sibling::sec)"/>
       
-      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">[low-level-sec-id-test] sec id must be a concatenation of it's parent sec id and this element's position relative to it's sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
+      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">[low-level-sec-id-test] sec id must be a concatenation of its parent sec id and this element's position relative to its sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="app-ids-pattern">
@@ -3199,11 +3199,11 @@
       
       <assert test="if ($pos = 1) then @article-type='decision-letter'                     else @article-type='reply'" role="error" id="dec-letter-reply-test-1">[dec-letter-reply-test-1] 1st sub-article must be the decision letter. 2nd sub-article must be the author response.</assert>
       
-      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">[dec-letter-reply-test-2] sub-article id must be in the format 'sa0', where '0' is it's position (1 or 2).</assert>
+      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">[dec-letter-reply-test-2] sub-article id must be in the format 'sa0', where '0' is its position (1 or 2).</assert>
       
-      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">[dec-letter-reply-test-3] sub-article contain one and only one front-stub.</assert>
+      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">[dec-letter-reply-test-3] sub-article contains one and only one front-stub.</assert>
       
-      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">[dec-letter-reply-test-4] sub-article contain one and only one body.</assert>
+      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">[dec-letter-reply-test-4] sub-article contains one and only one body.</assert>
       
     </rule>
   </pattern>
@@ -4948,7 +4948,7 @@
       <report test="(@pub-id-type='pmid') and matches(.,'\D')" role="error" id="pub-id-test-3">[pub-id-test-3] pub-id is tagged as a pmid, but it contains a character(s) which is not a digit - <value-of select="."/>
       </report>
       
-      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">[pub-id-doi-test-1] pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">[pub-id-doi-test-1] pub-id has a doi link - <value-of select="@xlink:href"/> - but its pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
       
       <report test="matches(@xlink:href,'https?://(dx.doi.org|doi.org)/') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">[pub-id-doi-test-2] pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. Either the doi link is correct, and the identifier needs changing, or the identifier is correct and needs adding after 'https://doi.org/' in order to create the real doi link.</report>
       
@@ -5956,11 +5956,11 @@
       
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">[singapore-test-1] <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
       
-      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">[taiwan-test] Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">[taiwan-test] Affiliation has a Taiwanese city - <value-of select="$city"/> - but its country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
       
-      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">[s-korea-test] Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">[s-korea-test] Affiliation has a South Korean city - <value-of select="$city"/> - but its country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
       
-      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">[n-korea-test] Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">[n-korea-test] Affiliation has '<value-of select="."/>' as its country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1756,7 +1756,7 @@
     <rule context="article-meta/elocation-id" id="elocation-id-tests">
       <let name="article-id" value="parent::article-meta/article-id[@pub-id-type='publisher-id'][1]"/>
       
-      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">elocation-id is incorrect. It's value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
+      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">elocation-id is incorrect. Its value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="related-object-tests-pattern">
@@ -1855,7 +1855,7 @@
   <pattern id="body-xref-tests-pattern">
     <rule context="body//xref" id="body-xref-tests">
       
-      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">Empty xref in the body is not allowed. It's position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
+      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">Empty xref in the body is not allowed. Its position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
       
       <report test="ends-with(.,';') or ends-with(.,'; ')" role="warning" id="semi-colon-xref-test">xref ends with semi-colon - '<value-of select="."/>' - which is almost definitely incorrect. The semi-colon should very likely be placed after the link as 'normal' text.</report>
       
@@ -2452,7 +2452,7 @@
         <value-of select="$label"/> does not appear in the same section as where it is first cited (sec with title '<value-of select="$sec1/title"/>'), which is incorrect.</report>
       
       <report test="($xref-sib = 'p') and ($xref1//following::media/@id = $id)" role="warning" id="video-placement-2">
-        <value-of select="$label"/> appears after it's first citation but not directly after it's first citation. Is this correct?</report>
+        <value-of select="$label"/> appears after its first citation but not directly after its first citation. Is this correct?</report>
       
     </rule>
   </pattern>
@@ -2674,7 +2674,7 @@
       
       <assert test="parent::fig-group" role="error" id="fig-sup-test-1">fig supplement is not a child of fig-group. This cannot be correct.</assert>
       
-      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure X—figure supplement X.' (where X is one or more digits).</assert>
+      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure 0—figure supplement 0.' (where 0 is one or more digits).</assert>
       
       <assert test="starts-with(label[1],concat('Figure ',$parent-fig-no))" role="error" id="fig-sup-test-3">
         <value-of select="label"/> does not start with the main figure number it is associated with - <value-of select="concat('Figure ',$parent-fig-no)"/>.</assert>
@@ -2896,7 +2896,7 @@
       
       <assert test="title = 'References'" role="warning" id="ref-list-title-test">reference list usually has a title that is 'References', but currently it is '<value-of select="title"/>' - is that correct?</assert>
       
-      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">In the reference list, each reference must be unique in it's citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
+      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">In the reference list, each reference must be unique in its citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
       
     </rule>
   </pattern>
@@ -3119,7 +3119,7 @@
     <rule context="article/body/sec" id="body-top-level-sec-ids">
       <let name="pos" value="count(parent::body/sec) - count(following-sibling::sec)"/>
     
-      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">This sec id must be a concatenation of 's' and this element's position relative to it's siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
+      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">This sec id must be a concatenation of 's' and this element's position relative to its siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
       </rule>
   </pattern>
   <pattern id="back-top-level-sec-ids-pattern">
@@ -3134,7 +3134,7 @@
       <let name="parent-sec" value="parent::sec/@id"/>
       <let name="pos" value="count(parent::sec/sec) - count(following-sibling::sec)"/>
       
-      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">sec id must be a concatenation of it's parent sec id and this element's position relative to it's sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
+      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">sec id must be a concatenation of its parent sec id and this element's position relative to its sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="app-ids-pattern">
@@ -3296,11 +3296,11 @@
       
       <assert test="if ($pos = 1) then @article-type='decision-letter'                     else @article-type='reply'" role="error" id="dec-letter-reply-test-1">1st sub-article must be the decision letter. 2nd sub-article must be the author response.</assert>
       
-      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">sub-article id must be in the format 'sa0', where '0' is it's position (1 or 2).</assert>
+      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">sub-article id must be in the format 'sa0', where '0' is its position (1 or 2).</assert>
       
-      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">sub-article contain one and only one front-stub.</assert>
+      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">sub-article contains one and only one front-stub.</assert>
       
-      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">sub-article contain one and only one body.</assert>
+      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">sub-article contains one and only one body.</assert>
       
     </rule>
   </pattern>
@@ -5050,7 +5050,7 @@
       <report test="(@pub-id-type='pmid') and matches(.,'\D')" role="error" id="pub-id-test-3">pub-id is tagged as a pmid, but it contains a character(s) which is not a digit - <value-of select="."/>
       </report>
       
-      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but its pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
       
       <report test="matches(@xlink:href,'https?://(dx.doi.org|doi.org)/') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. Either the doi link is correct, and the identifier needs changing, or the identifier is correct and needs adding after 'https://doi.org/' in order to create the real doi link.</report>
       
@@ -6254,11 +6254,11 @@
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
         <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
       
-      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but its country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
       
-      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but its country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
       
-      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as its country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1712,7 +1712,7 @@
     <rule context="article-meta/elocation-id" id="elocation-id-tests">
       <let name="article-id" value="parent::article-meta/article-id[@pub-id-type='publisher-id'][1]"/>
       
-      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">[test-elocation-conformance] elocation-id is incorrect. It's value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
+      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">[test-elocation-conformance] elocation-id is incorrect. Its value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="related-object-tests-pattern">
@@ -1810,7 +1810,7 @@
   <pattern id="body-xref-tests-pattern">
     <rule context="body//xref" id="body-xref-tests">
       
-      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">[empty-xref-test] Empty xref in the body is not allowed. It's position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
+      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">[empty-xref-test] Empty xref in the body is not allowed. Its position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
       
       <report test="ends-with(.,';') or ends-with(.,'; ')" role="warning" id="semi-colon-xref-test">[semi-colon-xref-test] xref ends with semi-colon - '<value-of select="."/>' - which is almost definitely incorrect. The semi-colon should very likely be placed after the link as 'normal' text.</report>
       
@@ -2376,7 +2376,7 @@
       
       <report test="($xrefs//*:match) and ($sec-id != $sec1/@id)" role="error" id="video-placement-1">[video-placement-1] <value-of select="$label"/> does not appear in the same section as where it is first cited (sec with title '<value-of select="$sec1/title"/>'), which is incorrect.</report>
       
-      <report test="($xref-sib = 'p') and ($xref1//following::media/@id = $id)" role="warning" id="video-placement-2">[video-placement-2] <value-of select="$label"/> appears after it's first citation but not directly after it's first citation. Is this correct?</report>
+      <report test="($xref-sib = 'p') and ($xref1//following::media/@id = $id)" role="warning" id="video-placement-2">[video-placement-2] <value-of select="$label"/> appears after its first citation but not directly after its first citation. Is this correct?</report>
       
     </rule>
   </pattern>
@@ -2583,7 +2583,7 @@
       
       <assert test="parent::fig-group" role="error" id="fig-sup-test-1">[fig-sup-test-1] fig supplement is not a child of fig-group. This cannot be correct.</assert>
       
-      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">[fig-sup-test-2] fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure X—figure supplement X.' (where X is one or more digits).</assert>
+      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">[fig-sup-test-2] fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure 0—figure supplement 0.' (where 0 is one or more digits).</assert>
       
       <assert test="starts-with(label[1],concat('Figure ',$parent-fig-no))" role="error" id="fig-sup-test-3">[fig-sup-test-3] <value-of select="label"/> does not start with the main figure number it is associated with - <value-of select="concat('Figure ',$parent-fig-no)"/>.</assert>
       
@@ -2799,7 +2799,7 @@
       
       <assert test="title = 'References'" role="warning" id="ref-list-title-test">[ref-list-title-test] reference list usually has a title that is 'References', but currently it is '<value-of select="title"/>' - is that correct?</assert>
       
-      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">[ref-list-distinct-1] In the reference list, each reference must be unique in it's citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
+      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">[ref-list-distinct-1] In the reference list, each reference must be unique in its citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
       
     </rule>
   </pattern>
@@ -3022,7 +3022,7 @@
     <rule context="article/body/sec" id="body-top-level-sec-ids">
       <let name="pos" value="count(parent::body/sec) - count(following-sibling::sec)"/>
     
-      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">[body-top-level-sec-id-test] This sec id must be a concatenation of 's' and this element's position relative to it's siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
+      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">[body-top-level-sec-id-test] This sec id must be a concatenation of 's' and this element's position relative to its siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
       </rule>
   </pattern>
   <pattern id="back-top-level-sec-ids-pattern">
@@ -3037,7 +3037,7 @@
       <let name="parent-sec" value="parent::sec/@id"/>
       <let name="pos" value="count(parent::sec/sec) - count(following-sibling::sec)"/>
       
-      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">[low-level-sec-id-test] sec id must be a concatenation of it's parent sec id and this element's position relative to it's sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
+      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">[low-level-sec-id-test] sec id must be a concatenation of its parent sec id and this element's position relative to its sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="app-ids-pattern">
@@ -3197,11 +3197,11 @@
       
       <assert test="if ($pos = 1) then @article-type='decision-letter'                     else @article-type='reply'" role="error" id="dec-letter-reply-test-1">[dec-letter-reply-test-1] 1st sub-article must be the decision letter. 2nd sub-article must be the author response.</assert>
       
-      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">[dec-letter-reply-test-2] sub-article id must be in the format 'sa0', where '0' is it's position (1 or 2).</assert>
+      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">[dec-letter-reply-test-2] sub-article id must be in the format 'sa0', where '0' is its position (1 or 2).</assert>
       
-      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">[dec-letter-reply-test-3] sub-article contain one and only one front-stub.</assert>
+      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">[dec-letter-reply-test-3] sub-article contains one and only one front-stub.</assert>
       
-      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">[dec-letter-reply-test-4] sub-article contain one and only one body.</assert>
+      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">[dec-letter-reply-test-4] sub-article contains one and only one body.</assert>
       
     </rule>
   </pattern>
@@ -4946,7 +4946,7 @@
       <report test="(@pub-id-type='pmid') and matches(.,'\D')" role="error" id="pub-id-test-3">[pub-id-test-3] pub-id is tagged as a pmid, but it contains a character(s) which is not a digit - <value-of select="."/>
       </report>
       
-      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">[pub-id-doi-test-1] pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">[pub-id-doi-test-1] pub-id has a doi link - <value-of select="@xlink:href"/> - but its pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
       
       <report test="matches(@xlink:href,'https?://(dx.doi.org|doi.org)/') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">[pub-id-doi-test-2] pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. Either the doi link is correct, and the identifier needs changing, or the identifier is correct and needs adding after 'https://doi.org/' in order to create the real doi link.</report>
       
@@ -5954,11 +5954,11 @@
       
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">[singapore-test-1] <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
       
-      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">[taiwan-test] Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">[taiwan-test] Affiliation has a Taiwanese city - <value-of select="$city"/> - but its country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
       
-      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">[s-korea-test] Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">[s-korea-test] Affiliation has a South Korean city - <value-of select="$city"/> - but its country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
       
-      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">[n-korea-test] Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">[n-korea-test] Affiliation has '<value-of select="."/>' as its country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2252,7 +2252,7 @@
       
       <assert test=". = concat('e' , $article-id)"
         role="error" 
-        id="test-elocation-conformance">elocation-id is incorrect. It's value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
+        id="test-elocation-conformance">elocation-id is incorrect. Its value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
     </rule>
     
     <rule context="related-object" 
@@ -2412,7 +2412,7 @@
       
       <report test="not(child::*) and normalize-space(.)=''"
         role="error" 
-        id="empty-xref-test">Empty xref in the body is not allowed. It's position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
+        id="empty-xref-test">Empty xref in the body is not allowed. Its position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
       
       <report test="ends-with(.,';') or ends-with(.,'; ')"
         role="warning" 
@@ -3309,7 +3309,7 @@
       
       <report test="($xref-sib = 'p') and ($xref1//following::media/@id = $id)" 
         role="warning"
-        id="video-placement-2"><value-of select="$label"/> appears after it's first citation but not directly after it's first citation. Is this correct?</report>
+        id="video-placement-2"><value-of select="$label"/> appears after its first citation but not directly after its first citation. Is this correct?</report>
       
     </rule>
     
@@ -3613,7 +3613,7 @@
       
       <assert test="$label-conform = true()" 
         role="error"
-        id="fig-sup-test-2">fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure X—figure supplement X.' (where X is one or more digits).</assert>
+        id="fig-sup-test-2">fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure 0—figure supplement 0.' (where 0 is one or more digits).</assert>
       
       <assert test="starts-with(label[1],concat('Figure ',$parent-fig-no))" 
         role="error"
@@ -3961,7 +3961,7 @@
       
       <report test="$non-distinct//*:item"
         role="error"
-        id="ref-list-distinct-1">In the reference list, each reference must be unique in it's citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
+        id="ref-list-distinct-1">In the reference list, each reference must be unique in its citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
       
     </rule>
     
@@ -4286,7 +4286,7 @@
     
       <assert test="@id = concat('s',$pos)"
         role="error"
-        id="body-top-level-sec-id-test">This sec id must be a concatenation of 's' and this element's position relative to it's siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
+        id="body-top-level-sec-id-test">This sec id must be a concatenation of 's' and this element's position relative to its siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
       </rule>
     
     <rule context="article/back/sec" 
@@ -4305,7 +4305,7 @@
       
       <assert test="@id = concat($parent-sec,'-',$pos)"
         role="error"
-        id="low-level-sec-id-test">sec id must be a concatenation of it's parent sec id and this element's position relative to it's sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
+        id="low-level-sec-id-test">sec id must be a concatenation of its parent sec id and this element's position relative to its sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
     </rule>
     
     <rule context="app" 
@@ -4561,15 +4561,15 @@
       
       <assert test="@id = concat('sa',$pos)"
         role="error"
-        id="dec-letter-reply-test-2">sub-article id must be in the format 'sa0', where '0' is it's position (1 or 2).</assert>
+        id="dec-letter-reply-test-2">sub-article id must be in the format 'sa0', where '0' is its position (1 or 2).</assert>
       
       <assert test="count(front-stub) = 1"
         role="error"
-        id="dec-letter-reply-test-3">sub-article contain one and only one front-stub.</assert>
+        id="dec-letter-reply-test-3">sub-article contains one and only one front-stub.</assert>
       
       <assert test="count(body) = 1"
         role="error"
-        id="dec-letter-reply-test-4">sub-article contain one and only one body.</assert>
+        id="dec-letter-reply-test-4">sub-article contains one and only one body.</assert>
       
     </rule>
     
@@ -6600,7 +6600,7 @@
       
       <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" 
         role="error" 
-        id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+        id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but its pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
       
       <report test="matches(@xlink:href,'https?://(dx.doi.org|doi.org)/') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" 
         role="error" 
@@ -8443,15 +8443,15 @@
       
       <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))"
         role="warning"
-        id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+        id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but its country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
       
       <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))"
         role="warning"
-        id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+        id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but its country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
       
       <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'"
         role="warning"
-        id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
+        id="n-korea-test">Affiliation has '<value-of select="."/>' as its country which is very likely to be incorrect.</report>
     </rule>
     
     <rule context="front//aff//named-content[@content-type='city']"

--- a/test/tests/gen/body-top-level-sec-ids/body-top-level-sec-id-test/body-top-level-sec-id-test.sch
+++ b/test/tests/gen/body-top-level-sec-ids/body-top-level-sec-id-test/body-top-level-sec-id-test.sch
@@ -788,7 +788,7 @@
   <pattern id="id-conformance">
     <rule context="article/body/sec" id="body-top-level-sec-ids">
       <let name="pos" value="count(parent::body/sec) - count(following-sibling::sec)"/>
-      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">This sec id must be a concatenation of 's' and this element's position relative to it's siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
+      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">This sec id must be a concatenation of 's' and this element's position relative to its siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/body-top-level-sec-ids/body-top-level-sec-id-test/fail.xml
+++ b/test/tests/gen/body-top-level-sec-ids/body-top-level-sec-id-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="body-top-level-sec-id-test.sch"?>
 <!--Context: article/body/sec
 Test: assert    @id = concat('s',$pos)
-Message: This sec id must be a concatenation of 's' and this element's position relative to it's siblings. It must be . -->
+Message: This sec id must be a concatenation of 's' and this element's position relative to its siblings. It must be . -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <body>

--- a/test/tests/gen/body-top-level-sec-ids/body-top-level-sec-id-test/pass.xml
+++ b/test/tests/gen/body-top-level-sec-ids/body-top-level-sec-id-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="body-top-level-sec-id-test.sch"?>
 <!--Context: article/body/sec
 Test: assert    @id = concat('s',$pos)
-Message: This sec id must be a concatenation of 's' and this element's position relative to it's siblings. It must be . -->
+Message: This sec id must be a concatenation of 's' and this element's position relative to its siblings. It must be . -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <body>

--- a/test/tests/gen/body-xref-tests/empty-xref-test/empty-xref-test.sch
+++ b/test/tests/gen/body-xref-tests/empty-xref-test/empty-xref-test.sch
@@ -787,7 +787,7 @@
   </xsl:function>
   <pattern id="content-containers">
     <rule context="body//xref" id="body-xref-tests">
-      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">Empty xref in the body is not allowed. It's position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
+      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">Empty xref in the body is not allowed. Its position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/body-xref-tests/empty-xref-test/fail.xml
+++ b/test/tests/gen/body-xref-tests/empty-xref-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="empty-xref-test.sch"?>
 <!--Context: body//xref
 Test: report    not(child::*) and normalize-space(.)=''
-Message: Empty xref in the body is not allowed. It's position here in the text - "". -->
+Message: Empty xref in the body is not allowed. Its position here in the text - "". -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <body>

--- a/test/tests/gen/body-xref-tests/empty-xref-test/pass.xml
+++ b/test/tests/gen/body-xref-tests/empty-xref-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="empty-xref-test.sch"?>
 <!--Context: body//xref
 Test: report    not(child::*) and normalize-space(.)=''
-Message: Empty xref in the body is not allowed. It's position here in the text - "". -->
+Message: Empty xref in the body is not allowed. Its position here in the text - "". -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <body>

--- a/test/tests/gen/country-tests/n-korea-test/fail.xml
+++ b/test/tests/gen/country-tests/n-korea-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="n-korea-test.sch"?>
 <!--Context: front//aff/country
 Test: report    replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'
-Message: Affiliation has '' as it's country which is very likely to be incorrect. -->
+Message: Affiliation has '' as its country which is very likely to be incorrect. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/country-tests/n-korea-test/n-korea-test.sch
+++ b/test/tests/gen/country-tests/n-korea-test/n-korea-test.sch
@@ -790,7 +790,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as its country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/country-tests/n-korea-test/pass.xml
+++ b/test/tests/gen/country-tests/n-korea-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="n-korea-test.sch"?>
 <!--Context: front//aff/country
 Test: report    replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'
-Message: Affiliation has '' as it's country which is very likely to be incorrect. -->
+Message: Affiliation has '' as its country which is very likely to be incorrect. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/country-tests/s-korea-test/fail.xml
+++ b/test/tests/gen/country-tests/s-korea-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="s-korea-test.sch"?>
 <!--Context: front//aff/country
 Test: report    (. != 'Republic of Korea') and (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))
-Message: Affiliation has a South Korean city -  - but it's country is '', instead of 'Republic of Korea'. -->
+Message: Affiliation has a South Korean city -  - but its country is '', instead of 'Republic of Korea'. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/country-tests/s-korea-test/pass.xml
+++ b/test/tests/gen/country-tests/s-korea-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="s-korea-test.sch"?>
 <!--Context: front//aff/country
 Test: report    (. != 'Republic of Korea') and (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))
-Message: Affiliation has a South Korean city -  - but it's country is '', instead of 'Republic of Korea'. -->
+Message: Affiliation has a South Korean city -  - but its country is '', instead of 'Republic of Korea'. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/country-tests/s-korea-test/s-korea-test.sch
+++ b/test/tests/gen/country-tests/s-korea-test/s-korea-test.sch
@@ -790,7 +790,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but its country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/country-tests/taiwan-test/fail.xml
+++ b/test/tests/gen/country-tests/taiwan-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="taiwan-test.sch"?>
 <!--Context: front//aff/country
 Test: report    (. != 'Taiwan') and (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))
-Message: Affiliation has a Taiwanese city -  - but it's country is ''. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'. -->
+Message: Affiliation has a Taiwanese city -  - but its country is ''. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/country-tests/taiwan-test/pass.xml
+++ b/test/tests/gen/country-tests/taiwan-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="taiwan-test.sch"?>
 <!--Context: front//aff/country
 Test: report    (. != 'Taiwan') and (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))
-Message: Affiliation has a Taiwanese city -  - but it's country is ''. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'. -->
+Message: Affiliation has a Taiwanese city -  - but its country is ''. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/country-tests/taiwan-test/taiwan-test.sch
+++ b/test/tests/gen/country-tests/taiwan-test/taiwan-test.sch
@@ -790,7 +790,7 @@
       <let name="text" value="self::*/text()"/>
       <let name="countries" value="'../../../../../src/countries.xml'"/>
       <let name="city" value="parent::aff//named-content[@content-type='city'][1]"/>
-      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but its country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-2/dec-letter-reply-test-2.sch
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-2/dec-letter-reply-test-2.sch
@@ -788,7 +788,7 @@
   <pattern id="dec-letter-auth-response">
     <rule context="article/sub-article" id="dec-letter-reply-tests">
       <let name="pos" value="count(parent::article/sub-article) - count(following-sibling::sub-article)"/>
-      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">sub-article id must be in the format 'sa0', where '0' is it's position (1 or 2).</assert>
+      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">sub-article id must be in the format 'sa0', where '0' is its position (1 or 2).</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-2/fail.xml
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="dec-letter-reply-test-2.sch"?>
 <!--Context: article/sub-article
 Test: assert    @id = concat('sa',$pos)
-Message: sub-article id must be in the format 'sa0', where '0' is it's position (1 or 2). -->
+Message: sub-article id must be in the format 'sa0', where '0' is its position (1 or 2). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <sub-article article-type="reply" id="sa2">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-2/pass.xml
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="dec-letter-reply-test-2.sch"?>
 <!--Context: article/sub-article
 Test: assert    @id = concat('sa',$pos)
-Message: sub-article id must be in the format 'sa0', where '0' is it's position (1 or 2). -->
+Message: sub-article id must be in the format 'sa0', where '0' is its position (1 or 2). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <sub-article article-type="decision-letter" id="sa1">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-3/dec-letter-reply-test-3.sch
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-3/dec-letter-reply-test-3.sch
@@ -788,7 +788,7 @@
   <pattern id="dec-letter-auth-response">
     <rule context="article/sub-article" id="dec-letter-reply-tests">
       <let name="pos" value="count(parent::article/sub-article) - count(following-sibling::sub-article)"/>
-      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">sub-article contain one and only one front-stub.</assert>
+      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">sub-article contains one and only one front-stub.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-3/fail.xml
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="dec-letter-reply-test-3.sch"?>
 <!--Context: article/sub-article
 Test: assert    count(front-stub) = 1
-Message: sub-article contain one and only one front-stub. -->
+Message: sub-article contains one and only one front-stub. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <sub-article article-type="decision-letter" id="SA1"/>

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-3/pass.xml
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="dec-letter-reply-test-3.sch"?>
 <!--Context: article/sub-article
 Test: assert    count(front-stub) = 1
-Message: sub-article contain one and only one front-stub. -->
+Message: sub-article contains one and only one front-stub. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <sub-article article-type="decision-letter" id="SA1">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-4/dec-letter-reply-test-4.sch
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-4/dec-letter-reply-test-4.sch
@@ -788,7 +788,7 @@
   <pattern id="dec-letter-auth-response">
     <rule context="article/sub-article" id="dec-letter-reply-tests">
       <let name="pos" value="count(parent::article/sub-article) - count(following-sibling::sub-article)"/>
-      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">sub-article contain one and only one body.</assert>
+      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">sub-article contains one and only one body.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-4/fail.xml
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-4/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="dec-letter-reply-test-4.sch"?>
 <!--Context: article/sub-article
 Test: assert    count(body) = 1
-Message: sub-article contain one and only one body. -->
+Message: sub-article contains one and only one body. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <sub-article article-type="decision-letter" id="SA1">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-4/pass.xml
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-4/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="dec-letter-reply-test-4.sch"?>
 <!--Context: article/sub-article
 Test: assert    count(body) = 1
-Message: sub-article contain one and only one body. -->
+Message: sub-article contains one and only one body. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <sub-article article-type="decision-letter" id="SA1">

--- a/test/tests/gen/elocation-id-tests/test-elocation-conformance/fail.xml
+++ b/test/tests/gen/elocation-id-tests/test-elocation-conformance/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="test-elocation-conformance.sch"?>
 <!--Context: article-meta/elocation-id
 Test: assert    . = concat('e' , $article-id)
-Message: elocation-id is incorrect. It's value should be a concatenation of 'e' and the article id, in this case . -->
+Message: elocation-id is incorrect. Its value should be a concatenation of 'e' and the article id, in this case . -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/elocation-id-tests/test-elocation-conformance/pass.xml
+++ b/test/tests/gen/elocation-id-tests/test-elocation-conformance/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="test-elocation-conformance.sch"?>
 <!--Context: article-meta/elocation-id
 Test: assert    . = concat('e' , $article-id)
-Message: elocation-id is incorrect. It's value should be a concatenation of 'e' and the article id, in this case . -->
+Message: elocation-id is incorrect. Its value should be a concatenation of 'e' and the article id, in this case . -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <front>

--- a/test/tests/gen/elocation-id-tests/test-elocation-conformance/test-elocation-conformance.sch
+++ b/test/tests/gen/elocation-id-tests/test-elocation-conformance/test-elocation-conformance.sch
@@ -788,7 +788,7 @@
   <pattern id="article-metadata">
     <rule context="article-meta/elocation-id" id="elocation-id-tests">
       <let name="article-id" value="parent::article-meta/article-id[@pub-id-type='publisher-id'][1]"/>
-      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">elocation-id is incorrect. It's value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
+      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">elocation-id is incorrect. Its value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-2/fail.xml
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="fig-sup-test-2.sch"?>
 <!--Context: article/body//fig[@specific-use='child-fig']
 Test: assert    $label-conform = true()
-Message: fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure X—figure supplement X.' (where X is one or more digits). -->
+Message: fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure 0—figure supplement 0.' (where 0 is one or more digits). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <body>

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-2/fig-sup-test-2.sch
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-2/fig-sup-test-2.sch
@@ -794,7 +794,7 @@
       <let name="no" value="substring-after(@id,'s')"/>
       <let name="parent-fig-no" value="substring-after(parent::fig-group/fig[not(@specific-use='child-fig')][1]/@id,'fig')"/>
       <let name="label-no" value="replace(substring-after(label[1],'supplement'),'[^\d]','')"/>
-      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure X—figure supplement X.' (where X is one or more digits).</assert>
+      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure 0—figure supplement 0.' (where 0 is one or more digits).</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-2/pass.xml
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="fig-sup-test-2.sch"?>
 <!--Context: article/body//fig[@specific-use='child-fig']
 Test: assert    $label-conform = true()
-Message: fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure X—figure supplement X.' (where X is one or more digits). -->
+Message: fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure 0—figure supplement 0.' (where 0 is one or more digits). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <body>

--- a/test/tests/gen/general-video/video-placement-2/fail.xml
+++ b/test/tests/gen/general-video/video-placement-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="video-placement-2.sch"?>
 <!--Context: media[@mimetype='video'][matches(@id,'^video[0-9]{1,3}$')]
 Test: report    ($xref-sib = 'p') and ($xref1//following::media/@id = $id)
-Message:  appears after it's first citation but not directly after it's first citation. Is this correct? -->
+Message:  appears after its first citation but not directly after its first citation. Is this correct? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <sec id="sec1">

--- a/test/tests/gen/general-video/video-placement-2/pass.xml
+++ b/test/tests/gen/general-video/video-placement-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="video-placement-2.sch"?>
 <!--Context: media[@mimetype='video'][matches(@id,'^video[0-9]{1,3}$')]
 Test: report    ($xref-sib = 'p') and ($xref1//following::media/@id = $id)
-Message:  appears after it's first citation but not directly after it's first citation. Is this correct? -->
+Message:  appears after its first citation but not directly after its first citation. Is this correct? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <sec id="sec1">

--- a/test/tests/gen/general-video/video-placement-2/video-placement-2.sch
+++ b/test/tests/gen/general-video/video-placement-2/video-placement-2.sch
@@ -795,7 +795,7 @@
       <let name="xref1" value="ancestor::article/descendant::xref[(@rid = $id) and not(ancestor::caption)][1]"/>
       <let name="xref-sib" value="$xref1/parent::*/following-sibling::*[1]/local-name()"/>
       <report test="($xref-sib = 'p') and ($xref1//following::media/@id = $id)" role="warning" id="video-placement-2">
-        <value-of select="$label"/> appears after it's first citation but not directly after it's first citation. Is this correct?</report>
+        <value-of select="$label"/> appears after its first citation but not directly after its first citation. Is this correct?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/low-level-sec-ids/low-level-sec-id-test/fail.xml
+++ b/test/tests/gen/low-level-sec-ids/low-level-sec-id-test/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="low-level-sec-id-test.sch"?>
 <!--Context: article/body/sec//sec|article/back/sec//sec
 Test: assert    @id = concat($parent-sec,'-',$pos)
-Message: sec id must be a concatenation of it's parent sec id and this element's position relative to it's sibling secs. It must be . -->
+Message: sec id must be a concatenation of its parent sec id and this element's position relative to its sibling secs. It must be . -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <body>

--- a/test/tests/gen/low-level-sec-ids/low-level-sec-id-test/low-level-sec-id-test.sch
+++ b/test/tests/gen/low-level-sec-ids/low-level-sec-id-test/low-level-sec-id-test.sch
@@ -789,7 +789,7 @@
     <rule context="article/body/sec//sec|article/back/sec//sec" id="low-level-sec-ids">
       <let name="parent-sec" value="parent::sec/@id"/>
       <let name="pos" value="count(parent::sec/sec) - count(following-sibling::sec)"/>
-      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">sec id must be a concatenation of it's parent sec id and this element's position relative to it's sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
+      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">sec id must be a concatenation of its parent sec id and this element's position relative to its sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/low-level-sec-ids/low-level-sec-id-test/pass.xml
+++ b/test/tests/gen/low-level-sec-ids/low-level-sec-id-test/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="low-level-sec-id-test.sch"?>
 <!--Context: article/body/sec//sec|article/back/sec//sec
 Test: assert    @id = concat($parent-sec,'-',$pos)
-Message: sec id must be a concatenation of it's parent sec id and this element's position relative to it's sibling secs. It must be . -->
+Message: sec id must be a concatenation of its parent sec id and this element's position relative to its sibling secs. It must be . -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <body>

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-1/fail.xml
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="pub-id-doi-test-1.sch"?>
 <!--Context: element-citation/pub-id
 Test: report    (@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')
-Message: pub-id has a doi link -  - but it's pub-id-type is  instead of doi. -->
+Message: pub-id has a doi link -  - but its pub-id-type is  instead of doi. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pass.xml
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="pub-id-doi-test-1.sch"?>
 <!--Context: element-citation/pub-id
 Test: report    (@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')
-Message: pub-id has a doi link -  - but it's pub-id-type is  instead of doi. -->
+Message: pub-id has a doi link -  - but its pub-id-type is  instead of doi. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pub-id-doi-test-1.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pub-id-doi-test-1.sch
@@ -787,7 +787,7 @@
   </xsl:function>
   <pattern id="pub-id-pattern">
     <rule context="element-citation/pub-id" id="pub-id-tests">
-      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but its pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/ref-list-title-tests/ref-list-distinct-1/fail.xml
+++ b/test/tests/gen/ref-list-title-tests/ref-list-distinct-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="ref-list-distinct-1.sch"?>
 <!--Context: ref-list
 Test: report    $non-distinct//*:item
-Message: In the reference list, each reference must be unique in it's citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a).  does not meet this requirement. -->
+Message: In the reference list, each reference must be unique in its citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a).  does not meet this requirement. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <ref-list>

--- a/test/tests/gen/ref-list-title-tests/ref-list-distinct-1/pass.xml
+++ b/test/tests/gen/ref-list-title-tests/ref-list-distinct-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="ref-list-distinct-1.sch"?>
 <!--Context: ref-list
 Test: report    $non-distinct//*:item
-Message: In the reference list, each reference must be unique in it's citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a).  does not meet this requirement. -->
+Message: In the reference list, each reference must be unique in its citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a).  does not meet this requirement. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <ref-list>

--- a/test/tests/gen/ref-list-title-tests/ref-list-distinct-1/ref-list-distinct-1.sch
+++ b/test/tests/gen/ref-list-title-tests/ref-list-distinct-1/ref-list-distinct-1.sch
@@ -789,7 +789,7 @@
     <rule context="ref-list" id="ref-list-title-tests">
       <let name="cite-list" value="e:ref-cite-list(.)"/>
       <let name="non-distinct" value="e:non-distinct-citations($cite-list)"/>
-      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">In the reference list, each reference must be unique in it's citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
+      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">In the reference list, each reference must be unique in its citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1751,7 +1751,7 @@
     <rule context="article-meta/elocation-id" id="elocation-id-tests">
       <let name="article-id" value="parent::article-meta/article-id[@pub-id-type='publisher-id'][1]"/>
       
-      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">elocation-id is incorrect. It's value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
+      <assert test=". = concat('e' , $article-id)" role="error" id="test-elocation-conformance">elocation-id is incorrect. Its value should be a concatenation of 'e' and the article id, in this case <value-of select="concat('e',$article-id)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="related-object-tests-pattern">
@@ -1850,7 +1850,7 @@
   <pattern id="body-xref-tests-pattern">
     <rule context="body//xref" id="body-xref-tests">
       
-      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">Empty xref in the body is not allowed. It's position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
+      <report test="not(child::*) and normalize-space(.)=''" role="error" id="empty-xref-test">Empty xref in the body is not allowed. Its position here in the text - "<value-of select="concat(preceding-sibling::text()[1],'*Empty xref*',following-sibling::text()[1])"/>".</report>
       
       <report test="ends-with(.,';') or ends-with(.,'; ')" role="warning" id="semi-colon-xref-test">xref ends with semi-colon - '<value-of select="."/>' - which is almost definitely incorrect. The semi-colon should very likely be placed after the link as 'normal' text.</report>
       
@@ -2453,7 +2453,7 @@
         <value-of select="$label"/> does not appear in the same section as where it is first cited (sec with title '<value-of select="$sec1/title"/>'), which is incorrect.</report>
       
       <report test="($xref-sib = 'p') and ($xref1//following::media/@id = $id)" role="warning" id="video-placement-2">
-        <value-of select="$label"/> appears after it's first citation but not directly after it's first citation. Is this correct?</report>
+        <value-of select="$label"/> appears after its first citation but not directly after its first citation. Is this correct?</report>
       
     </rule>
   </pattern>
@@ -2681,7 +2681,7 @@
       
       <assert test="parent::fig-group" role="error" id="fig-sup-test-1">fig supplement is not a child of fig-group. This cannot be correct.</assert>
       
-      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure X—figure supplement X.' (where X is one or more digits).</assert>
+      <assert test="$label-conform = true()" role="error" id="fig-sup-test-2">fig in the body of the article which has a @specific-use='child-fig' must have a label in the format 'Figure 0—figure supplement 0.' (where 0 is one or more digits).</assert>
       
       <assert test="starts-with(label[1],concat('Figure ',$parent-fig-no))" role="error" id="fig-sup-test-3">
         <value-of select="label"/> does not start with the main figure number it is associated with - <value-of select="concat('Figure ',$parent-fig-no)"/>.</assert>
@@ -2903,7 +2903,7 @@
       
       <assert test="title = 'References'" role="warning" id="ref-list-title-test">reference list usually has a title that is 'References', but currently it is '<value-of select="title"/>' - is that correct?</assert>
       
-      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">In the reference list, each reference must be unique in it's citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
+      <report test="$non-distinct//*:item" role="error" id="ref-list-distinct-1">In the reference list, each reference must be unique in its citation style (combination of authors and year). If a reference's citation is the same as anothers, a lowercase letter should be suffixed to the year (e.g. Smith et al., 2020a). <value-of select="string-join(for $x in $non-distinct//*:item return concat($x,' with the id ',$x/@id),' and ')"/> does not meet this requirement.</report>
       
     </rule>
   </pattern>
@@ -3126,7 +3126,7 @@
     <rule context="article/body/sec" id="body-top-level-sec-ids">
       <let name="pos" value="count(parent::body/sec) - count(following-sibling::sec)"/>
     
-      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">This sec id must be a concatenation of 's' and this element's position relative to it's siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
+      <assert test="@id = concat('s',$pos)" role="error" id="body-top-level-sec-id-test">This sec id must be a concatenation of 's' and this element's position relative to its siblings. It must be <value-of select="concat('s',$pos)"/>.</assert>
       </rule>
   </pattern>
   <pattern id="back-top-level-sec-ids-pattern">
@@ -3141,7 +3141,7 @@
       <let name="parent-sec" value="parent::sec/@id"/>
       <let name="pos" value="count(parent::sec/sec) - count(following-sibling::sec)"/>
       
-      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">sec id must be a concatenation of it's parent sec id and this element's position relative to it's sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
+      <assert test="@id = concat($parent-sec,'-',$pos)" role="error" id="low-level-sec-id-test">sec id must be a concatenation of its parent sec id and this element's position relative to its sibling secs. It must be <value-of select="concat($parent-sec,'-',$pos)"/>.</assert>
     </rule>
   </pattern>
   <pattern id="app-ids-pattern">
@@ -3303,11 +3303,11 @@
       
       <assert test="if ($pos = 1) then @article-type='decision-letter'                     else @article-type='reply'" role="error" id="dec-letter-reply-test-1">1st sub-article must be the decision letter. 2nd sub-article must be the author response.</assert>
       
-      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">sub-article id must be in the format 'sa0', where '0' is it's position (1 or 2).</assert>
+      <assert test="@id = concat('sa',$pos)" role="error" id="dec-letter-reply-test-2">sub-article id must be in the format 'sa0', where '0' is its position (1 or 2).</assert>
       
-      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">sub-article contain one and only one front-stub.</assert>
+      <assert test="count(front-stub) = 1" role="error" id="dec-letter-reply-test-3">sub-article contains one and only one front-stub.</assert>
       
-      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">sub-article contain one and only one body.</assert>
+      <assert test="count(body) = 1" role="error" id="dec-letter-reply-test-4">sub-article contains one and only one body.</assert>
       
     </rule>
   </pattern>
@@ -5059,7 +5059,7 @@
       <report test="(@pub-id-type='pmid') and matches(.,'\D')" role="error" id="pub-id-test-3">pub-id is tagged as a pmid, but it contains a character(s) which is not a digit - <value-of select="."/>
       </report>
       
-      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but it's pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
+      <report test="(@pub-id-type != 'doi') and matches(@xlink:href,'https?://(dx.doi.org|doi.org)/')" role="error" id="pub-id-doi-test-1">pub-id has a doi link - <value-of select="@xlink:href"/> - but its pub-id-type is <value-of select="@pub-id-type"/> instead of doi.</report>
       
       <report test="matches(@xlink:href,'https?://(dx.doi.org|doi.org)/') and not(contains(.,substring-after(@xlink:href,'doi.org/')))" role="error" id="pub-id-doi-test-2">pub id has a doi link - <value-of select="@xlink:href"/> - but the identifier is not the doi - '<value-of select="."/>', which is incorrect. Either the doi link is correct, and the identifier needs changing, or the identifier is correct and needs adding after 'https://doi.org/' in order to create the real doi link.</report>
       
@@ -6254,11 +6254,11 @@
       <report test="(. = 'Singapore') and ($city != 'Singapore')" role="error" id="singapore-test-1">
         <value-of select="ancestor::aff/@id"/> has 'Singapore' as its country but '<value-of select="$city"/>' as its city, which must be incorrect.</report>
       
-      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but it's country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
+      <report test="(. != 'Taiwan') and  (matches(lower-case($city),'ta[i]?pei|tai\s?chung|kaohsiung|taoyuan|tainan|hsinchu|keelung|chiayi|changhua|jhongli|tao-yuan|hualien'))" role="warning" id="taiwan-test">Affiliation has a Taiwanese city - <value-of select="$city"/> - but its country is '<value-of select="."/>'. Please check the original manuscript. If it has 'Taiwan' as the country in the original manuscript then ensure it is changed to 'Taiwan'.</report>
       
-      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but it's country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
+      <report test="(. != 'Republic of Korea') and  (matches(lower-case($city),'chuncheon|gyeongsan|daejeon|seoul|daegu|gwangju|ansan|goyang|suwon|gwanju|ochang|wonju|jeonnam|cheongju|ulsan|inharo|chonnam|miryang|pohang|deagu|gwangjin-gu|gyeonggi-do|incheon|gimhae|gyungnam|muan-gun|chungbuk|chungnam|ansung|cheongju-si'))" role="warning" id="s-korea-test">Affiliation has a South Korean city - <value-of select="$city"/> - but its country is '<value-of select="."/>', instead of 'Republic of Korea'.</report>
       
-      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as it's country which is very likely to be incorrect.</report>
+      <report test="replace(.,'\p{P}','') = 'Democratic Peoples Republic of Korea'" role="warning" id="n-korea-test">Affiliation has '<value-of select="."/>' as its country which is very likely to be incorrect.</report>
     </rule>
   </pattern>
   <pattern id="city-tests-pattern">


### PR DESCRIPTION
- fig-sup-test-2 message edit re elifesciences/schematron-gitbook#37
- Corrections for `low-level-sec-id-test` and `body-top-level-sec-id-test` re elifesciences/schematron-gitbook#138
- Typo fixes re elifesciences/schematron-gitbook#100